### PR TITLE
feat: add /api/v1 prefix with backward-compatible legacy routes

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,3 +3,4 @@
 // Will be populated as features are implemented.
 
 export const API_PREFIX = "/api" as const;
+export const API_V1_PREFIX = "/api/v1" as const;


### PR DESCRIPTION
- Register all routes under /api/v1 (primary versioned prefix)
- Keep /api as legacy aliases for backward compatibility
- Add API_V1_PREFIX constant to shared package
- Rewrite README: explicit pnpm filter commands, db:generate step, smoke checks pointing to /api/v1 endpoints
- Document ignoredBuiltDependencies rationale in README

https://claude.ai/code/session_01NYMtdr8vttRQAosyqzNJtF