### PR TITLE
feat: add Bot Factory UI (strategies/bots/runs)

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -2,6 +2,14 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
+  async rewrites() {
+    return [
+      {
+        source: "/api/:path*",
+        destination: `${process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000"}/api/:path*`,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/apps/web/src/app/factory/api.ts
+++ b/apps/web/src/app/factory/api.ts
@@ -1,0 +1,49 @@
+const API_PREFIX = "/api/v1";
+
+export function getWorkspaceId(): string | null {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem("workspaceId");
+}
+
+export function setWorkspaceId(id: string) {
+  localStorage.setItem("workspaceId", id);
+}
+
+export interface ProblemDetails {
+  type: string;
+  title: string;
+  status: number;
+  detail: string;
+  errors?: Array<{ field: string; message: string }>;
+}
+
+export async function apiFetch<T = unknown>(
+  path: string,
+  options: RequestInit = {},
+): Promise<{ ok: true; data: T } | { ok: false; problem: ProblemDetails }> {
+  const workspaceId = getWorkspaceId();
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...(options.headers as Record<string, string>),
+  };
+  if (workspaceId) {
+    headers["X-Workspace-Id"] = workspaceId;
+  }
+
+  const res = await fetch(`${API_PREFIX}${path}`, { ...options, headers });
+
+  if (!res.ok) {
+    const contentType = res.headers.get("content-type") ?? "";
+    if (contentType.includes("application/problem+json") || contentType.includes("application/json")) {
+      const problem = (await res.json()) as ProblemDetails;
+      return { ok: false, problem };
+    }
+    return {
+      ok: false,
+      problem: { type: "about:blank", title: "Error", status: res.status, detail: res.statusText },
+    };
+  }
+
+  const data = (await res.json()) as T;
+  return { ok: true, data };
+}

--- a/apps/web/src/app/factory/bots/[id]/page.tsx
+++ b/apps/web/src/app/factory/bots/[id]/page.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import { apiFetch, getWorkspaceId, type ProblemDetails } from "../../api";
+
+interface BotRun {
+  id: string;
+  state: string;
+  startedAt: string | null;
+  stoppedAt: string | null;
+  errorCode: string | null;
+  createdAt: string;
+}
+
+interface BotDetail {
+  id: string;
+  name: string;
+  symbol: string;
+  timeframe: string;
+  status: string;
+  strategyVersion: {
+    id: string;
+    version: number;
+    strategy: { id: string; name: string };
+  };
+  lastRun: BotRun | null;
+}
+
+interface BotEvent {
+  id: string;
+  ts: string;
+  type: string;
+  payloadJson: Record<string, unknown>;
+}
+
+export default function BotDetailPage() {
+  const { id: botId } = useParams<{ id: string }>();
+  const [bot, setBot] = useState<BotDetail | null>(null);
+  const [events, setEvents] = useState<BotEvent[]>([]);
+  const [error, setError] = useState<ProblemDetails | null>(null);
+  const [polling, setPolling] = useState(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const loadBot = useCallback(async () => {
+    if (!getWorkspaceId()) return;
+    const res = await apiFetch<BotDetail>(`/bots/${botId}`);
+    if (res.ok) {
+      setBot(res.data);
+      setError(null);
+      return res.data;
+    } else {
+      setError(res.problem);
+      return null;
+    }
+  }, [botId]);
+
+  const loadEvents = useCallback(async (runId: string) => {
+    const res = await apiFetch<BotEvent[]>(`/runs/${runId}/events`);
+    if (res.ok) setEvents(res.data);
+  }, []);
+
+  // Initial load
+  useEffect(() => {
+    loadBot().then((b) => {
+      if (b?.lastRun) loadEvents(b.lastRun.id);
+    });
+  }, [loadBot, loadEvents]);
+
+  // Polling
+  useEffect(() => {
+    if (polling && bot?.lastRun) {
+      const runId = bot.lastRun.id;
+      intervalRef.current = setInterval(async () => {
+        const b = await loadBot();
+        if (b?.lastRun) await loadEvents(b.lastRun.id);
+        // Auto-stop polling if run is terminal
+        if (b?.lastRun && ["STOPPED", "FAILED", "TIMED_OUT"].includes(b.lastRun.state)) {
+          setPolling(false);
+        }
+      }, 2000);
+    }
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [polling, bot?.lastRun?.id, loadBot, loadEvents]);
+
+  async function startRun() {
+    setError(null);
+    const res = await apiFetch<BotRun>(`/bots/${botId}/runs`, { method: "POST" });
+    if (res.ok) {
+      await loadBot().then((b) => {
+        if (b?.lastRun) loadEvents(b.lastRun.id);
+      });
+      setPolling(true);
+    } else {
+      setError(res.problem);
+    }
+  }
+
+  async function stopRun() {
+    if (!bot?.lastRun) return;
+    setError(null);
+    const res = await apiFetch(`/bots/${botId}/runs/${bot.lastRun.id}/stop`, { method: "POST" });
+    if (res.ok) {
+      setPolling(false);
+      await loadBot().then((b) => {
+        if (b?.lastRun) loadEvents(b.lastRun.id);
+      });
+    } else {
+      setError((res as { ok: false; problem: ProblemDetails }).problem);
+    }
+  }
+
+  if (!getWorkspaceId()) {
+    return (
+      <div style={{ padding: "48px 24px" }}>
+        <Link href="/factory">Set Workspace ID first</Link>
+      </div>
+    );
+  }
+
+  const lastRun = bot?.lastRun;
+  const isActive = lastRun && !["STOPPED", "FAILED", "TIMED_OUT"].includes(lastRun.state);
+
+  return (
+    <div style={{ padding: "48px 24px", maxWidth: 800, margin: "0 auto" }}>
+      <p style={{ marginBottom: 16 }}>
+        <Link href="/factory/bots">← Bots</Link>
+      </p>
+
+      {error && <ErrorBox problem={error} />}
+
+      {bot && (
+        <>
+          <h1 style={{ fontSize: 24, marginBottom: 8 }}>{bot.name}</h1>
+          <p style={{ color: "var(--text-secondary)", marginBottom: 4 }}>
+            {bot.symbol} · {bot.timeframe} · {bot.status}
+          </p>
+          <p style={{ color: "var(--text-secondary)", marginBottom: 24, fontSize: 13 }}>
+            Strategy: <strong>{bot.strategyVersion.strategy.name}</strong> v{bot.strategyVersion.version}
+          </p>
+
+          {/* Run controls */}
+          <div style={{ ...card, display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
+            <button style={btn} onClick={startRun} disabled={!!isActive}>
+              Start Run
+            </button>
+            <button style={btnDanger} onClick={stopRun} disabled={!isActive}>
+              Stop Run
+            </button>
+            <button style={btnSecondary} onClick={() => setPolling((p) => !p)}>
+              {polling ? "Stop Polling" : "Start Polling"}
+            </button>
+            <button
+              style={btnSecondary}
+              onClick={() => {
+                loadBot().then((b) => {
+                  if (b?.lastRun) loadEvents(b.lastRun.id);
+                });
+              }}
+            >
+              Refresh
+            </button>
+            {lastRun && (
+              <span style={{ color: "var(--text-secondary)", fontSize: 13 }}>
+                Last run: <strong>{lastRun.state}</strong>{" "}
+                {lastRun.errorCode && `(${lastRun.errorCode})`}
+              </span>
+            )}
+            {polling && <span style={{ fontSize: 12, color: "#3fb950" }}>● polling</span>}
+          </div>
+
+          {/* Events log */}
+          <h3 style={{ marginTop: 24, marginBottom: 12 }}>Events</h3>
+          {events.length > 0 ? (
+            <table style={{ width: "100%", borderCollapse: "collapse" }}>
+              <thead>
+                <tr>
+                  {["Time", "Type", "Payload"].map((h) => (
+                    <th key={h} style={th}>{h}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {events.map((ev) => (
+                  <tr key={ev.id}>
+                    <td style={{ ...td, fontSize: 12, whiteSpace: "nowrap" }}>
+                      {new Date(ev.ts).toLocaleTimeString()}
+                    </td>
+                    <td style={{ ...td, fontWeight: 600 }}>{ev.type}</td>
+                    <td style={{ ...td, fontFamily: "monospace", fontSize: 12 }}>
+                      {JSON.stringify(ev.payloadJson)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : (
+            <p style={{ color: "var(--text-secondary)" }}>
+              {lastRun ? "No events yet" : "No runs yet — click Start Run"}
+            </p>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function ErrorBox({ problem }: { problem: ProblemDetails }) {
+  return (
+    <div style={{ background: "#3d1f1f", border: "1px solid #f85149", borderRadius: 6, padding: 12, marginBottom: 16 }}>
+      <strong>{problem.title}</strong>: {problem.detail}
+    </div>
+  );
+}
+
+const card: React.CSSProperties = { background: "var(--bg-card)", border: "1px solid var(--border)", borderRadius: 8, padding: 16 };
+const btn: React.CSSProperties = { padding: "8px 16px", background: "var(--accent)", color: "#fff", border: "none", borderRadius: 6, cursor: "pointer", fontSize: 14 };
+const btnDanger: React.CSSProperties = { ...btn, background: "#da3633" };
+const btnSecondary: React.CSSProperties = { ...btn, background: "var(--bg-secondary)", border: "1px solid var(--border)" };
+const th: React.CSSProperties = { textAlign: "left", padding: "8px 12px", borderBottom: "1px solid var(--border)", color: "var(--text-secondary)", fontSize: 13 };
+const td: React.CSSProperties = { padding: "8px 12px", borderBottom: "1px solid var(--border)", fontSize: 14 };

--- a/apps/web/src/app/factory/bots/page.tsx
+++ b/apps/web/src/app/factory/bots/page.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import { apiFetch, getWorkspaceId, type ProblemDetails } from "../api";
+
+interface Bot {
+  id: string;
+  name: string;
+  symbol: string;
+  timeframe: string;
+  status: string;
+  strategyVersionId: string;
+  updatedAt: string;
+}
+
+const TIMEFRAMES = ["M1", "M5", "M15", "H1"];
+
+export default function BotsPage() {
+  const [bots, setBots] = useState<Bot[]>([]);
+  const [error, setError] = useState<ProblemDetails | null>(null);
+  const [name, setName] = useState("");
+  const [svId, setSvId] = useState("");
+  const [symbol, setSymbol] = useState("BTCUSDT");
+  const [timeframe, setTimeframe] = useState("H1");
+
+  const load = useCallback(async () => {
+    if (!getWorkspaceId()) return;
+    const res = await apiFetch<Bot[]>("/bots");
+    if (res.ok) {
+      setBots(res.data);
+      setError(null);
+    } else {
+      setError(res.problem);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function create(e: React.FormEvent) {
+    e.preventDefault();
+    const res = await apiFetch<Bot>("/bots", {
+      method: "POST",
+      body: JSON.stringify({ name, strategyVersionId: svId, symbol, timeframe }),
+    });
+    if (res.ok) {
+      setName("");
+      setSvId("");
+      setError(null);
+      load();
+    } else {
+      setError(res.problem);
+    }
+  }
+
+  if (!getWorkspaceId()) {
+    return (
+      <div style={{ padding: "48px 24px" }}>
+        <Link href="/factory">Set Workspace ID first</Link>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: "48px 24px", maxWidth: 800, margin: "0 auto" }}>
+      <h1 style={{ fontSize: 24, marginBottom: 24 }}>Bots</h1>
+
+      {error && <ErrorBox problem={error} />}
+
+      <form onSubmit={create} style={card}>
+        <h3 style={{ marginBottom: 12 }}>Create Bot</h3>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <input style={input} placeholder="Name" value={name} onChange={(e) => setName(e.target.value)} required />
+          <input style={{ ...input, flex: 2 }} placeholder="Strategy Version ID" value={svId} onChange={(e) => setSvId(e.target.value)} required />
+          <input style={{ ...input, width: 120 }} placeholder="Symbol" value={symbol} onChange={(e) => setSymbol(e.target.value)} required />
+          <select style={input} value={timeframe} onChange={(e) => setTimeframe(e.target.value)}>
+            {TIMEFRAMES.map((t) => (
+              <option key={t} value={t}>{t}</option>
+            ))}
+          </select>
+          <button style={btn} type="submit">Create</button>
+        </div>
+      </form>
+
+      <table style={{ width: "100%", marginTop: 24, borderCollapse: "collapse" }}>
+        <thead>
+          <tr>
+            {["Name", "Symbol", "TF", "Status", "Updated"].map((h) => (
+              <th key={h} style={th}>{h}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {bots.map((b) => (
+            <tr key={b.id}>
+              <td style={td}>
+                <Link href={`/factory/bots/${b.id}`}>{b.name}</Link>
+              </td>
+              <td style={td}>{b.symbol}</td>
+              <td style={td}>{b.timeframe}</td>
+              <td style={td}>{b.status}</td>
+              <td style={td}>{new Date(b.updatedAt).toLocaleString()}</td>
+            </tr>
+          ))}
+          {bots.length === 0 && (
+            <tr>
+              <td colSpan={5} style={{ ...td, color: "var(--text-secondary)" }}>No bots yet</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function ErrorBox({ problem }: { problem: ProblemDetails }) {
+  return (
+    <div style={{ background: "#3d1f1f", border: "1px solid #f85149", borderRadius: 6, padding: 12, marginBottom: 16 }}>
+      <strong>{problem.title}</strong>: {problem.detail}
+      {problem.errors?.map((e, i) => (
+        <div key={i} style={{ fontSize: 13, marginTop: 4 }}>{e.field}: {e.message}</div>
+      ))}
+    </div>
+  );
+}
+
+const card: React.CSSProperties = { background: "var(--bg-card)", border: "1px solid var(--border)", borderRadius: 8, padding: 16 };
+const input: React.CSSProperties = { padding: "8px 12px", background: "var(--bg-secondary)", border: "1px solid var(--border)", borderRadius: 6, color: "var(--text-primary)", fontSize: 14 };
+const btn: React.CSSProperties = { padding: "8px 16px", background: "var(--accent)", color: "#fff", border: "none", borderRadius: 6, cursor: "pointer", fontSize: 14 };
+const th: React.CSSProperties = { textAlign: "left", padding: "8px 12px", borderBottom: "1px solid var(--border)", color: "var(--text-secondary)", fontSize: 13 };
+const td: React.CSSProperties = { padding: "8px 12px", borderBottom: "1px solid var(--border)", fontSize: 14 };

--- a/apps/web/src/app/factory/page.tsx
+++ b/apps/web/src/app/factory/page.tsx
@@ -1,10 +1,107 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { getWorkspaceId, setWorkspaceId } from "./api";
+
 export default function FactoryPage() {
+  const [wsId, setWsId] = useState("");
+  const [saved, setSaved] = useState<string | null>(null);
+
+  useEffect(() => {
+    const stored = getWorkspaceId();
+    if (stored) {
+      setWsId(stored);
+      setSaved(stored);
+    }
+  }, []);
+
+  function save() {
+    const trimmed = wsId.trim();
+    if (!trimmed) return;
+    setWorkspaceId(trimmed);
+    setSaved(trimmed);
+  }
+
   return (
-    <div style={{ padding: "48px 24px", textAlign: "center" }}>
-      <h1 style={{ fontSize: "28px", marginBottom: "16px" }}>Bot Factory</h1>
-      <p style={{ color: "var(--text-secondary)" }}>
-        Bot management, runtime logs and controls — coming in Stage 4.
-      </p>
+    <div style={{ padding: "48px 24px", maxWidth: 600, margin: "0 auto" }}>
+      <h1 style={{ fontSize: 28, marginBottom: 24 }}>Bot Factory</h1>
+
+      <div style={card}>
+        <h2 style={{ fontSize: 18, marginBottom: 12 }}>Workspace</h2>
+        <div style={{ display: "flex", gap: 8 }}>
+          <input
+            style={input}
+            placeholder="Workspace UUID"
+            value={wsId}
+            onChange={(e) => setWsId(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && save()}
+          />
+          <button style={btn} onClick={save}>
+            Save
+          </button>
+        </div>
+        {saved && (
+          <p style={{ marginTop: 8, color: "var(--text-secondary)", fontSize: 13 }}>
+            Active: <code>{saved}</code>
+          </p>
+        )}
+      </div>
+
+      {saved ? (
+        <div style={{ display: "flex", gap: 16, marginTop: 24 }}>
+          <Link href="/factory/strategies" style={linkCard}>
+            Strategies
+          </Link>
+          <Link href="/factory/bots" style={linkCard}>
+            Bots
+          </Link>
+        </div>
+      ) : (
+        <p style={{ marginTop: 24, color: "var(--text-secondary)" }}>
+          Set a Workspace ID to continue.
+        </p>
+      )}
     </div>
   );
 }
+
+const card: React.CSSProperties = {
+  background: "var(--bg-card)",
+  border: "1px solid var(--border)",
+  borderRadius: 8,
+  padding: 16,
+};
+
+const input: React.CSSProperties = {
+  flex: 1,
+  padding: "8px 12px",
+  background: "var(--bg-secondary)",
+  border: "1px solid var(--border)",
+  borderRadius: 6,
+  color: "var(--text-primary)",
+  fontSize: 14,
+};
+
+const btn: React.CSSProperties = {
+  padding: "8px 16px",
+  background: "var(--accent)",
+  color: "#fff",
+  border: "none",
+  borderRadius: 6,
+  cursor: "pointer",
+  fontSize: 14,
+};
+
+const linkCard: React.CSSProperties = {
+  flex: 1,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: 24,
+  background: "var(--bg-card)",
+  border: "1px solid var(--border)",
+  borderRadius: 8,
+  fontSize: 18,
+  fontWeight: 600,
+};

--- a/apps/web/src/app/factory/strategies/[id]/page.tsx
+++ b/apps/web/src/app/factory/strategies/[id]/page.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import { apiFetch, getWorkspaceId, type ProblemDetails } from "../../api";
+
+interface StrategyVersion {
+  id: string;
+  version: number;
+  createdAt: string;
+}
+
+interface StrategyDetail {
+  id: string;
+  name: string;
+  symbol: string;
+  timeframe: string;
+  status: string;
+  versions: StrategyVersion[];
+}
+
+export default function StrategyDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const [strategy, setStrategy] = useState<StrategyDetail | null>(null);
+  const [error, setError] = useState<ProblemDetails | null>(null);
+  const [dsl, setDsl] = useState('{"kind":"stub"}');
+  const [validateMsg, setValidateMsg] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!getWorkspaceId()) return;
+    const res = await apiFetch<StrategyDetail>(`/strategies/${id}`);
+    if (res.ok) {
+      setStrategy(res.data);
+      setError(null);
+    } else {
+      setError(res.problem);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function validate() {
+    setValidateMsg(null);
+    setError(null);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(dsl);
+    } catch {
+      setValidateMsg("Invalid JSON");
+      return;
+    }
+    const res = await apiFetch("/strategies/validate", {
+      method: "POST",
+      body: JSON.stringify({ dslJson: parsed }),
+    });
+    if (res.ok) {
+      setValidateMsg("Valid!");
+    } else {
+      setError(res.problem);
+    }
+  }
+
+  async function createVersion() {
+    setError(null);
+    setValidateMsg(null);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(dsl);
+    } catch {
+      setValidateMsg("Invalid JSON");
+      return;
+    }
+    const res = await apiFetch(`/strategies/${id}/versions`, {
+      method: "POST",
+      body: JSON.stringify({ dslJson: parsed }),
+    });
+    if (res.ok) {
+      load();
+    } else {
+      setError(res.problem);
+    }
+  }
+
+  if (!getWorkspaceId()) {
+    return (
+      <div style={{ padding: "48px 24px" }}>
+        <Link href="/factory">Set Workspace ID first</Link>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: "48px 24px", maxWidth: 700, margin: "0 auto" }}>
+      <p style={{ marginBottom: 16 }}>
+        <Link href="/factory/strategies">← Strategies</Link>
+      </p>
+
+      {error && <ErrorBox problem={error} />}
+
+      {strategy && (
+        <>
+          <h1 style={{ fontSize: 24, marginBottom: 8 }}>{strategy.name}</h1>
+          <p style={{ color: "var(--text-secondary)", marginBottom: 24 }}>
+            {strategy.symbol} · {strategy.timeframe} · {strategy.status}
+          </p>
+
+          <div style={card}>
+            <h3 style={{ marginBottom: 8 }}>New Version</h3>
+            <textarea
+              style={{ ...inputStyle, width: "100%", minHeight: 80, fontFamily: "monospace" }}
+              value={dsl}
+              onChange={(e) => setDsl(e.target.value)}
+            />
+            {validateMsg && (
+              <p style={{ fontSize: 13, marginTop: 4, color: validateMsg === "Valid!" ? "#3fb950" : "#f85149" }}>
+                {validateMsg}
+              </p>
+            )}
+            <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
+              <button style={btnSecondary} onClick={validate}>Validate</button>
+              <button style={btn} onClick={createVersion}>Create Version</button>
+            </div>
+          </div>
+
+          <h3 style={{ marginTop: 24, marginBottom: 12 }}>Versions</h3>
+          <table style={{ width: "100%", borderCollapse: "collapse" }}>
+            <thead>
+              <tr>
+                {["#", "ID", "Created"].map((h) => (
+                  <th key={h} style={th}>{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {strategy.versions.map((v) => (
+                <tr key={v.id}>
+                  <td style={td}>v{v.version}</td>
+                  <td style={{ ...td, fontFamily: "monospace", fontSize: 12 }}>{v.id}</td>
+                  <td style={td}>{new Date(v.createdAt).toLocaleString()}</td>
+                </tr>
+              ))}
+              {strategy.versions.length === 0 && (
+                <tr>
+                  <td colSpan={3} style={{ ...td, color: "var(--text-secondary)" }}>No versions yet</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </>
+      )}
+    </div>
+  );
+}
+
+function ErrorBox({ problem }: { problem: ProblemDetails }) {
+  return (
+    <div style={{ background: "#3d1f1f", border: "1px solid #f85149", borderRadius: 6, padding: 12, marginBottom: 16 }}>
+      <strong>{problem.title}</strong>: {problem.detail}
+      {problem.errors?.map((e, i) => (
+        <div key={i} style={{ fontSize: 13, marginTop: 4 }}>{e.field}: {e.message}</div>
+      ))}
+    </div>
+  );
+}
+
+const card: React.CSSProperties = { background: "var(--bg-card)", border: "1px solid var(--border)", borderRadius: 8, padding: 16 };
+const inputStyle: React.CSSProperties = { padding: "8px 12px", background: "var(--bg-secondary)", border: "1px solid var(--border)", borderRadius: 6, color: "var(--text-primary)", fontSize: 14 };
+const btn: React.CSSProperties = { padding: "8px 16px", background: "var(--accent)", color: "#fff", border: "none", borderRadius: 6, cursor: "pointer", fontSize: 14 };
+const btnSecondary: React.CSSProperties = { ...btn, background: "var(--bg-secondary)", border: "1px solid var(--border)" };
+const th: React.CSSProperties = { textAlign: "left", padding: "8px 12px", borderBottom: "1px solid var(--border)", color: "var(--text-secondary)", fontSize: 13 };
+const td: React.CSSProperties = { padding: "8px 12px", borderBottom: "1px solid var(--border)", fontSize: 14 };

--- a/apps/web/src/app/factory/strategies/page.tsx
+++ b/apps/web/src/app/factory/strategies/page.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import { apiFetch, getWorkspaceId, type ProblemDetails } from "../api";
+
+interface Strategy {
+  id: string;
+  name: string;
+  symbol: string;
+  timeframe: string;
+  status: string;
+  createdAt: string;
+}
+
+const TIMEFRAMES = ["M1", "M5", "M15", "H1"];
+
+export default function StrategiesPage() {
+  const [strategies, setStrategies] = useState<Strategy[]>([]);
+  const [error, setError] = useState<ProblemDetails | null>(null);
+  const [name, setName] = useState("");
+  const [symbol, setSymbol] = useState("BTCUSDT");
+  const [timeframe, setTimeframe] = useState("H1");
+
+  const load = useCallback(async () => {
+    if (!getWorkspaceId()) return;
+    const res = await apiFetch<Strategy[]>("/strategies");
+    if (res.ok) {
+      setStrategies(res.data);
+      setError(null);
+    } else {
+      setError(res.problem);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function create(e: React.FormEvent) {
+    e.preventDefault();
+    const res = await apiFetch<Strategy>("/strategies", {
+      method: "POST",
+      body: JSON.stringify({ name, symbol, timeframe }),
+    });
+    if (res.ok) {
+      setName("");
+      setError(null);
+      load();
+    } else {
+      setError(res.problem);
+    }
+  }
+
+  if (!getWorkspaceId()) {
+    return (
+      <div style={{ padding: "48px 24px" }}>
+        <p>
+          <Link href="/factory">Set Workspace ID first</Link>
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: "48px 24px", maxWidth: 700, margin: "0 auto" }}>
+      <h1 style={{ fontSize: 24, marginBottom: 24 }}>Strategies</h1>
+
+      {error && <ErrorBox problem={error} />}
+
+      <form onSubmit={create} style={card}>
+        <h3 style={{ marginBottom: 12 }}>Create Strategy</h3>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <input style={input} placeholder="Name" value={name} onChange={(e) => setName(e.target.value)} required />
+          <input style={{ ...input, width: 120 }} placeholder="Symbol" value={symbol} onChange={(e) => setSymbol(e.target.value)} required />
+          <select style={input} value={timeframe} onChange={(e) => setTimeframe(e.target.value)}>
+            {TIMEFRAMES.map((t) => (
+              <option key={t} value={t}>{t}</option>
+            ))}
+          </select>
+          <button style={btn} type="submit">Create</button>
+        </div>
+      </form>
+
+      <table style={{ width: "100%", marginTop: 24, borderCollapse: "collapse" }}>
+        <thead>
+          <tr>
+            {["Name", "Symbol", "Timeframe", "Status", "Created"].map((h) => (
+              <th key={h} style={th}>{h}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {strategies.map((s) => (
+            <tr key={s.id}>
+              <td style={td}>
+                <Link href={`/factory/strategies/${s.id}`}>{s.name}</Link>
+              </td>
+              <td style={td}>{s.symbol}</td>
+              <td style={td}>{s.timeframe}</td>
+              <td style={td}>{s.status}</td>
+              <td style={td}>{new Date(s.createdAt).toLocaleString()}</td>
+            </tr>
+          ))}
+          {strategies.length === 0 && (
+            <tr>
+              <td colSpan={5} style={{ ...td, color: "var(--text-secondary)" }}>No strategies yet</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function ErrorBox({ problem }: { problem: ProblemDetails }) {
+  return (
+    <div style={{ background: "#3d1f1f", border: "1px solid #f85149", borderRadius: 6, padding: 12, marginBottom: 16 }}>
+      <strong>{problem.title}</strong>: {problem.detail}
+      {problem.errors?.map((e, i) => (
+        <div key={i} style={{ fontSize: 13, marginTop: 4 }}>{e.field}: {e.message}</div>
+      ))}
+    </div>
+  );
+}
+
+const card: React.CSSProperties = { background: "var(--bg-card)", border: "1px solid var(--border)", borderRadius: 8, padding: 16 };
+const input: React.CSSProperties = { padding: "8px 12px", background: "var(--bg-secondary)", border: "1px solid var(--border)", borderRadius: 6, color: "var(--text-primary)", fontSize: 14 };
+const btn: React.CSSProperties = { padding: "8px 16px", background: "var(--accent)", color: "#fff", border: "none", borderRadius: 6, cursor: "pointer", fontSize: 14 };
+const th: React.CSSProperties = { textAlign: "left", padding: "8px 12px", borderBottom: "1px solid var(--border)", color: "var(--text-secondary)", fontSize: 13 };
+const td: React.CSSProperties = { padding: "8px 12px", borderBottom: "1px solid var(--border)", fontSize: 14 };


### PR DESCRIPTION
Pages:
- /factory — workspace ID selector (localStorage), links to strategies/bots
- /factory/strategies — list + create strategy form
- /factory/strategies/[id] — strategy detail, validate DSL, create versions
- /factory/bots — list + create bot form (with strategyVersionId)
- /factory/bots/[id] — bot detail, start/stop run, events log with polling

Infrastructure:
- Add apiFetch helper with X-Workspace-Id header injection
- Add Next.js rewrite to proxy /api/* to API server (port 4000)
- Dark theme with existing CSS variables, inline styles

https://claude.ai/code/session_01NYMtdr8vttRQAosyqzNJtF