### PR TITLE
feat: add Bot model and link BotRun to Bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ in order. If you need to create a **new** migration during development, use
 execution plan, create a new `StrategyVersion` with an incremented `version`
 integer. This keeps a full audit trail and allows rollback.
 
+### Bot aggregate
+
+`Bot` is the executable unit that ties together a workspace, a specific
+`StrategyVersion`, a symbol (e.g. BTCUSDT), and a timeframe. Each `BotRun`
+belongs to a `Bot`. Deleting a `StrategyVersion` that is referenced by a bot is
+blocked (`onDelete: Restrict`), while deleting a bot cascades to its runs.
+
 ### Bot runtime constraint
 
 Only **one active bot run** is allowed per (workspace, symbol) pair. This is

--- a/apps/api/prisma/migrations/20260216_add_bots/migration.sql
+++ b/apps/api/prisma/migrations/20260216_add_bots/migration.sql
@@ -1,0 +1,44 @@
+-- CreateEnum
+CREATE TYPE "BotStatus" AS ENUM ('DRAFT', 'ACTIVE', 'DISABLED');
+
+-- CreateTable
+CREATE TABLE "Bot" (
+    "id" TEXT NOT NULL,
+    "workspaceId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "strategyVersionId" TEXT NOT NULL,
+    "symbol" TEXT NOT NULL,
+    "timeframe" "Timeframe" NOT NULL,
+    "status" "BotStatus" NOT NULL DEFAULT 'DRAFT',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Bot_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Bot_workspaceId_name_key" ON "Bot"("workspaceId", "name");
+
+-- CreateIndex
+CREATE INDEX "Bot_workspaceId_idx" ON "Bot"("workspaceId");
+
+-- CreateIndex
+CREATE INDEX "Bot_strategyVersionId_idx" ON "Bot"("strategyVersionId");
+
+-- CreateIndex
+CREATE INDEX "Bot_workspaceId_symbol_idx" ON "Bot"("workspaceId", "symbol");
+
+-- AddForeignKey (Workspace cascade)
+ALTER TABLE "Bot" ADD CONSTRAINT "Bot_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "Workspace"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey (StrategyVersion restrict — prevent deleting a version used by a bot)
+ALTER TABLE "Bot" ADD CONSTRAINT "Bot_strategyVersionId_fkey" FOREIGN KEY ("strategyVersionId") REFERENCES "StrategyVersion"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AlterTable: add botId to BotRun (required — no existing rows in MVP)
+ALTER TABLE "BotRun" ADD COLUMN "botId" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE INDEX "BotRun_botId_idx" ON "BotRun"("botId");
+
+-- AddForeignKey (Bot cascade — deleting bot removes its runs)
+ALTER TABLE "BotRun" ADD CONSTRAINT "BotRun_botId_fkey" FOREIGN KEY ("botId") REFERENCES "Bot"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -31,6 +31,7 @@ model Workspace {
 
   members    WorkspaceMember[]
   strategies Strategy[]
+  bots       Bot[]
   botRuns    BotRun[]
 }
 
@@ -90,9 +91,39 @@ model StrategyVersion {
   createdAt         DateTime @default(now())
 
   strategy Strategy @relation(fields: [strategyId], references: [id], onDelete: Cascade)
+  bots     Bot[]
 
   @@unique([strategyId, version])
   @@index([strategyId])
+}
+
+// ── Bot aggregate ────────────────────────────────────────────────
+
+enum BotStatus {
+  DRAFT
+  ACTIVE
+  DISABLED
+}
+
+model Bot {
+  id                String          @id @default(uuid())
+  workspaceId       String
+  name              String
+  strategyVersionId String
+  symbol            String
+  timeframe         Timeframe
+  status            BotStatus       @default(DRAFT)
+  createdAt         DateTime        @default(now())
+  updatedAt         DateTime        @updatedAt
+
+  workspace       Workspace       @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  strategyVersion StrategyVersion @relation(fields: [strategyVersionId], references: [id], onDelete: Restrict)
+  runs            BotRun[]
+
+  @@unique([workspaceId, name])
+  @@index([workspaceId])
+  @@index([strategyVersionId])
+  @@index([workspaceId, symbol])
 }
 
 // ── Bot runtime domain ───────────────────────────────────────────
@@ -111,6 +142,7 @@ enum BotRunState {
 
 model BotRun {
   id          String       @id @default(uuid())
+  botId       String
   workspaceId String
   symbol      String
   state       BotRunState  @default(CREATED)
@@ -122,6 +154,7 @@ model BotRun {
   createdAt   DateTime     @default(now())
   updatedAt   DateTime     @updatedAt
 
+  bot       Bot       @relation(fields: [botId], references: [id], onDelete: Cascade)
   workspace Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
   events    BotEvent[]
 
@@ -129,6 +162,7 @@ model BotRun {
   // is defined in the migration SQL because Prisma cannot express
   // WHERE-filtered unique indexes.
 
+  @@index([botId])
   @@index([workspaceId])
   @@index([workspaceId, symbol])
   @@index([state])


### PR DESCRIPTION
- Add BotStatus enum (DRAFT, ACTIVE, DISABLED)
- Add Bot model: workspace + strategyVersion + symbol + timeframe
  - onDelete Cascade from Workspace, Restrict from StrategyVersion
  - @@unique([workspaceId, name]), indexes on workspaceId, strategyVersionId, (workspaceId, symbol)
- Add required botId column to BotRun with cascade delete from Bot
- Add bots relation on StrategyVersion and Workspace
- Migration SQL: create Bot table, alter BotRun, add FKs and indexes
- Document Bot aggregate in README

https://claude.ai/code/session_01NYMtdr8vttRQAosyqzNJtF