### PR TITLE
feat: add workspaces API (list/create) + factory create button

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -6,12 +6,14 @@ import { authRoutes } from "./routes/auth.js";
 import { strategyRoutes } from "./routes/strategies.js";
 import { botRoutes } from "./routes/bots.js";
 import { runRoutes } from "./routes/runs.js";
+import { workspacesRoutes } from "./routes/workspaces.js";
 
 /** Registers all domain routes. */
 async function registerRoutes(scope: import("fastify").FastifyInstance) {
   await scope.register(healthzRoutes);
   await scope.register(readyzRoutes);
   await scope.register(authRoutes);
+  await scope.register(workspacesRoutes);
   await scope.register(strategyRoutes);
   await scope.register(botRoutes);
   await scope.register(runRoutes);

--- a/apps/api/src/routes/workspaces.ts
+++ b/apps/api/src/routes/workspaces.ts
@@ -1,0 +1,37 @@
+import type { FastifyInstance } from "fastify";
+import { prisma } from "../lib/prisma.js";
+import { problem } from "../lib/problem.js";
+
+interface CreateWorkspaceBody {
+  name?: string;
+}
+
+export async function workspacesRoutes(app: FastifyInstance) {
+  // GET /workspaces — list all workspaces (MVP: no auth filter)
+  app.get("/workspaces", async (_request, reply) => {
+    const workspaces = await prisma.workspace.findMany({
+      orderBy: { createdAt: "desc" },
+      select: { id: true, name: true, createdAt: true, updatedAt: true },
+    });
+    return reply.send(workspaces);
+  });
+
+  // POST /workspaces — create a new workspace
+  app.post<{ Body: CreateWorkspaceBody }>("/workspaces", async (request, reply) => {
+    const { name } = request.body ?? {};
+
+    if (name !== undefined && (typeof name !== "string" || name.trim().length === 0)) {
+      return problem(reply, 400, "Validation Error", "name must be a non-empty string");
+    }
+
+    const shortId = crypto.randomUUID().slice(0, 8);
+    const finalName = name?.trim() || `Workspace ${shortId}`;
+
+    const workspace = await prisma.workspace.create({
+      data: { name: finalName },
+      select: { id: true, name: true, createdAt: true, updatedAt: true },
+    });
+
+    return reply.status(201).send(workspace);
+  });
+}


### PR DESCRIPTION
Backend:
- GET /workspaces — list all workspaces (MVP, no auth filter)
- POST /workspaces — create workspace with optional name (defaults to "Workspace <shortId>")
- Register workspacesRoutes in app.ts

Frontend:
- Add "Create Workspace" button to /factory page
- Add apiFetchNoWorkspace helper (no X-Workspace-Id header)
- On create: auto-fill and save workspace ID to localStorage

https://claude.ai/code/session_01NYMtdr8vttRQAosyqzNJtF