### PR TITLE
feat: add bots API (list/create/get) with Problem Details

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -4,13 +4,15 @@ import { healthzRoutes } from "./routes/healthz.js";
 import { readyzRoutes } from "./routes/readyz.js";
 import { authRoutes } from "./routes/auth.js";
 import { strategyRoutes } from "./routes/strategies.js";
+import { botRoutes } from "./routes/bots.js";
 
-/** Registers all domain routes (healthz, readyz, auth). */
+/** Registers all domain routes. */
 async function registerRoutes(scope: import("fastify").FastifyInstance) {
   await scope.register(healthzRoutes);
   await scope.register(readyzRoutes);
   await scope.register(authRoutes);
   await scope.register(strategyRoutes);
+  await scope.register(botRoutes);
 }
 
 export async function buildApp() {

--- a/apps/api/src/lib/workspace.ts
+++ b/apps/api/src/lib/workspace.ts
@@ -1,0 +1,22 @@
+import type { FastifyRequest, FastifyReply } from "fastify";
+import { prisma } from "./prisma.js";
+import { problem } from "./problem.js";
+
+/**
+ * Resolve workspace from X-Workspace-Id header.
+ * Returns the workspace or null (after sending a Problem Details error).
+ * Temporary — will be replaced by real auth middleware.
+ */
+export async function resolveWorkspace(request: FastifyRequest, reply: FastifyReply) {
+  const workspaceId = request.headers["x-workspace-id"] as string | undefined;
+  if (!workspaceId) {
+    problem(reply, 400, "Bad Request", "Missing required header: X-Workspace-Id");
+    return null;
+  }
+  const workspace = await prisma.workspace.findUnique({ where: { id: workspaceId } });
+  if (!workspace) {
+    problem(reply, 404, "Not Found", `Workspace ${workspaceId} not found`);
+    return null;
+  }
+  return workspace;
+}

--- a/apps/api/src/routes/bots.ts
+++ b/apps/api/src/routes/bots.ts
@@ -1,0 +1,132 @@
+import type { FastifyInstance } from "fastify";
+import { prisma } from "../lib/prisma.js";
+import { problem } from "../lib/problem.js";
+import { resolveWorkspace } from "../lib/workspace.js";
+
+const VALID_TIMEFRAMES = ["M1", "M5", "M15", "H1"] as const;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface CreateBotBody {
+  name: string;
+  strategyVersionId: string;
+  symbol: string;
+  timeframe: string;
+}
+
+// ---------------------------------------------------------------------------
+// Routes
+// ---------------------------------------------------------------------------
+
+export async function botRoutes(app: FastifyInstance) {
+  // GET /bots — list bots for workspace
+  app.get("/bots", async (request, reply) => {
+    const workspace = await resolveWorkspace(request, reply);
+    if (!workspace) return;
+
+    const bots = await prisma.bot.findMany({
+      where: { workspaceId: workspace.id },
+      orderBy: { updatedAt: "desc" },
+      select: {
+        id: true,
+        name: true,
+        symbol: true,
+        timeframe: true,
+        status: true,
+        strategyVersionId: true,
+        updatedAt: true,
+      },
+    });
+    return reply.send(bots);
+  });
+
+  // POST /bots — create a new bot (DRAFT)
+  app.post<{ Body: CreateBotBody }>("/bots", async (request, reply) => {
+    const workspace = await resolveWorkspace(request, reply);
+    if (!workspace) return;
+
+    const { name, strategyVersionId, symbol, timeframe } = request.body ?? {};
+
+    // --- field validation ---
+    const errors: Array<{ field: string; message: string }> = [];
+    if (!name || typeof name !== "string") {
+      errors.push({ field: "name", message: "name is required" });
+    }
+    if (!strategyVersionId || typeof strategyVersionId !== "string") {
+      errors.push({ field: "strategyVersionId", message: "strategyVersionId is required" });
+    }
+    if (!symbol || typeof symbol !== "string") {
+      errors.push({ field: "symbol", message: "symbol is required" });
+    }
+    if (!timeframe || !VALID_TIMEFRAMES.includes(timeframe as typeof VALID_TIMEFRAMES[number])) {
+      errors.push({ field: "timeframe", message: `timeframe must be one of: ${VALID_TIMEFRAMES.join(", ")}` });
+    }
+    if (errors.length > 0) {
+      return problem(reply, 400, "Validation Error", "Invalid bot payload", { errors });
+    }
+
+    // --- verify strategyVersion exists and belongs to same workspace ---
+    const sv = await prisma.strategyVersion.findUnique({
+      where: { id: strategyVersionId },
+      include: { strategy: { select: { workspaceId: true } } },
+    });
+    if (!sv || sv.strategy.workspaceId !== workspace.id) {
+      return problem(reply, 400, "Bad Request", "strategyVersionId not found in this workspace");
+    }
+
+    // --- unique name check ---
+    const existing = await prisma.bot.findUnique({
+      where: { workspaceId_name: { workspaceId: workspace.id, name } },
+    });
+    if (existing) {
+      return problem(reply, 409, "Conflict", `Bot "${name}" already exists in this workspace`);
+    }
+
+    const bot = await prisma.bot.create({
+      data: {
+        workspaceId: workspace.id,
+        name,
+        strategyVersionId,
+        symbol,
+        timeframe: timeframe as typeof VALID_TIMEFRAMES[number],
+        status: "DRAFT",
+      },
+    });
+    return reply.status(201).send(bot);
+  });
+
+  // GET /bots/:id — get single bot (must belong to workspace)
+  app.get<{ Params: { id: string } }>("/bots/:id", async (request, reply) => {
+    const workspace = await resolveWorkspace(request, reply);
+    if (!workspace) return;
+
+    const bot = await prisma.bot.findUnique({
+      where: { id: request.params.id },
+      include: {
+        strategyVersion: {
+          include: { strategy: { select: { id: true, name: true } } },
+        },
+        runs: {
+          orderBy: { createdAt: "desc" },
+          take: 1,
+          select: {
+            id: true,
+            state: true,
+            startedAt: true,
+            stoppedAt: true,
+            errorCode: true,
+            createdAt: true,
+          },
+        },
+      },
+    });
+    if (!bot || bot.workspaceId !== workspace.id) {
+      return problem(reply, 404, "Not Found", "Bot not found");
+    }
+
+    const { runs, ...rest } = bot;
+    return reply.send({ ...rest, lastRun: runs[0] ?? null });
+  });
+}

--- a/apps/api/src/routes/strategies.ts
+++ b/apps/api/src/routes/strategies.ts
@@ -1,26 +1,9 @@
 import type { FastifyInstance } from "fastify";
 import { prisma } from "../lib/prisma.js";
 import { problem } from "../lib/problem.js";
+import { resolveWorkspace } from "../lib/workspace.js";
 
 const VALID_TIMEFRAMES = ["M1", "M5", "M15", "H1"] as const;
-
-// ---------------------------------------------------------------------------
-// Workspace resolution helper (temporary — will be replaced by real auth)
-// ---------------------------------------------------------------------------
-
-async function resolveWorkspace(request: import("fastify").FastifyRequest, reply: import("fastify").FastifyReply) {
-  const workspaceId = request.headers["x-workspace-id"] as string | undefined;
-  if (!workspaceId) {
-    problem(reply, 400, "Bad Request", "Missing required header: X-Workspace-Id");
-    return null;
-  }
-  const workspace = await prisma.workspace.findUnique({ where: { id: workspaceId } });
-  if (!workspace) {
-    problem(reply, 404, "Not Found", `Workspace ${workspaceId} not found`);
-    return null;
-  }
-  return workspace;
-}
 
 // ---------------------------------------------------------------------------
 // Minimal DSL validation


### PR DESCRIPTION
- Add GET /bots, POST /bots, GET /bots/:id endpoints
  - POST validates: name, strategyVersionId (must belong to same workspace), symbol, timeframe; returns 409 on duplicate name
  - GET /:id includes linked strategyVersion, strategy name, and lastRun
- Extract resolveWorkspace to shared lib/workspace.ts (used by both strategies and bots routes)
- Register botRoutes in app.ts (both /api/v1 and /api prefixes)

https://claude.ai/code/session_01NYMtdr8vttRQAosyqzNJtF