### PR TITLE
feat: stage 4 — bot runtime core (state machine + idempotency + recon…

### DIFF
--- a/apps/api/prisma/migrations/20260219a_add_bot_intents/migration.sql
+++ b/apps/api/prisma/migrations/20260219a_add_bot_intents/migration.sql
@@ -1,0 +1,47 @@
+-- CreateEnum
+CREATE TYPE "IntentType" AS ENUM ('ENTRY', 'EXIT', 'SL', 'TP', 'CANCEL');
+
+-- CreateEnum
+CREATE TYPE "IntentState" AS ENUM ('PENDING', 'PLACED', 'FILLED', 'CANCELLED', 'FAILED');
+
+-- CreateEnum
+CREATE TYPE "OrderSide" AS ENUM ('BUY', 'SELL');
+
+-- CreateTable
+CREATE TABLE "BotIntent" (
+    "id" TEXT NOT NULL,
+    "botRunId" TEXT NOT NULL,
+    "intentId" TEXT NOT NULL,
+    "orderLinkId" TEXT NOT NULL,
+    "type" "IntentType" NOT NULL,
+    "state" "IntentState" NOT NULL DEFAULT 'PENDING',
+    "side" "OrderSide" NOT NULL,
+    "qty" DECIMAL(18,8) NOT NULL,
+    "price" DECIMAL(18,8),
+    "orderId" TEXT,
+    "metaJson" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "BotIntent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex (intentId unique per run — client idempotency key)
+CREATE UNIQUE INDEX "BotIntent_botRunId_intentId_key" ON "BotIntent"("botRunId", "intentId");
+
+-- CreateIndex (orderLinkId unique globally — sent to exchange as clientOrderId)
+CREATE UNIQUE INDEX "BotIntent_orderLinkId_key" ON "BotIntent"("orderLinkId");
+
+-- CreateIndex
+CREATE INDEX "BotIntent_botRunId_idx" ON "BotIntent"("botRunId");
+
+-- CreateIndex
+CREATE INDEX "BotIntent_orderLinkId_idx" ON "BotIntent"("orderLinkId");
+
+-- CreateIndex
+CREATE INDEX "BotIntent_botRunId_state_idx" ON "BotIntent"("botRunId", "state");
+
+-- AddForeignKey
+ALTER TABLE "BotIntent"
+    ADD CONSTRAINT "BotIntent_botRunId_fkey"
+    FOREIGN KEY ("botRunId") REFERENCES "BotRun"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -157,6 +157,7 @@ model BotRun {
   bot       Bot       @relation(fields: [botId], references: [id], onDelete: Cascade)
   workspace Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
   events    BotEvent[]
+  intents   BotIntent[]
 
   // NOTE: partial unique index (one active run per workspace+symbol)
   // is defined in the migration SQL because Prisma cannot express
@@ -178,4 +179,54 @@ model BotEvent {
   botRun BotRun @relation(fields: [botRunId], references: [id], onDelete: Cascade)
 
   @@index([botRunId, ts(sort: Desc)])
+}
+
+// ── Idempotency / Order intents ───────────────────────────────────
+
+enum IntentType {
+  ENTRY
+  EXIT
+  SL
+  TP
+  CANCEL
+}
+
+enum IntentState {
+  PENDING
+  PLACED
+  FILLED
+  CANCELLED
+  FAILED
+}
+
+enum OrderSide {
+  BUY
+  SELL
+}
+
+model BotIntent {
+  id          String      @id @default(uuid())
+  botRunId    String
+  /// Client-provided idempotency key — unique per run
+  intentId    String
+  /// Exchange order link ID generated server-side (sent to exchange as clientOrderId)
+  orderLinkId String      @unique
+  type        IntentType
+  state       IntentState @default(PENDING)
+  side        OrderSide
+  qty         Decimal     @db.Decimal(18, 8)
+  price       Decimal?    @db.Decimal(18, 8)
+  /// Exchange-assigned order ID, set after placement confirmation
+  orderId     String?
+  /// Extra metadata (e.g., sl/tp prices, retry count, exchange response)
+  metaJson    Json?
+  createdAt   DateTime    @default(now())
+  updatedAt   DateTime    @updatedAt
+
+  botRun BotRun @relation(fields: [botRunId], references: [id], onDelete: Cascade)
+
+  @@unique([botRunId, intentId])
+  @@index([botRunId])
+  @@index([orderLinkId])
+  @@index([botRunId, state])
 }

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -6,6 +6,7 @@ import { authRoutes } from "./routes/auth.js";
 import { strategyRoutes } from "./routes/strategies.js";
 import { botRoutes } from "./routes/bots.js";
 import { runRoutes } from "./routes/runs.js";
+import { intentRoutes } from "./routes/intents.js";
 import { workspacesRoutes } from "./routes/workspaces.js";
 
 /** Registers all domain routes. */
@@ -17,6 +18,7 @@ async function registerRoutes(scope: import("fastify").FastifyInstance) {
   await scope.register(strategyRoutes);
   await scope.register(botRoutes);
   await scope.register(runRoutes);
+  await scope.register(intentRoutes);
 }
 
 export async function buildApp() {

--- a/apps/api/src/lib/stateMachine.ts
+++ b/apps/api/src/lib/stateMachine.ts
@@ -1,0 +1,152 @@
+/**
+ * Bot Run State Machine
+ *
+ * Enforces valid state transitions and atomically logs each transition
+ * as a BotEvent. All state changes MUST go through `transition()`.
+ */
+
+import type { BotRunState } from "@prisma/client";
+import { prisma as defaultPrisma } from "./prisma.js";
+
+// ---------------------------------------------------------------------------
+// Transition graph
+// ---------------------------------------------------------------------------
+
+const TRANSITIONS: Record<BotRunState, readonly BotRunState[]> = {
+  CREATED:   ["QUEUED"],
+  QUEUED:    ["STARTING", "FAILED"],
+  STARTING:  ["SYNCING", "STOPPING", "FAILED", "TIMED_OUT"],
+  SYNCING:   ["RUNNING", "STOPPING", "FAILED", "TIMED_OUT"],
+  RUNNING:   ["STOPPING", "FAILED", "TIMED_OUT"],
+  STOPPING:  ["STOPPED", "FAILED"],
+  STOPPED:   [],
+  FAILED:    [],
+  TIMED_OUT: [],
+};
+
+export const TERMINAL_STATES: ReadonlySet<BotRunState> = new Set([
+  "STOPPED",
+  "FAILED",
+  "TIMED_OUT",
+]);
+
+export function isTerminalState(state: BotRunState): boolean {
+  return TERMINAL_STATES.has(state);
+}
+
+export function isValidTransition(from: BotRunState, to: BotRunState): boolean {
+  return (TRANSITIONS[from] as readonly BotRunState[]).includes(to);
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+export class InvalidTransitionError extends Error {
+  constructor(
+    public readonly from: BotRunState,
+    public readonly to: BotRunState,
+  ) {
+    super(`Invalid state transition: ${from} → ${to}`);
+    this.name = "InvalidTransitionError";
+  }
+}
+
+export class RunNotFoundError extends Error {
+  constructor(public readonly runId: string) {
+    super(`BotRun not found: ${runId}`);
+    this.name = "RunNotFoundError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Transition function
+// ---------------------------------------------------------------------------
+
+export interface TransitionOptions {
+  /** Short label for the BotEvent.type field, e.g. "RUN_STARTING" */
+  eventType?: string;
+  /** Human-readable message for BotEvent.payloadJson.message */
+  message?: string;
+  /** Extra fields merged into BotEvent.payloadJson */
+  meta?: Record<string, unknown>;
+  /** If provided, also set stoppedAt on terminal transitions */
+  stoppedAt?: Date;
+  /** If provided, also set startedAt when transitioning to RUNNING */
+  startedAt?: Date;
+  /** If provided, set errorCode on FAILED/TIMED_OUT */
+  errorCode?: string;
+}
+
+export interface TransitionResult {
+  id: string;
+  state: BotRunState;
+  stoppedAt: Date | null;
+  startedAt: Date | null;
+  errorCode: string | null;
+  updatedAt: Date;
+}
+
+/**
+ * Atomically transition a BotRun to a new state and record the event.
+ *
+ * @throws {RunNotFoundError}       if runId doesn't exist
+ * @throws {InvalidTransitionError} if the transition is not allowed
+ */
+export async function transition(
+  runId: string,
+  to: BotRunState,
+  options: TransitionOptions = {},
+): Promise<TransitionResult> {
+  const run = await defaultPrisma.botRun.findUnique({ where: { id: runId } });
+  if (!run) throw new RunNotFoundError(runId);
+
+  const from = run.state;
+  if (!isValidTransition(from, to)) {
+    throw new InvalidTransitionError(from, to);
+  }
+
+  const now = new Date();
+  const eventType = options.eventType ?? `RUN_${to}`;
+  const payload: Record<string, unknown> = {
+    from,
+    to,
+    message: options.message ?? `State transition: ${from} → ${to}`,
+    at: now.toISOString(),
+    ...(options.meta ?? {}),
+  };
+
+  const updateData: Record<string, unknown> = { state: to };
+  if (to === "RUNNING" && options.startedAt) updateData.startedAt = options.startedAt;
+  if (isTerminalState(to)) {
+    updateData.stoppedAt = options.stoppedAt ?? now;
+    if (options.errorCode) updateData.errorCode = options.errorCode;
+  }
+
+  const updated = await defaultPrisma.$transaction(async (tx) => {
+    const result = await tx.botRun.update({
+      where: { id: runId },
+      data: updateData,
+      select: {
+        id: true,
+        state: true,
+        stoppedAt: true,
+        startedAt: true,
+        errorCode: true,
+        updatedAt: true,
+      },
+    });
+
+    await tx.botEvent.create({
+      data: {
+        botRunId: runId,
+        type: eventType,
+        payloadJson: payload,
+      },
+    });
+
+    return result;
+  });
+
+  return updated as TransitionResult;
+}

--- a/apps/api/src/routes/intents.ts
+++ b/apps/api/src/routes/intents.ts
@@ -1,0 +1,153 @@
+/**
+ * Bot Intent routes — idempotency layer for exchange orders.
+ *
+ * Intents represent "our intent to place an order". Each intent carries:
+ *  - intentId   : client-provided idempotency key (unique per run)
+ *  - orderLinkId: server-generated exchange clientOrderId (globally unique)
+ *
+ * The API is deliberately simple; the actual order placement is done by
+ * the bot runtime worker, which uses orderLinkId when calling the exchange.
+ */
+
+import { randomUUID } from "node:crypto";
+import type { FastifyInstance } from "fastify";
+import type { IntentState, IntentType, OrderSide } from "@prisma/client";
+import { prisma } from "../lib/prisma.js";
+import { problem } from "../lib/problem.js";
+import { resolveWorkspace } from "../lib/workspace.js";
+
+// ---------------------------------------------------------------------------
+// Route plugin
+// ---------------------------------------------------------------------------
+
+export async function intentRoutes(app: FastifyInstance) {
+  // ── POST /runs/:runId/intents ── create intent (idempotent) ──────────────
+  app.post<{
+    Params: { runId: string };
+    Body: {
+      intentId: string;
+      type: IntentType;
+      side: OrderSide;
+      qty: number;
+      price?: number;
+      metaJson?: Record<string, unknown>;
+    };
+  }>("/runs/:runId/intents", async (request, reply) => {
+    const workspace = await resolveWorkspace(request, reply);
+    if (!workspace) return;
+
+    const run = await prisma.botRun.findUnique({ where: { id: request.params.runId } });
+    if (!run || run.workspaceId !== workspace.id) {
+      return problem(reply, 404, "Not Found", "Run not found");
+    }
+
+    const { intentId, type, side, qty, price, metaJson } = request.body ?? {};
+
+    if (!intentId) return problem(reply, 400, "BadRequest", "'intentId' is required");
+    if (!type)     return problem(reply, 400, "BadRequest", "'type' is required");
+    if (!side)     return problem(reply, 400, "BadRequest", "'side' is required");
+    if (qty == null || qty <= 0) return problem(reply, 400, "BadRequest", "'qty' must be a positive number");
+
+    // Idempotency: if an intent with this intentId already exists for this run, return it
+    const existing = await prisma.botIntent.findUnique({
+      where: { botRunId_intentId: { botRunId: run.id, intentId } },
+    });
+    if (existing) {
+      return reply.status(200).send(existing);
+    }
+
+    try {
+      const intent = await prisma.botIntent.create({
+        data: {
+          botRunId:    run.id,
+          intentId,
+          orderLinkId: randomUUID(), // globally unique; sent to exchange as clientOrderId
+          type,
+          side,
+          qty:         qty,
+          price:       price ?? null,
+          metaJson:    metaJson ?? null,
+          state:       "PENDING",
+        },
+      });
+
+      return reply.status(201).send(intent);
+    } catch (err) {
+      // P2002 = unique constraint violation → race on intentId creation
+      if ((err as { code?: string })?.code === "P2002") {
+        // Race: concurrent request created the same intentId; re-fetch and return
+        const raced = await prisma.botIntent.findUnique({
+          where: { botRunId_intentId: { botRunId: run.id, intentId } },
+        });
+        return reply.status(200).send(raced);
+      }
+      throw err;
+    }
+  });
+
+  // ── GET /runs/:runId/intents ── list intents for a run ───────────────────
+  app.get<{
+    Params: { runId: string };
+    Querystring: { state?: IntentState };
+  }>("/runs/:runId/intents", async (request, reply) => {
+    const workspace = await resolveWorkspace(request, reply);
+    if (!workspace) return;
+
+    const run = await prisma.botRun.findUnique({ where: { id: request.params.runId } });
+    if (!run || run.workspaceId !== workspace.id) {
+      return problem(reply, 404, "Not Found", "Run not found");
+    }
+
+    const intents = await prisma.botIntent.findMany({
+      where: {
+        botRunId: run.id,
+        ...(request.query?.state ? { state: request.query.state } : {}),
+      },
+      orderBy: { createdAt: "asc" },
+    });
+
+    return reply.send(intents);
+  });
+
+  // ── PATCH /runs/:runId/intents/:intentId/state ── advance intent state ───
+  app.patch<{
+    Params: { runId: string; intentId: string };
+    Body: { state: IntentState; orderId?: string; metaJson?: Record<string, unknown> };
+  }>("/runs/:runId/intents/:intentId/state", async (request, reply) => {
+    const workspace = await resolveWorkspace(request, reply);
+    if (!workspace) return;
+
+    const run = await prisma.botRun.findUnique({ where: { id: request.params.runId } });
+    if (!run || run.workspaceId !== workspace.id) {
+      return problem(reply, 404, "Not Found", "Run not found");
+    }
+
+    const intent = await prisma.botIntent.findUnique({
+      where: { botRunId_intentId: { botRunId: run.id, intentId: request.params.intentId } },
+    });
+    if (!intent) {
+      return problem(reply, 404, "Not Found", "Intent not found");
+    }
+
+    const { state: newState, orderId, metaJson } = request.body ?? {};
+    if (!newState) return problem(reply, 400, "BadRequest", "'state' is required");
+
+    // Terminal intents cannot be updated
+    if (intent.state === "FILLED" || intent.state === "CANCELLED" || intent.state === "FAILED") {
+      return problem(reply, 409, "Conflict", `Intent is already in terminal state: ${intent.state}`);
+    }
+
+    const updated = await prisma.botIntent.update({
+      where: { id: intent.id },
+      data: {
+        state:   newState,
+        orderId: orderId ?? intent.orderId,
+        metaJson: metaJson != null
+          ? { ...(intent.metaJson as Record<string, unknown> ?? {}), ...metaJson }
+          : intent.metaJson,
+      },
+    });
+
+    return reply.send(updated);
+  });
+}

--- a/apps/api/src/routes/runs.ts
+++ b/apps/api/src/routes/runs.ts
@@ -1,34 +1,22 @@
 import type { FastifyInstance } from "fastify";
-import { Prisma } from "@prisma/client";
+import type { BotRunState } from "@prisma/client";
 import { prisma } from "../lib/prisma.js";
 import { problem } from "../lib/problem.js";
 import { resolveWorkspace } from "../lib/workspace.js";
-
-// ---------------------------------------------------------------------------
-// Active states — must match the partial unique index in migration SQL
-// ---------------------------------------------------------------------------
-
-const ACTIVE_STATES = ["CREATED", "QUEUED", "STARTING", "SYNCING", "RUNNING"] as const;
-const TERMINAL_STATES = ["STOPPED", "FAILED", "TIMED_OUT"] as const;
-
-function isTerminal(state: string): boolean {
-  return (TERMINAL_STATES as readonly string[]).includes(state);
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function eventPayload(message: string, state: string) {
-  return { message, state, at: new Date().toISOString() };
-}
+import {
+  transition,
+  isTerminalState,
+  isValidTransition,
+  InvalidTransitionError,
+  RunNotFoundError,
+} from "../lib/stateMachine.js";
 
 // ---------------------------------------------------------------------------
 // Routes
 // ---------------------------------------------------------------------------
 
 export async function runRoutes(app: FastifyInstance) {
-  // POST /bots/:botId/runs — start a new run
+  // ── POST /bots/:botId/runs ── start a new run ────────────────────────────
   app.post<{ Params: { botId: string } }>("/bots/:botId/runs", async (request, reply) => {
     const workspace = await resolveWorkspace(request, reply);
     if (!workspace) return;
@@ -38,95 +26,107 @@ export async function runRoutes(app: FastifyInstance) {
       return problem(reply, 404, "Not Found", "Bot not found");
     }
 
-    try {
-      const run = await prisma.$transaction(async (tx) => {
-        const created = await tx.botRun.create({
-          data: {
-            botId: bot.id,
-            workspaceId: bot.workspaceId,
-            symbol: bot.symbol,
-            state: "QUEUED",
-          },
-        });
+    // Enforce single-active-run invariant
+    const activeRun = await prisma.botRun.findFirst({
+      where: {
+        botId: bot.id,
+        state: { notIn: ["STOPPED", "FAILED", "TIMED_OUT"] },
+      },
+    });
+    if (activeRun) {
+      return problem(reply, 409, "ActiveRunExists", "An active run already exists for this bot");
+    }
 
-        await tx.botEvent.createMany({
-          data: [
-            {
-              botRunId: created.id,
-              type: "RUN_CREATED",
-              payloadJson: eventPayload("Run created", "CREATED"),
-            },
-            {
-              botRunId: created.id,
-              type: "RUN_QUEUED",
-              payloadJson: eventPayload("Run queued", "QUEUED"),
-            },
-          ],
-        });
-
-        return created;
+    const run = await prisma.$transaction(async (tx) => {
+      const created = await tx.botRun.create({
+        data: {
+          botId: bot.id,
+          workspaceId: bot.workspaceId,
+          symbol: bot.symbol,
+          state: "CREATED",
+        },
       });
 
-      return reply.status(201).send(run);
-    } catch (err) {
-      // Partial unique index violation → active run already exists
-      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
-        return problem(reply, 409, "ActiveRunExists", "An active run already exists for this bot's symbol in this workspace");
-      }
-      throw err;
-    }
-  });
-
-  // POST /bots/:botId/runs/:runId/stop — stop a run
-  app.post<{ Params: { botId: string; runId: string } }>("/bots/:botId/runs/:runId/stop", async (request, reply) => {
-    const workspace = await resolveWorkspace(request, reply);
-    if (!workspace) return;
-
-    const bot = await prisma.bot.findUnique({ where: { id: request.params.botId } });
-    if (!bot || bot.workspaceId !== workspace.id) {
-      return problem(reply, 404, "Not Found", "Bot not found");
-    }
-
-    const run = await prisma.botRun.findUnique({ where: { id: request.params.runId } });
-    if (!run || run.botId !== bot.id) {
-      return problem(reply, 404, "Not Found", "Run not found");
-    }
-
-    if (isTerminal(run.state)) {
-      return problem(reply, 409, "Conflict", `Run is already in terminal state: ${run.state}`);
-    }
-
-    const now = new Date();
-
-    const stopped = await prisma.$transaction(async (tx) => {
-      const updated = await tx.botRun.update({
-        where: { id: run.id },
-        data: { state: "STOPPED", stoppedAt: now },
+      await tx.botEvent.create({
+        data: {
+          botRunId: created.id,
+          type: "RUN_CREATED",
+          payloadJson: {
+            from: null,
+            to: "CREATED",
+            message: "Run created",
+            at: new Date().toISOString(),
+          },
+        },
       });
 
-      await tx.botEvent.createMany({
-        data: [
-          {
-            botRunId: run.id,
-            type: "RUN_STOPPING",
-            payloadJson: eventPayload("Stopping run", "STOPPING"),
-          },
-          {
-            botRunId: run.id,
-            type: "RUN_STOPPED",
-            payloadJson: eventPayload("Run stopped", "STOPPED"),
-          },
-        ],
-      });
-
-      return updated;
+      return created;
     });
 
-    return reply.send(stopped);
+    // Immediately transition to QUEUED via state machine
+    await transition(run.id, "QUEUED", {
+      eventType: "RUN_QUEUED",
+      message: "Run queued for processing",
+    });
+
+    const fresh = await prisma.botRun.findUnique({ where: { id: run.id } });
+    return reply.status(201).send(fresh);
   });
 
-  // GET /runs/:runId/events — list events for a run
-  app.get<{ Params: { runId: string } }>("/runs/:runId/events", async (request, reply) => {
+  // ── POST /bots/:botId/runs/:runId/stop ───────────────────────────────────
+  app.post<{ Params: { botId: string; runId: string } }>(
+    "/bots/:botId/runs/:runId/stop",
+    async (request, reply) => {
+      const workspace = await resolveWorkspace(request, reply);
+      if (!workspace) return;
+
+      const bot = await prisma.bot.findUnique({ where: { id: request.params.botId } });
+      if (!bot || bot.workspaceId !== workspace.id) {
+        return problem(reply, 404, "Not Found", "Bot not found");
+      }
+
+      const run = await prisma.botRun.findUnique({ where: { id: request.params.runId } });
+      if (!run || run.botId !== bot.id) {
+        return problem(reply, 404, "Not Found", "Run not found");
+      }
+
+      if (isTerminalState(run.state)) {
+        return problem(reply, 409, "Conflict", `Run is already in terminal state: ${run.state}`);
+      }
+
+      try {
+        // STOPPING is intermediate; if state doesn't allow STOPPING, go straight to STOPPED
+        let updated;
+        if (isValidTransition(run.state, "STOPPING")) {
+          await transition(run.id, "STOPPING", {
+            eventType: "RUN_STOPPING",
+            message: "Stop requested",
+          });
+          updated = await transition(run.id, "STOPPED", {
+            eventType: "RUN_STOPPED",
+            message: "Run stopped",
+          });
+        } else {
+          updated = await transition(run.id, "STOPPED", {
+            eventType: "RUN_STOPPED",
+            message: "Run stopped",
+          });
+        }
+        return reply.send(updated);
+      } catch (err) {
+        if (err instanceof InvalidTransitionError) {
+          return problem(reply, 409, "InvalidTransition", err.message);
+        }
+        throw err;
+      }
+    },
+  );
+
+  // ── PATCH /runs/:runId/state ── worker-driven state advance ──────────────
+  app.patch<{
+    Params: { runId: string };
+    Body: { state: BotRunState; message?: string; errorCode?: string };
+  }>("/runs/:runId/state", async (request, reply) => {
     const workspace = await resolveWorkspace(request, reply);
     if (!workspace) return;
 
@@ -135,11 +135,133 @@ export async function runRoutes(app: FastifyInstance) {
       return problem(reply, 404, "Not Found", "Run not found");
     }
 
-    const events = await prisma.botEvent.findMany({
-      where: { botRunId: run.id },
-      orderBy: { ts: "asc" },
-      select: { id: true, ts: true, type: true, payloadJson: true },
+    const { state: toState, message, errorCode } = request.body ?? {};
+    if (!toState) {
+      return problem(reply, 400, "BadRequest", "Body must include 'state'");
+    }
+
+    try {
+      const updated = await transition(run.id, toState, {
+        message,
+        errorCode,
+        startedAt: toState === "RUNNING" ? new Date() : undefined,
+      });
+      return reply.send(updated);
+    } catch (err) {
+      if (err instanceof InvalidTransitionError) {
+        return problem(reply, 409, "InvalidTransition", err.message);
+      }
+      if (err instanceof RunNotFoundError) {
+        return problem(reply, 404, "Not Found", err.message);
+      }
+      throw err;
+    }
+  });
+
+  // ── POST /runs/:runId/heartbeat ── lease renewal ──────────────────────────
+  app.post<{ Params: { runId: string }; Body: { workerId: string } }>(
+    "/runs/:runId/heartbeat",
+    async (request, reply) => {
+      const workspace = await resolveWorkspace(request, reply);
+      if (!workspace) return;
+
+      const run = await prisma.botRun.findUnique({ where: { id: request.params.runId } });
+      if (!run || run.workspaceId !== workspace.id) {
+        return problem(reply, 404, "Not Found", "Run not found");
+      }
+
+      if (isTerminalState(run.state)) {
+        return problem(reply, 409, "Conflict", `Run is in terminal state: ${run.state}`);
+      }
+
+      const workerId = request.body?.workerId ?? "unknown";
+      const leaseUntil = new Date(Date.now() + 30_000); // 30s lease
+
+      const updated = await prisma.botRun.update({
+        where: { id: run.id },
+        data: { leaseOwner: workerId, leaseUntil },
+        select: { id: true, state: true, leaseOwner: true, leaseUntil: true, updatedAt: true },
+      });
+
+      return reply.send(updated);
+    },
+  );
+
+  // ── GET /runs/:runId/events ── list events for a run ─────────────────────
+  app.get<{ Params: { runId: string }; Querystring: { limit?: string; after?: string } }>(
+    "/runs/:runId/events",
+    async (request, reply) => {
+      const workspace = await resolveWorkspace(request, reply);
+      if (!workspace) return;
+
+      const run = await prisma.botRun.findUnique({ where: { id: request.params.runId } });
+      if (!run || run.workspaceId !== workspace.id) {
+        return problem(reply, 404, "Not Found", "Run not found");
+      }
+
+      const limit = Math.min(Number(request.query?.limit ?? 100), 500);
+      const after = request.query?.after;
+
+      const events = await prisma.botEvent.findMany({
+        where: {
+          botRunId: run.id,
+          ...(after ? { ts: { gt: new Date(after) } } : {}),
+        },
+        orderBy: { ts: "asc" },
+        take: limit,
+        select: { id: true, ts: true, type: true, payloadJson: true },
+      });
+
+      return reply.send(events);
+    },
+  );
+
+  // ── POST /runs/reconcile ── recover stale runs ────────────────────────────
+  app.post("/runs/reconcile", async (request, reply) => {
+    const workspace = await resolveWorkspace(request, reply);
+    if (!workspace) return;
+
+    const now = new Date();
+    const staleTimeout = 60_000; // 60s — if no heartbeat for 60s, consider stale
+
+    // Find active runs with expired lease or no lease set for > 60s
+    const staleRuns = await prisma.botRun.findMany({
+      where: {
+        workspaceId: workspace.id,
+        state: { notIn: ["STOPPED", "FAILED", "TIMED_OUT", "CREATED", "QUEUED"] },
+        OR: [
+          { leaseUntil: { lt: now } },
+          {
+            leaseUntil: null,
+            updatedAt: { lt: new Date(now.getTime() - staleTimeout) },
+          },
+        ],
+      },
+      select: { id: true, state: true, leaseOwner: true, leaseUntil: true },
     });
-    return reply.send(events);
+
+    const recovered: string[] = [];
+    const errors: { id: string; error: string }[] = [];
+
+    for (const stale of staleRuns) {
+      try {
+        await transition(stale.id, "FAILED", {
+          eventType: "RUN_RECONCILED_FAILED",
+          message: "Run marked FAILED by reconciliation (stale lease)",
+          errorCode: "STALE_LEASE",
+          meta: { leaseOwner: stale.leaseOwner, leaseUntil: stale.leaseUntil },
+        });
+        recovered.push(stale.id);
+      } catch (err) {
+        errors.push({ id: stale.id, error: String(err) });
+      }
+    }
+
+    return reply.send({
+      staleFound: staleRuns.length,
+      markedFailed: recovered,
+      errors,
+      at: now.toISOString(),
+    });
   });
 }


### PR DESCRIPTION
…ciliation)

- Add stateMachine.ts: enforces valid BotRun state transitions atomically; each transition writes a BotEvent in the same transaction
- Add BotIntent model (schema + migration 20260219a): idempotency layer for exchange orders; intentId (client key) + orderLinkId (exchange clientOrderId) with enums IntentType / IntentState / OrderSide
- Refactor runs.ts: all state changes go through transition(); add PATCH /runs/:runId/state (worker-driven advance), POST /runs/:runId/heartbeat (lease renewal), POST /runs/reconcile (stale-lease recovery), and cursor-based GET /runs/:runId/events with limit/after query params
- Add intents.ts: POST /runs/:runId/intents (idempotent create), GET /runs/:runId/intents, PATCH /runs/:runId/intents/:intentId/state
- Register intentRoutes in app.ts

https://claude.ai/code/session_01F1Ph6zmDTqcsTRbunpoJZY