### PR TITLE
feat: add BotRun and BotEvent models with active-run constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,14 @@ in order. If you need to create a **new** migration during development, use
 execution plan, create a new `StrategyVersion` with an incremented `version`
 integer. This keeps a full audit trail and allows rollback.
 
+### Bot runtime constraint
+
+Only **one active bot run** is allowed per (workspace, symbol) pair. This is
+enforced at the database level via a partial unique index on `BotRun` where
+`state IN ('CREATED','QUEUED','STARTING','SYNCING','RUNNING')`. Attempting to
+insert a second active run for the same workspace + symbol will raise a unique
+violation error.
+
 ### pnpm `ignoredBuiltDependencies`
 
 `pnpm-workspace.yaml` lists `@prisma/client`, `@prisma/engines`, `esbuild`,

--- a/apps/api/prisma/migrations/20260216_add_bot_runtime/migration.sql
+++ b/apps/api/prisma/migrations/20260216_add_bot_runtime/migration.sql
@@ -1,0 +1,53 @@
+-- CreateEnum
+CREATE TYPE "BotRunState" AS ENUM ('CREATED', 'QUEUED', 'STARTING', 'SYNCING', 'RUNNING', 'STOPPING', 'STOPPED', 'FAILED', 'TIMED_OUT');
+
+-- CreateTable
+CREATE TABLE "BotRun" (
+    "id" TEXT NOT NULL,
+    "workspaceId" TEXT NOT NULL,
+    "symbol" TEXT NOT NULL,
+    "state" "BotRunState" NOT NULL DEFAULT 'CREATED',
+    "leaseOwner" TEXT,
+    "leaseUntil" TIMESTAMP(3),
+    "startedAt" TIMESTAMP(3),
+    "stoppedAt" TIMESTAMP(3),
+    "errorCode" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "BotRun_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "BotEvent" (
+    "id" TEXT NOT NULL,
+    "botRunId" TEXT NOT NULL,
+    "ts" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "type" TEXT NOT NULL,
+    "payloadJson" JSONB NOT NULL,
+
+    CONSTRAINT "BotEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "BotRun_workspaceId_idx" ON "BotRun"("workspaceId");
+
+-- CreateIndex
+CREATE INDEX "BotRun_workspaceId_symbol_idx" ON "BotRun"("workspaceId", "symbol");
+
+-- CreateIndex
+CREATE INDEX "BotRun_state_idx" ON "BotRun"("state");
+
+-- CreateIndex (partial unique: one active run per workspace+symbol)
+CREATE UNIQUE INDEX "BotRun_active_workspace_symbol_key"
+    ON "BotRun" ("workspaceId", "symbol")
+    WHERE "state" IN ('CREATED', 'QUEUED', 'STARTING', 'SYNCING', 'RUNNING');
+
+-- CreateIndex
+CREATE INDEX "BotEvent_botRunId_ts_idx" ON "BotEvent"("botRunId", "ts" DESC);
+
+-- AddForeignKey
+ALTER TABLE "BotRun" ADD CONSTRAINT "BotRun_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "Workspace"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BotEvent" ADD CONSTRAINT "BotEvent_botRunId_fkey" FOREIGN KEY ("botRunId") REFERENCES "BotRun"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -31,6 +31,7 @@ model Workspace {
 
   members    WorkspaceMember[]
   strategies Strategy[]
+  botRuns    BotRun[]
 }
 
 model WorkspaceMember {
@@ -92,4 +93,55 @@ model StrategyVersion {
 
   @@unique([strategyId, version])
   @@index([strategyId])
+}
+
+// ── Bot runtime domain ───────────────────────────────────────────
+
+enum BotRunState {
+  CREATED
+  QUEUED
+  STARTING
+  SYNCING
+  RUNNING
+  STOPPING
+  STOPPED
+  FAILED
+  TIMED_OUT
+}
+
+model BotRun {
+  id          String       @id @default(uuid())
+  workspaceId String
+  symbol      String
+  state       BotRunState  @default(CREATED)
+  leaseOwner  String?
+  leaseUntil  DateTime?
+  startedAt   DateTime?
+  stoppedAt   DateTime?
+  errorCode   String?
+  createdAt   DateTime     @default(now())
+  updatedAt   DateTime     @updatedAt
+
+  workspace Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  events    BotEvent[]
+
+  // NOTE: partial unique index (one active run per workspace+symbol)
+  // is defined in the migration SQL because Prisma cannot express
+  // WHERE-filtered unique indexes.
+
+  @@index([workspaceId])
+  @@index([workspaceId, symbol])
+  @@index([state])
+}
+
+model BotEvent {
+  id          String   @id @default(uuid())
+  botRunId    String
+  ts          DateTime @default(now())
+  type        String
+  payloadJson Json
+
+  botRun BotRun @relation(fields: [botRunId], references: [id], onDelete: Cascade)
+
+  @@index([botRunId, ts(sort: Desc)])
 }


### PR DESCRIPTION
- Add BotRunState enum (9 states: CREATED → TIMED_OUT)
- Add BotRun model with lease fields, timestamps, and error tracking
- Add BotEvent model with JSONB payload and descending ts index
- Add partial unique index: one active run per (workspace, symbol) enforced at DB level for states CREATED–RUNNING
- Add Workspace.botRuns relation, cascade deletes
- Document active-run constraint in README

https://claude.ai/code/session_01NYMtdr8vttRQAosyqzNJtF