### PR TITLE
feat: add Strategy and StrategyVersion models with migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ pnpm --filter @botmarketplace/api db:migrate
 in order. If you need to create a **new** migration during development, use
 `npx prisma migrate dev --name <name>` inside `apps/api/`.
 
+### Strategy versioning
+
+`StrategyVersion` rows are **immutable**. To update a strategy's DSL or
+execution plan, create a new `StrategyVersion` with an incremented `version`
+integer. This keeps a full audit trail and allows rollback.
+
 ### pnpm `ignoredBuiltDependencies`
 
 `pnpm-workspace.yaml` lists `@prisma/client`, `@prisma/engines`, `esbuild`,

--- a/apps/api/prisma/migrations/20260216_add_strategies/migration.sql
+++ b/apps/api/prisma/migrations/20260216_add_strategies/migration.sql
@@ -1,0 +1,49 @@
+-- CreateEnum
+CREATE TYPE "StrategyStatus" AS ENUM ('DRAFT', 'ACTIVE', 'ARCHIVED');
+
+-- CreateEnum
+CREATE TYPE "Timeframe" AS ENUM ('M1', 'M5', 'M15', 'H1');
+
+-- CreateTable
+CREATE TABLE "Strategy" (
+    "id" TEXT NOT NULL,
+    "workspaceId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "symbol" TEXT NOT NULL,
+    "timeframe" "Timeframe" NOT NULL,
+    "status" "StrategyStatus" NOT NULL DEFAULT 'DRAFT',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Strategy_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "StrategyVersion" (
+    "id" TEXT NOT NULL,
+    "strategyId" TEXT NOT NULL,
+    "version" INTEGER NOT NULL,
+    "dslJson" JSONB NOT NULL,
+    "executionPlanJson" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "StrategyVersion_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Strategy_workspaceId_idx" ON "Strategy"("workspaceId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Strategy_workspaceId_name_key" ON "Strategy"("workspaceId", "name");
+
+-- CreateIndex
+CREATE INDEX "StrategyVersion_strategyId_idx" ON "StrategyVersion"("strategyId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "StrategyVersion_strategyId_version_key" ON "StrategyVersion"("strategyId", "version");
+
+-- AddForeignKey
+ALTER TABLE "Strategy" ADD CONSTRAINT "Strategy_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "Workspace"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StrategyVersion" ADD CONSTRAINT "StrategyVersion_strategyId_fkey" FOREIGN KEY ("strategyId") REFERENCES "Strategy"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -29,7 +29,8 @@ model Workspace {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  members WorkspaceMember[]
+  members    WorkspaceMember[]
+  strategies Strategy[]
 }
 
 model WorkspaceMember {
@@ -45,4 +46,50 @@ model WorkspaceMember {
   @@unique([workspaceId, userId])
   @@index([workspaceId])
   @@index([userId])
+}
+
+// ── Strategy domain ──────────────────────────────────────────────
+
+enum StrategyStatus {
+  DRAFT
+  ACTIVE
+  ARCHIVED
+}
+
+enum Timeframe {
+  M1
+  M5
+  M15
+  H1
+}
+
+model Strategy {
+  id          String         @id @default(uuid())
+  workspaceId String
+  name        String
+  symbol      String
+  timeframe   Timeframe
+  status      StrategyStatus @default(DRAFT)
+  createdAt   DateTime       @default(now())
+  updatedAt   DateTime       @updatedAt
+
+  workspace Workspace        @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  versions  StrategyVersion[]
+
+  @@unique([workspaceId, name])
+  @@index([workspaceId])
+}
+
+model StrategyVersion {
+  id                String   @id @default(uuid())
+  strategyId        String
+  version           Int
+  dslJson           Json
+  executionPlanJson Json
+  createdAt         DateTime @default(now())
+
+  strategy Strategy @relation(fields: [strategyId], references: [id], onDelete: Cascade)
+
+  @@unique([strategyId, version])
+  @@index([strategyId])
 }


### PR DESCRIPTION
- Add StrategyStatus enum (DRAFT, ACTIVE, ARCHIVED)
- Add Timeframe enum (M1, M5, M15, H1)
- Add Strategy model with unique (workspaceId, name) constraint
- Add StrategyVersion model (immutable, versioned DSL + execution plan)
- Add Workspace.strategies relation, cascade deletes
- Document strategy versioning pattern in README

https://claude.ai/code/session_01NYMtdr8vttRQAosyqzNJtF