### PR TITLE
feat: stage 5 — Research Lab (backtest engine + Lab UI)

### DIFF
--- a/apps/api/prisma/migrations/20260220a_add_backtest_result/migration.sql
+++ b/apps/api/prisma/migrations/20260220a_add_backtest_result/migration.sql
@@ -1,0 +1,39 @@
+-- CreateEnum
+CREATE TYPE "BacktestStatus" AS ENUM ('PENDING', 'RUNNING', 'DONE', 'FAILED');
+
+-- CreateTable
+CREATE TABLE "BacktestResult" (
+    "id" TEXT NOT NULL,
+    "workspaceId" TEXT NOT NULL,
+    "strategyId" TEXT NOT NULL,
+    "symbol" TEXT NOT NULL,
+    "interval" TEXT NOT NULL,
+    "fromTs" TIMESTAMP(3) NOT NULL,
+    "toTs" TIMESTAMP(3) NOT NULL,
+    "status" "BacktestStatus" NOT NULL DEFAULT 'PENDING',
+    "reportJson" JSONB,
+    "errorMessage" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "BacktestResult_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "BacktestResult_workspaceId_idx" ON "BacktestResult"("workspaceId");
+
+-- CreateIndex
+CREATE INDEX "BacktestResult_strategyId_idx" ON "BacktestResult"("strategyId");
+
+-- CreateIndex
+CREATE INDEX "BacktestResult_workspaceId_createdAt_idx" ON "BacktestResult"("workspaceId", "createdAt" DESC);
+
+-- AddForeignKey
+ALTER TABLE "BacktestResult"
+    ADD CONSTRAINT "BacktestResult_workspaceId_fkey"
+    FOREIGN KEY ("workspaceId") REFERENCES "Workspace"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BacktestResult"
+    ADD CONSTRAINT "BacktestResult_strategyId_fkey"
+    FOREIGN KEY ("strategyId") REFERENCES "Strategy"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -33,6 +33,7 @@ model Workspace {
   strategies Strategy[]
   bots       Bot[]
   botRuns    BotRun[]
+  backtests  BacktestResult[]
 }
 
 model WorkspaceMember {
@@ -77,6 +78,7 @@ model Strategy {
 
   workspace Workspace        @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
   versions  StrategyVersion[]
+  backtests BacktestResult[]
 
   @@unique([workspaceId, name])
   @@index([workspaceId])
@@ -229,4 +231,38 @@ model BotIntent {
   @@index([botRunId])
   @@index([orderLinkId])
   @@index([botRunId, state])
+}
+
+// ── Research Lab ─────────────────────────────────────────────────
+
+enum BacktestStatus {
+  PENDING
+  RUNNING
+  DONE
+  FAILED
+}
+
+model BacktestResult {
+  id           String         @id @default(uuid())
+  workspaceId  String
+  strategyId   String
+  /// Symbol passed at request time (may differ from strategy default)
+  symbol       String
+  /// Bybit kline interval: "1", "5", "15", "60"
+  interval     String
+  fromTs       DateTime
+  toTs         DateTime
+  status       BacktestStatus @default(PENDING)
+  /// Filled when status=DONE: { trades, wins, winrate, totalPnlPct, maxDrawdownPct, candles }
+  reportJson   Json?
+  errorMessage String?
+  createdAt    DateTime       @default(now())
+  updatedAt    DateTime       @updatedAt
+
+  workspace Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  strategy  Strategy  @relation(fields: [strategyId], references: [id], onDelete: Cascade)
+
+  @@index([workspaceId])
+  @@index([strategyId])
+  @@index([workspaceId, createdAt(sort: Desc)])
 }

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -8,6 +8,7 @@ import { botRoutes } from "./routes/bots.js";
 import { runRoutes } from "./routes/runs.js";
 import { intentRoutes } from "./routes/intents.js";
 import { workspacesRoutes } from "./routes/workspaces.js";
+import { labRoutes } from "./routes/lab.js";
 
 /** Registers all domain routes. */
 async function registerRoutes(scope: import("fastify").FastifyInstance) {
@@ -19,6 +20,7 @@ async function registerRoutes(scope: import("fastify").FastifyInstance) {
   await scope.register(botRoutes);
   await scope.register(runRoutes);
   await scope.register(intentRoutes);
+  await scope.register(labRoutes);
 }
 
 export async function buildApp() {

--- a/apps/api/src/lib/backtest.ts
+++ b/apps/api/src/lib/backtest.ts
@@ -1,0 +1,134 @@
+/**
+ * Deterministic backtest engine (pure function, no I/O).
+ *
+ * Algorithm (price-breakout, 2:1 R/R):
+ *   - Lookback N = 20 candles
+ *   - Signal BUY: close[i] > max(close[i-N .. i-1])
+ *   - Entry at close[i] price when no open position
+ *   - SL  = entry * (1 - riskPct / 100)
+ *   - TP  = entry * (1 + 2 * riskPct / 100)
+ *   - Next candles: low ≤ SL → LOSS, high ≥ TP → WIN
+ *   - End of data with open position → close at last close (NEUTRAL)
+ */
+
+import type { Candle } from "./bybitCandles.js";
+
+export interface TradeRecord {
+  entryTime: number;
+  exitTime: number;
+  entryPrice: number;
+  exitPrice: number;
+  slPrice: number;
+  tpPrice: number;
+  outcome: "WIN" | "LOSS" | "NEUTRAL";
+  pnlPct: number;
+}
+
+export interface BacktestReport {
+  /** Number of completed trades */
+  trades: number;
+  /** Number of winning trades */
+  wins: number;
+  /** Win rate 0–1 */
+  winrate: number;
+  /** Sum of per-trade PnL % */
+  totalPnlPct: number;
+  /** Maximum drawdown % (peak-to-trough on cumulative PnL) */
+  maxDrawdownPct: number;
+  /** Candles processed */
+  candles: number;
+  tradeLog: TradeRecord[];
+}
+
+const LOOKBACK = 20;
+
+export function runBacktest(candleData: Candle[], riskPct: number): BacktestReport {
+  if (candleData.length < LOOKBACK + 1) {
+    return {
+      trades: 0, wins: 0, winrate: 0, totalPnlPct: 0, maxDrawdownPct: 0,
+      candles: candleData.length, tradeLog: [],
+    };
+  }
+
+  const tradeLog: TradeRecord[] = [];
+  let inPosition = false;
+  let entryPrice = 0;
+  let entryTime = 0;
+  let slPrice = 0;
+  let tpPrice = 0;
+
+  let cumulativePnl = 0;
+  let peakPnl = 0;
+  let maxDrawdownPct = 0;
+
+  for (let i = LOOKBACK; i < candleData.length; i++) {
+    const c = candleData[i];
+
+    if (inPosition) {
+      // Check SL first, then TP (conservative assumption: SL triggers before TP on the same candle)
+      if (c.low <= slPrice) {
+        const pnlPct = ((slPrice - entryPrice) / entryPrice) * 100;
+        tradeLog.push({
+          entryTime, exitTime: c.openTime, entryPrice, exitPrice: slPrice,
+          slPrice, tpPrice, outcome: "LOSS", pnlPct,
+        });
+        cumulativePnl += pnlPct;
+        if (cumulativePnl > peakPnl) peakPnl = cumulativePnl;
+        const dd = peakPnl - cumulativePnl;
+        if (dd > maxDrawdownPct) maxDrawdownPct = dd;
+        inPosition = false;
+      } else if (c.high >= tpPrice) {
+        const pnlPct = ((tpPrice - entryPrice) / entryPrice) * 100;
+        tradeLog.push({
+          entryTime, exitTime: c.openTime, entryPrice, exitPrice: tpPrice,
+          slPrice, tpPrice, outcome: "WIN", pnlPct,
+        });
+        cumulativePnl += pnlPct;
+        if (cumulativePnl > peakPnl) peakPnl = cumulativePnl;
+        const dd = peakPnl - cumulativePnl;
+        if (dd > maxDrawdownPct) maxDrawdownPct = dd;
+        inPosition = false;
+      }
+      // else: still in position, continue
+    } else {
+      // Entry signal: close[i] > rolling max of previous LOOKBACK closes
+      const rollingMax = Math.max(...candleData.slice(i - LOOKBACK, i).map((x) => x.close));
+      if (c.close > rollingMax) {
+        inPosition = true;
+        entryPrice = c.close;
+        entryTime = c.openTime;
+        slPrice = entryPrice * (1 - riskPct / 100);
+        tpPrice = entryPrice * (1 + (2 * riskPct) / 100);
+      }
+    }
+  }
+
+  // Close open position at last candle's close
+  if (inPosition) {
+    const last = candleData[candleData.length - 1];
+    const pnlPct = ((last.close - entryPrice) / entryPrice) * 100;
+    tradeLog.push({
+      entryTime, exitTime: last.openTime, entryPrice, exitPrice: last.close,
+      slPrice, tpPrice, outcome: "NEUTRAL", pnlPct,
+    });
+    cumulativePnl += pnlPct;
+    if (cumulativePnl > peakPnl) peakPnl = cumulativePnl;
+    const dd = peakPnl - cumulativePnl;
+    if (dd > maxDrawdownPct) maxDrawdownPct = dd;
+  }
+
+  const trades = tradeLog.length;
+  const wins = tradeLog.filter((t) => t.outcome === "WIN").length;
+  const winrate = trades > 0 ? wins / trades : 0;
+  const totalPnlPct = tradeLog.reduce((s, t) => s + t.pnlPct, 0);
+
+  return {
+    trades,
+    wins,
+    winrate: Math.round(winrate * 10000) / 10000,
+    totalPnlPct: Math.round(totalPnlPct * 100) / 100,
+    maxDrawdownPct: Math.round(maxDrawdownPct * 100) / 100,
+    candles: candleData.length,
+    tradeLog,
+  };
+}

--- a/apps/api/src/lib/bybitCandles.ts
+++ b/apps/api/src/lib/bybitCandles.ts
@@ -1,0 +1,92 @@
+/**
+ * Fetch historical OHLCV candles from Bybit public API (market/kline).
+ * Uses mainnet public endpoint — no auth required.
+ */
+
+const BYBIT_PUBLIC = "https://api.bybit.com";
+/** Maximum candles per request (Bybit cap) */
+const PAGE_LIMIT = 1000;
+
+export interface Candle {
+  openTime: number; // ms
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+interface BybitKlineResponse {
+  retCode: number;
+  retMsg: string;
+  result: {
+    list: string[][];
+  };
+}
+
+/**
+ * Fetch up to maxCandles candles for the given symbol/interval between fromMs and toMs.
+ * Bybit returns candles in descending order; we reverse to ascending.
+ *
+ * @param symbol  e.g. "BTCUSDT"
+ * @param interval  "1" | "5" | "15" | "60"
+ * @param fromMs  start timestamp in milliseconds (inclusive)
+ * @param toMs    end timestamp in milliseconds (inclusive)
+ * @param maxCandles  cap to avoid runaway fetches (default 2000)
+ */
+export async function fetchCandles(
+  symbol: string,
+  interval: string,
+  fromMs: number,
+  toMs: number,
+  maxCandles = 2000,
+): Promise<Candle[]> {
+  const all: Candle[] = [];
+  let cursor = toMs;
+
+  while (all.length < maxCandles) {
+    const url =
+      `${BYBIT_PUBLIC}/v5/market/kline` +
+      `?category=linear&symbol=${encodeURIComponent(symbol)}` +
+      `&interval=${interval}&start=${fromMs}&end=${cursor}&limit=${PAGE_LIMIT}`;
+
+    const res = await fetch(url, { headers: { "User-Agent": "botmarketplace-backtest/1" } });
+    if (!res.ok) {
+      throw new Error(`Bybit kline request failed: ${res.status} ${res.statusText}`);
+    }
+
+    const json = (await res.json()) as BybitKlineResponse;
+    if (json.retCode !== 0) {
+      throw new Error(`Bybit API error ${json.retCode}: ${json.retMsg}`);
+    }
+
+    const raw = json.result?.list ?? [];
+    if (raw.length === 0) break;
+
+    // Each item: [openTime, open, high, low, close, volume, turnover]
+    const page: Candle[] = raw.map((row) => ({
+      openTime: Number(row[0]),
+      open:     Number(row[1]),
+      high:     Number(row[2]),
+      low:      Number(row[3]),
+      close:    Number(row[4]),
+      volume:   Number(row[5]),
+    }));
+
+    // Bybit returns newest-first; collect them in reverse
+    for (let i = page.length - 1; i >= 0; i--) {
+      if (page[i].openTime >= fromMs && page[i].openTime <= toMs) {
+        all.push(page[i]);
+      }
+    }
+
+    const oldest = Math.min(...page.map((c) => c.openTime));
+    if (oldest <= fromMs || page.length < PAGE_LIMIT) break;
+    cursor = oldest - 1;
+  }
+
+  // Sort ascending by openTime (deduplicate just in case)
+  all.sort((a, b) => a.openTime - b.openTime);
+  const unique = all.filter((c, i) => i === 0 || c.openTime !== all[i - 1].openTime);
+  return unique.slice(0, maxCandles);
+}

--- a/apps/api/src/routes/lab.ts
+++ b/apps/api/src/routes/lab.ts
@@ -1,0 +1,203 @@
+import type { FastifyInstance } from "fastify";
+import { prisma } from "../lib/prisma.js";
+import { problem } from "../lib/problem.js";
+import { resolveWorkspace } from "../lib/workspace.js";
+import { fetchCandles } from "../lib/bybitCandles.js";
+import { runBacktest } from "../lib/backtest.js";
+
+// Valid Bybit kline intervals for backtest (MVP subset)
+const VALID_INTERVALS = ["1", "5", "15", "60"] as const;
+type Interval = typeof VALID_INTERVALS[number];
+
+// Max candles to load per backtest (limits execution time)
+const MAX_CANDLES = 2000;
+
+// ---------------------------------------------------------------------------
+// Routes
+// ---------------------------------------------------------------------------
+
+interface StartBacktestBody {
+  strategyId: string;
+  symbol?: string;
+  interval?: Interval;
+  fromTs: string; // ISO date string
+  toTs: string;   // ISO date string
+}
+
+export async function labRoutes(app: FastifyInstance) {
+  // ── POST /lab/backtest ── trigger a new backtest ──────────────────────────
+  app.post<{ Body: StartBacktestBody }>("/lab/backtest", async (request, reply) => {
+    const workspace = await resolveWorkspace(request, reply);
+    if (!workspace) return;
+
+    const { strategyId, symbol: bodySymbol, interval: bodyInterval, fromTs, toTs } =
+      request.body ?? {};
+
+    // Validate required fields
+    const errors: Array<{ field: string; message: string }> = [];
+    if (!strategyId) errors.push({ field: "strategyId", message: "strategyId is required" });
+    if (!fromTs) errors.push({ field: "fromTs", message: "fromTs is required (ISO date)" });
+    if (!toTs) errors.push({ field: "toTs", message: "toTs is required (ISO date)" });
+    if (bodyInterval && !VALID_INTERVALS.includes(bodyInterval)) {
+      errors.push({ field: "interval", message: `interval must be one of: ${VALID_INTERVALS.join(", ")}` });
+    }
+    if (errors.length > 0) {
+      return problem(reply, 400, "Validation Error", "Invalid backtest request", { errors });
+    }
+
+    const fromDate = new Date(fromTs);
+    const toDate = new Date(toTs);
+    if (isNaN(fromDate.getTime()) || isNaN(toDate.getTime())) {
+      return problem(reply, 400, "Validation Error", "fromTs and toTs must be valid ISO dates");
+    }
+    if (fromDate >= toDate) {
+      return problem(reply, 400, "Validation Error", "fromTs must be before toTs");
+    }
+
+    // Resolve strategy (must belong to workspace)
+    const strategy = await prisma.strategy.findUnique({ where: { id: strategyId } });
+    if (!strategy || strategy.workspaceId !== workspace.id) {
+      return problem(reply, 404, "Not Found", "Strategy not found");
+    }
+
+    const symbol = bodySymbol ?? strategy.symbol;
+    const interval = bodyInterval ?? intervalFromTimeframe(strategy.timeframe);
+
+    // Create PENDING record
+    const bt = await prisma.backtestResult.create({
+      data: {
+        workspaceId: workspace.id,
+        strategyId: strategy.id,
+        symbol,
+        interval,
+        fromTs: fromDate,
+        toTs: toDate,
+        status: "PENDING",
+      },
+    });
+
+    // Run async (fire-and-forget) — update record when done
+    runBacktestAsync(bt.id, symbol, interval, fromDate, toDate).catch(() => {
+      // errors are already handled inside runBacktestAsync
+    });
+
+    return reply.status(202).send(bt);
+  });
+
+  // ── GET /lab/backtest/:id ── get result ────────────────────────────────────
+  app.get<{ Params: { id: string } }>("/lab/backtest/:id", async (request, reply) => {
+    const workspace = await resolveWorkspace(request, reply);
+    if (!workspace) return;
+
+    const bt = await prisma.backtestResult.findUnique({ where: { id: request.params.id } });
+    if (!bt || bt.workspaceId !== workspace.id) {
+      return problem(reply, 404, "Not Found", "Backtest not found");
+    }
+    return reply.send(bt);
+  });
+
+  // ── GET /lab/backtests ── list for workspace ───────────────────────────────
+  app.get("/lab/backtests", async (request, reply) => {
+    const workspace = await resolveWorkspace(request, reply);
+    if (!workspace) return;
+
+    const list = await prisma.backtestResult.findMany({
+      where: { workspaceId: workspace.id },
+      orderBy: { createdAt: "desc" },
+      take: 50,
+      select: {
+        id: true,
+        strategyId: true,
+        symbol: true,
+        interval: true,
+        fromTs: true,
+        toTs: true,
+        status: true,
+        reportJson: true,
+        errorMessage: true,
+        createdAt: true,
+      },
+    });
+    return reply.send(list);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Async backtest runner
+// ---------------------------------------------------------------------------
+
+async function runBacktestAsync(
+  btId: string,
+  symbol: string,
+  interval: string,
+  fromDate: Date,
+  toDate: Date,
+): Promise<void> {
+  try {
+    await prisma.backtestResult.update({
+      where: { id: btId },
+      data: { status: "RUNNING" },
+    });
+
+    // Fetch strategy to get riskPct
+    const bt = await prisma.backtestResult.findUnique({ where: { id: btId } });
+    const strategy = bt
+      ? await prisma.strategy.findUnique({
+          where: { id: bt.strategyId },
+          include: { versions: { orderBy: { version: "desc" }, take: 1 } },
+        })
+      : null;
+
+    const riskPct = extractRiskPct(strategy?.versions[0]?.dslJson);
+
+    const candles = await fetchCandles(
+      symbol,
+      interval,
+      fromDate.getTime(),
+      toDate.getTime(),
+      MAX_CANDLES,
+    );
+
+    const report = runBacktest(candles, riskPct);
+
+    await prisma.backtestResult.update({
+      where: { id: btId },
+      data: {
+        status: "DONE",
+        reportJson: report as unknown as object,
+      },
+    });
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    await prisma.backtestResult.update({
+      where: { id: btId },
+      data: { status: "FAILED", errorMessage: msg },
+    }).catch(() => undefined);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Extract riskPerTradePct from DSL JSON, defaulting to 1.0 */
+function extractRiskPct(dslJson: unknown): number {
+  if (!dslJson || typeof dslJson !== "object") return 1.0;
+  const dsl = dslJson as Record<string, unknown>;
+  const risk = dsl["risk"];
+  if (!risk || typeof risk !== "object") return 1.0;
+  const r = risk as Record<string, unknown>;
+  const pct = Number(r["riskPerTradePct"]);
+  return Number.isFinite(pct) && pct > 0 ? pct : 1.0;
+}
+
+/** Map DB Timeframe enum → Bybit interval string */
+function intervalFromTimeframe(tf: string): string {
+  switch (tf) {
+    case "M1":  return "1";
+    case "M5":  return "5";
+    case "M15": return "15";
+    case "H1":  return "60";
+    default:    return "15";
+  }
+}

--- a/apps/web/src/app/lab/page.tsx
+++ b/apps/web/src/app/lab/page.tsx
@@ -1,10 +1,408 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import { getWorkspaceId, apiFetch } from "../factory/api";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface BacktestReport {
+  trades: number;
+  wins: number;
+  winrate: number;
+  totalPnlPct: number;
+  maxDrawdownPct: number;
+  candles: number;
+}
+
+interface BacktestItem {
+  id: string;
+  strategyId: string;
+  symbol: string;
+  interval: string;
+  fromTs: string;
+  toTs: string;
+  status: "PENDING" | "RUNNING" | "DONE" | "FAILED";
+  reportJson: BacktestReport | null;
+  errorMessage: string | null;
+  createdAt: string;
+}
+
+const INTERVALS = [
+  { value: "1",  label: "1m" },
+  { value: "5",  label: "5m" },
+  { value: "15", label: "15m" },
+  { value: "60", label: "1h" },
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function pct(n: number) {
+  return `${n >= 0 ? "+" : ""}${n.toFixed(2)}%`;
+}
+
+function fmtRate(n: number) {
+  return (n * 100).toFixed(1) + "%";
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
 export default function LabPage() {
+  const [wsId, setWsId] = useState("");
+  const [strategyId, setStrategyId] = useState("");
+  const [symbol, setSymbol] = useState("BTCUSDT");
+  const [interval, setInterval] = useState("15");
+  const [fromDate, setFromDate] = useState(() => {
+    const d = new Date();
+    d.setMonth(d.getMonth() - 1);
+    return d.toISOString().slice(0, 10);
+  });
+  const [toDate, setToDate] = useState(() => new Date().toISOString().slice(0, 10));
+
+  const [running, setRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [activeBtId, setActiveBtId] = useState<string | null>(null);
+  const [activeResult, setActiveResult] = useState<BacktestItem | null>(null);
+  const [history, setHistory] = useState<BacktestItem[]>([]);
+  const [historyLoading, setHistoryLoading] = useState(false);
+
+  useEffect(() => {
+    const stored = getWorkspaceId();
+    if (stored) setWsId(stored);
+  }, []);
+
+  const loadHistory = useCallback(async () => {
+    if (!getWorkspaceId()) return;
+    setHistoryLoading(true);
+    const res = await apiFetch<BacktestItem[]>("/lab/backtests");
+    setHistoryLoading(false);
+    if (res.ok) setHistory(res.data);
+  }, []);
+
+  useEffect(() => { loadHistory(); }, [loadHistory]);
+
+  useEffect(() => {
+    if (!activeBtId) return;
+    if (activeResult?.status === "DONE" || activeResult?.status === "FAILED") return;
+    const timer = setInterval(async () => {
+      const res = await apiFetch<BacktestItem>(`/lab/backtest/${activeBtId}`);
+      if (res.ok) {
+        setActiveResult(res.data);
+        if (res.data.status === "DONE" || res.data.status === "FAILED") {
+          setRunning(false);
+          loadHistory();
+        }
+      }
+    }, 2000);
+    return () => clearInterval(timer);
+  }, [activeBtId, activeResult?.status, loadHistory]);
+
+  async function startBacktest() {
+    setError(null);
+    if (!wsId.trim()) { setError("Set Workspace ID in Factory first"); return; }
+    if (!strategyId.trim()) { setError("Strategy ID is required"); return; }
+    setRunning(true);
+    setActiveResult(null);
+    setActiveBtId(null);
+
+    const res = await apiFetch<BacktestItem>("/lab/backtest", {
+      method: "POST",
+      body: JSON.stringify({
+        strategyId: strategyId.trim(),
+        symbol: symbol.trim() || undefined,
+        interval,
+        fromTs: new Date(fromDate).toISOString(),
+        toTs:   new Date(toDate).toISOString(),
+      }),
+    });
+
+    if (!res.ok) {
+      setRunning(false);
+      setError(`${res.problem.title}: ${res.problem.detail}`);
+      return;
+    }
+
+    setActiveBtId(res.data.id);
+    setActiveResult(res.data);
+  }
+
+  const report = activeResult?.reportJson ?? null;
+
   return (
-    <div style={{ padding: "48px 24px", textAlign: "center" }}>
-      <h1 style={{ fontSize: "28px", marginBottom: "16px" }}>Research Lab</h1>
-      <p style={{ color: "var(--text-secondary)" }}>
-        Strategy DSL editor, AI chat and backtesting — coming in Stage 5.
+    <div style={{ padding: "32px 24px", maxWidth: 760, margin: "0 auto" }}>
+      <h1 style={{ fontSize: 26, marginBottom: 4 }}>Research Lab</h1>
+      <p style={{ color: "var(--text-secondary)", marginBottom: 28, fontSize: 14 }}>
+        Historical backtest · price-breakout strategy (lookback 20) · 2:1 R/R
       </p>
+
+      {/* ── Form ── */}
+      <section style={sectionStyle}>
+        <h2 style={{ fontSize: 16, marginBottom: 16 }}>Run Backtest</h2>
+
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+          <label style={labelStyle}>
+            Workspace ID
+            <input
+              style={inputStyle}
+              value={wsId}
+              onChange={(e) => setWsId(e.target.value)}
+              placeholder="from Factory"
+            />
+          </label>
+          <label style={labelStyle}>
+            Strategy ID
+            <input
+              style={inputStyle}
+              value={strategyId}
+              onChange={(e) => setStrategyId(e.target.value)}
+              placeholder="uuid"
+            />
+          </label>
+          <label style={labelStyle}>
+            Symbol
+            <input
+              style={inputStyle}
+              value={symbol}
+              onChange={(e) => setSymbol(e.target.value)}
+              placeholder="BTCUSDT"
+            />
+          </label>
+          <label style={labelStyle}>
+            Interval
+            <select
+              style={inputStyle}
+              value={interval}
+              onChange={(e) => setInterval(e.target.value)}
+            >
+              {INTERVALS.map((iv) => (
+                <option key={iv.value} value={iv.value}>{iv.label}</option>
+              ))}
+            </select>
+          </label>
+          <label style={labelStyle}>
+            From
+            <input
+              style={inputStyle}
+              type="date"
+              value={fromDate}
+              onChange={(e) => setFromDate(e.target.value)}
+            />
+          </label>
+          <label style={labelStyle}>
+            To
+            <input
+              style={inputStyle}
+              type="date"
+              value={toDate}
+              onChange={(e) => setToDate(e.target.value)}
+            />
+          </label>
+        </div>
+
+        {error && (
+          <div style={{ color: "#f87171", fontSize: 13, marginTop: 12 }}>{error}</div>
+        )}
+
+        <button
+          style={{ ...btnStyle, marginTop: 16, opacity: running ? 0.6 : 1 }}
+          disabled={running}
+          onClick={startBacktest}
+        >
+          {running ? "Running…" : "Run Backtest"}
+        </button>
+      </section>
+
+      {/* ── Active result ── */}
+      {activeResult && (
+        <section style={sectionStyle}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 16 }}>
+            <h2 style={{ fontSize: 16 }}>Result</h2>
+            <StatusBadge status={activeResult.status} />
+          </div>
+
+          {activeResult.status === "FAILED" && (
+            <div style={{ color: "#f87171", fontSize: 13 }}>
+              Error: {activeResult.errorMessage}
+            </div>
+          )}
+
+          {(activeResult.status === "PENDING" || activeResult.status === "RUNNING") && (
+            <div style={{ color: "var(--text-secondary)", fontSize: 13 }}>
+              Fetching candles and simulating… polling every 2 s
+            </div>
+          )}
+
+          {activeResult.status === "DONE" && report && (
+            <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 12 }}>
+              <MetricCard label="Trades" value={String(report.trades)} />
+              <MetricCard label="Wins" value={String(report.wins)} />
+              <MetricCard label="Winrate" value={fmtRate(report.winrate)} />
+              <MetricCard
+                label="Total PnL"
+                value={pct(report.totalPnlPct)}
+                positive={report.totalPnlPct >= 0}
+              />
+              <MetricCard
+                label="Max Drawdown"
+                value={`-${report.maxDrawdownPct.toFixed(2)}%`}
+                positive={false}
+              />
+              <MetricCard label="Candles" value={String(report.candles)} />
+            </div>
+          )}
+
+          <div style={{ fontSize: 11, color: "var(--text-secondary)", marginTop: 12 }}>
+            {activeResult.symbol} · {activeResult.interval}m ·{" "}
+            {new Date(activeResult.fromTs).toLocaleDateString()} –{" "}
+            {new Date(activeResult.toTs).toLocaleDateString()}
+          </div>
+        </section>
+      )}
+
+      {/* ── Demo-forward note ── */}
+      <section style={sectionStyle}>
+        <h2 style={{ fontSize: 16, marginBottom: 8 }}>Demo-Forward Run</h2>
+        <p style={{ fontSize: 13, color: "var(--text-secondary)", margin: 0 }}>
+          To run your strategy live on Bybit Demo and record all events (signal, order_sent,
+          order_update, position_update) in the journal, go to{" "}
+          <Link href="/factory" style={{ color: "#60a5fa" }}>Factory</Link>
+          , create a Bot from a strategy, and start a Run.
+          The event log is available on the Bot detail page.
+        </p>
+      </section>
+
+      {/* ── History ── */}
+      <section style={sectionStyle}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 12 }}>
+          <h2 style={{ fontSize: 16 }}>History</h2>
+          <button style={{ ...btnStyle, fontSize: 12, padding: "4px 12px" }} onClick={loadHistory}>
+            Refresh
+          </button>
+        </div>
+
+        {historyLoading && (
+          <div style={{ fontSize: 13, color: "var(--text-secondary)" }}>Loading…</div>
+        )}
+
+        {!historyLoading && history.length === 0 && (
+          <div style={{ fontSize: 13, color: "var(--text-secondary)" }}>No backtests yet.</div>
+        )}
+
+        {history.length > 0 && (
+          <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
+            <thead>
+              <tr style={{ color: "var(--text-secondary)", textAlign: "left" }}>
+                <th style={thStyle}>Symbol</th>
+                <th style={thStyle}>Int</th>
+                <th style={thStyle}>Period</th>
+                <th style={thStyle}>Status</th>
+                <th style={thStyle}>Trades</th>
+                <th style={thStyle}>Winrate</th>
+                <th style={thStyle}>PnL</th>
+              </tr>
+            </thead>
+            <tbody>
+              {history.map((bt) => (
+                <tr
+                  key={bt.id}
+                  style={{ cursor: "pointer", borderTop: "1px solid rgba(255,255,255,0.06)" }}
+                  onClick={() => { setActiveResult(bt); setActiveBtId(bt.id); }}
+                >
+                  <td style={tdStyle}>{bt.symbol}</td>
+                  <td style={tdStyle}>{bt.interval}m</td>
+                  <td style={tdStyle}>
+                    {new Date(bt.fromTs).toLocaleDateString()} –{" "}
+                    {new Date(bt.toTs).toLocaleDateString()}
+                  </td>
+                  <td style={tdStyle}><StatusBadge status={bt.status} /></td>
+                  <td style={tdStyle}>{bt.reportJson?.trades ?? "—"}</td>
+                  <td style={tdStyle}>
+                    {bt.reportJson ? fmtRate(bt.reportJson.winrate) : "—"}
+                  </td>
+                  <td style={tdStyle}>
+                    {bt.reportJson ? (
+                      <span style={{ color: bt.reportJson.totalPnlPct >= 0 ? "#4ade80" : "#f87171" }}>
+                        {pct(bt.reportJson.totalPnlPct)}
+                      </span>
+                    ) : "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
     </div>
   );
 }
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function StatusBadge({ status }: { status: string }) {
+  const colors: Record<string, string> = {
+    PENDING: "#fbbf24",
+    RUNNING: "#60a5fa",
+    DONE:    "#4ade80",
+    FAILED:  "#f87171",
+  };
+  const color = colors[status] ?? "#888";
+  return (
+    <span style={{
+      fontSize: 11, fontWeight: 600, padding: "2px 8px", borderRadius: 4,
+      background: color + "22", color,
+    }}>
+      {status}
+    </span>
+  );
+}
+
+function MetricCard({ label, value, positive }: { label: string; value: string; positive?: boolean }) {
+  const color = positive === undefined ? undefined : positive ? "#4ade80" : "#f87171";
+  return (
+    <div style={{ background: "rgba(255,255,255,0.04)", borderRadius: 6, padding: "12px 16px" }}>
+      <div style={{ fontSize: 11, color: "var(--text-secondary)", marginBottom: 4 }}>{label}</div>
+      <div style={{ fontSize: 20, fontWeight: 700, color }}>{value}</div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const sectionStyle: { [key: string]: string | number | undefined } = {
+  background: "var(--surface, #1a1a2e)",
+  borderRadius: 8,
+  padding: 20,
+  marginBottom: 20,
+};
+
+const labelStyle: { [key: string]: string | number | undefined } = {
+  display: "flex", flexDirection: "column", gap: 6,
+  fontSize: 13, color: "var(--text-secondary)",
+};
+
+const inputStyle: { [key: string]: string | number | undefined } = {
+  background: "rgba(255,255,255,0.07)",
+  border: "1px solid rgba(255,255,255,0.12)",
+  borderRadius: 6, padding: "8px 10px",
+  color: "inherit", fontSize: 13,
+  outline: "none", width: "100%", boxSizing: "border-box",
+};
+
+const btnStyle: { [key: string]: string | number | undefined } = {
+  background: "#3b82f6", color: "#fff", border: "none",
+  borderRadius: 6, padding: "10px 20px",
+  fontSize: 14, fontWeight: 600, cursor: "pointer",
+};
+
+const thStyle: { [key: string]: string | number | undefined } = { padding: "6px 8px", fontWeight: 500, fontSize: 12 };
+const tdStyle: { [key: string]: string | number | undefined } = { padding: "8px 8px" };

--- a/docs/steps/05-stage-5-research-lab.md
+++ b/docs/steps/05-stage-5-research-lab.md
@@ -1,0 +1,72 @@
+# Stage 5 — Research Lab Minimum
+
+## Цель
+
+Реализовать минимальный backtesting модуль:
+- исторический replay по свечам Bybit
+- детерминированный отчёт (trades, winrate, PnL, max drawdown)
+- demo-forward прогон (через существующий bot runtime)
+
+## Acceptance criteria (из docs/15-acceptance-criteria.md)
+
+- [ ] Исторический replay по свечам генерирует отчёт
+- [ ] Отчёт содержит: количество сделок, winrate, PnL, max drawdown
+- [ ] Отчёт детерминированный (одинаковые данные → одинаковый результат)
+- [ ] Demo-forward прогон стратегии записывает события в журнал
+
+## Архитектура
+
+### Backend
+
+1. **DB: `BacktestResult`** — хранит параметры и результаты бэктеста
+2. **`lib/bybitCandles.ts`** — загрузка исторических свечей из Bybit public API
+3. **`lib/backtest.ts`** — движок симуляции (детерминированный, без IO)
+4. **`routes/lab.ts`** — эндпоинты:
+   - `POST /api/v1/lab/backtest` — запуск бэктеста
+   - `GET  /api/v1/lab/backtest/:id` — статус / результат
+   - `GET  /api/v1/lab/backtests` — список для workspace
+
+### Алгоритм симуляции (MVP, детерминированный)
+
+1. Загружаем OHLCV свечи для symbol/interval за указанный период
+2. Для каждой свечи вычисляем rolling high (lookback N candles)
+3. Сигнал BUY: close[i] > max(close[i-N..i-1])  (price breakout)
+4. Если нет открытой позиции → открываем LONG по close[i]
+   - SL = entry * (1 − riskPct/100)
+   - TP = entry * (1 + 2 × riskPct/100)  (2:1 R/R)
+5. На каждой следующей свече:
+   - low[j] ≤ SL → закрыть (LOSS)
+   - high[j] ≥ TP → закрыть (WIN)
+6. Конец периода → закрыть позицию по close (NEUTRAL)
+7. Метрики: trades, wins, winrate, totalPnlPct, maxDrawdownPct
+
+Параметры берутся из Strategy DSL (`risk.riskPerTradePct`, дефолт 1.0%).
+Lookback N = 20 (фиксировано, MVP).
+
+### Frontend
+
+Lab page (`apps/web/src/app/lab/page.tsx`):
+- Форма: workspace, strategy ID, symbol, interval, from/to дата
+- Кнопка "Run Backtest"
+- Опрос статуса каждые 2с
+- Отображение результатов в таблице
+
+## Файлы, затронутые изменениями
+
+```
+apps/api/prisma/schema.prisma
+apps/api/prisma/migrations/20260220a_add_backtest_result/migration.sql
+apps/api/src/lib/bybitCandles.ts          (новый)
+apps/api/src/lib/backtest.ts              (новый)
+apps/api/src/routes/lab.ts               (новый)
+apps/api/src/app.ts
+apps/web/src/app/lab/page.tsx
+docs/steps/05-stage-5-research-lab.md    (этот файл)
+```
+
+## Demo-forward
+
+Demo-forward реализован через существующий BotRun + BotEvent pipeline:
+- Пользователь создаёт Bot из стратегии и запускает Run
+- BotEvent лог пишет события (signal, order_sent, order_update, ...)
+- Lab страница ссылается на Factory для demo-forward запуска


### PR DESCRIPTION
- Add BacktestResult model + migration (PENDING/RUNNING/DONE/FAILED)
- lib/bybitCandles.ts: fetch historical OHLCV from Bybit public API
- lib/backtest.ts: deterministic price-breakout simulator (lookback 20, 2:1 R/R) reports: trades, wins, winrate, totalPnlPct, maxDrawdownPct
- routes/lab.ts: POST /lab/backtest, GET /lab/backtest/:id, GET /lab/backtests async fire-and-forget execution, polls updated status to DB
- Register labRoutes in app.ts
- Lab page: backtest form (strategy, symbol, interval, date range), auto-polling result display, metrics grid, history table, demo-forward note

https://claude.ai/code/session_01F1Ph6zmDTqcsTRbunpoJZY