### PR TITLE
feat: prod-friendly API routing (dev rewrite only)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,4 +12,6 @@ API_PORT=4000
 API_HOST="0.0.0.0"
 
 # Frontend
-NEXT_PUBLIC_API_URL="http://localhost:4000/api"
+# Dev only: Next.js rewrites /api/* to this target.
+# In production, leave empty — a reverse proxy (nginx) handles /api routing.
+NEXT_PUBLIC_API_URL="http://localhost:4000"

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,12 +1,18 @@
 import type { NextConfig } from "next";
 
+const isDev = process.env.NODE_ENV !== "production";
+
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   async rewrites() {
+    if (!isDev) return [];
+    // In dev, proxy /api/* requests to the local Fastify API server
+    // so the frontend can call relative paths without CORS issues.
+    const apiTarget = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000";
     return [
       {
         source: "/api/:path*",
-        destination: `${process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000"}/api/:path*`,
+        destination: `${apiTarget}/api/:path*`,
       },
     ];
   },


### PR DESCRIPTION
- next.config.ts: only apply /api/* rewrite in dev (NODE_ENV !== production); in prod, return empty rewrites — expects reverse proxy
- .env.example: fix NEXT_PUBLIC_API_URL to point to host only (no /api suffix), add comment explaining dev-only usage
- README: add "API routing (dev vs prod)" section with nginx example config

Frontend api.ts already uses relative paths (/api/v1/...) so no changes needed there — works in both dev (Next rewrite) and prod (reverse proxy).

https://claude.ai/code/session_01NYMtdr8vttRQAosyqzNJtF