### PR TITLE
feat: Stage 6 — Hardening & Release Readiness

### DIFF
--- a/apps/api/package-lock.json
+++ b/apps/api/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@fastify/cors": "^11.0.0",
         "@fastify/jwt": "^10.0.0",
+        "@fastify/rate-limit": "^10.3.0",
         "@prisma/client": "^6.5.0",
         "bcryptjs": "^3.0.3",
         "fastify": "^5.3.0",
@@ -617,6 +618,27 @@
       "dependencies": {
         "@fastify/forwarded": "^3.0.0",
         "ipaddr.js": "^2.1.0"
+      }
+    },
+    "node_modules/@fastify/rate-limit": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@fastify/rate-limit/-/rate-limit-10.3.0.tgz",
+      "integrity": "sha512-eIGkG9XKQs0nyynatApA3EVrojHOuq4l6fhB4eeCk4PIOeadvOJz9/4w3vGI44Go17uaXOWEcPkaD8kuKm7g6Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/ms": "^2.0.2",
+        "fastify-plugin": "^5.0.0",
+        "toad-cache": "^3.7.0"
       }
     },
     "node_modules/@lukeed/ms": {

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@fastify/cors": "^11.0.0",
     "@fastify/jwt": "^10.0.0",
+    "@fastify/rate-limit": "^10.3.0",
     "@prisma/client": "^6.5.0",
     "bcryptjs": "^3.0.3",
     "fastify": "^5.3.0",

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -19,7 +19,9 @@ function authProblem(reply: FastifyReply, status: number, detail: string) {
 
 export async function authRoutes(app: FastifyInstance) {
   // ── POST /auth/register ────────────────────────────────────────────────────
-  app.post<{ Body: RegisterBody }>("/auth/register", async (request, reply) => {
+  app.post<{ Body: RegisterBody }>("/auth/register", {
+    config: { rateLimit: { max: 5, timeWindow: "15 minutes" } },
+  }, async (request, reply) => {
     const { email, password } = request.body ?? {};
 
     if (!email || !password) {

--- a/apps/api/src/routes/lab.ts
+++ b/apps/api/src/routes/lab.ts
@@ -26,7 +26,9 @@ interface StartBacktestBody {
 
 export async function labRoutes(app: FastifyInstance) {
   // ── POST /lab/backtest ── trigger a new backtest ──────────────────────────
-  app.post<{ Body: StartBacktestBody }>("/lab/backtest", async (request, reply) => {
+  app.post<{ Body: StartBacktestBody }>("/lab/backtest", {
+    config: { rateLimit: { max: 5, timeWindow: "1 minute" } },
+  }, async (request, reply) => {
     const workspace = await resolveWorkspace(request, reply);
     if (!workspace) return;
 

--- a/deploy/backup.sh
+++ b/deploy/backup.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# backup.sh — Daily PostgreSQL backup
+# Managed by: deploy/botmarket-backup.timer (systemd)
+# Manual run: bash deploy/backup.sh
+
+set -euo pipefail
+
+BACKUP_DIR="/var/backups/botmarketplace"
+KEEP_DAYS=7
+ENV_FILE="/opt/-botmarketplace-site/.env"
+
+# Load env vars to get DATABASE_URL
+if [[ -f "$ENV_FILE" ]]; then
+  set -a; source "$ENV_FILE"; set +a
+fi
+
+if [[ -z "${DATABASE_URL:-}" ]]; then
+  echo "[backup] ERROR: DATABASE_URL not set" >&2
+  exit 1
+fi
+
+# Parse connection string: postgresql://user:pass@host:port/dbname
+DB_USER=$(echo "$DATABASE_URL" | sed -E 's|.*://([^:]+):.*|\1|')
+DB_PASS=$(echo "$DATABASE_URL" | sed -E 's|.*://[^:]+:([^@]+)@.*|\1|')
+DB_HOST=$(echo "$DATABASE_URL" | sed -E 's|.*@([^:/]+)[:/].*|\1|')
+DB_PORT=$(echo "$DATABASE_URL" | sed -E 's|.*:([0-9]+)/.*|\1|')
+DB_NAME=$(echo "$DATABASE_URL" | sed -E 's|.*/([^?]+).*|\1|')
+
+mkdir -p "$BACKUP_DIR"
+
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+FILENAME="$BACKUP_DIR/botmarket_${TIMESTAMP}.sql.gz"
+
+echo "[backup] Starting backup → $FILENAME"
+
+PGPASSWORD="$DB_PASS" pg_dump \
+  -h "$DB_HOST" \
+  -p "$DB_PORT" \
+  -U "$DB_USER" \
+  "$DB_NAME" | gzip > "$FILENAME"
+
+echo "[backup] Done: $(du -sh "$FILENAME" | cut -f1)"
+
+# Remove backups older than KEEP_DAYS
+find "$BACKUP_DIR" -name "botmarket_*.sql.gz" -mtime +"$KEEP_DAYS" -delete
+echo "[backup] Cleaned backups older than ${KEEP_DAYS} days"
+echo "[backup] Stored backups: $(ls -1 "$BACKUP_DIR"/botmarket_*.sql.gz 2>/dev/null | wc -l)"

--- a/deploy/botmarket-backup.service
+++ b/deploy/botmarket-backup.service
@@ -1,0 +1,15 @@
+# systemd one-shot service for daily DB backup
+# Triggered by: botmarket-backup.timer
+# Install: cp deploy/botmarket-backup.service /etc/systemd/system/
+
+[Unit]
+Description=BotMarketplace Daily DB Backup
+After=network-online.target postgresql.service
+
+[Service]
+Type=oneshot
+User=root
+ExecStart=/bin/bash /opt/-botmarketplace-site/deploy/backup.sh
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=botmarket-backup

--- a/deploy/botmarket-backup.timer
+++ b/deploy/botmarket-backup.timer
@@ -1,0 +1,18 @@
+# systemd timer — triggers daily DB backup at 03:00
+# Install:
+#   cp deploy/botmarket-backup.timer /etc/systemd/system/
+#   cp deploy/botmarket-backup.service /etc/systemd/system/
+#   systemctl daemon-reload
+#   systemctl enable --now botmarket-backup.timer
+# Status: systemctl status botmarket-backup.timer
+# Last run: journalctl -u botmarket-backup -n 20
+
+[Unit]
+Description=BotMarketplace Daily DB Backup Timer
+
+[Timer]
+OnCalendar=03:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -29,9 +29,13 @@ echo "[✓] .env found"
 echo "[1/4] Installing systemd services..."
 cp "$APP_DIR/deploy/botmarket-api.service" /etc/systemd/system/botmarket-api.service
 cp "$APP_DIR/deploy/botmarket-web.service" /etc/systemd/system/botmarket-web.service
+cp "$APP_DIR/deploy/botmarket-backup.service" /etc/systemd/system/botmarket-backup.service
+cp "$APP_DIR/deploy/botmarket-backup.timer"   /etc/systemd/system/botmarket-backup.timer
 systemctl daemon-reload
 systemctl enable botmarket-api botmarket-web
-echo "      botmarket-api and botmarket-web enabled"
+systemctl enable --now botmarket-backup.timer
+echo "      botmarket-api, botmarket-web enabled"
+echo "      botmarket-backup.timer enabled (daily 03:00)"
 
 # 3. Install nginx config
 echo "[2/4] Installing nginx config..."
@@ -68,6 +72,7 @@ echo ""
 echo "Status:"
 systemctl is-active botmarket-api && echo "  ✓ botmarket-api" || echo "  ✗ botmarket-api FAILED — check: journalctl -u botmarket-api -n 50"
 systemctl is-active botmarket-web  && echo "  ✓ botmarket-web"  || echo "  ✗ botmarket-web FAILED  — check: journalctl -u botmarket-web -n 50"
+systemctl is-active botmarket-backup.timer && echo "  ✓ botmarket-backup.timer" || echo "  ✗ botmarket-backup.timer NOT active"
 
 echo ""
 echo "Setup complete!"

--- a/deploy/smoke-test.sh
+++ b/deploy/smoke-test.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# smoke-test.sh — MVP release smoke tests
+# Usage: bash deploy/smoke-test.sh [--base-url https://botmarketplace.store]
+# Exit code: 0 = all passed, 1 = failures found
+
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-https://botmarketplace.store}"
+TEST_EMAIL="smoke_$(date +%s)@test.com"
+TEST_PASS="Smoke1234!"
+PASS=0
+FAIL=0
+
+# ─── helpers ────────────────────────────────────────────────────────────────
+
+green()  { printf "\033[32m✓ %s\033[0m\n" "$1"; }
+red()    { printf "\033[31m✗ %s\033[0m\n" "$1"; }
+header() { printf "\n\033[1m%s\033[0m\n" "$1"; }
+
+check() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    green "$label"
+    ((PASS++))
+  else
+    red "$label (expected: $expected, got: $actual)"
+    ((FAIL++))
+  fi
+}
+
+check_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if echo "$haystack" | grep -q "$needle"; then
+    green "$label"
+    ((PASS++))
+  else
+    red "$label (expected to contain: $needle)"
+    ((FAIL++))
+  fi
+}
+
+# Parse args
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --base-url) BASE_URL="$2"; shift 2 ;;
+    *) echo "Unknown arg: $1"; exit 1 ;;
+  esac
+done
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  BotMarketplace Smoke Tests"
+echo "  Target: $BASE_URL"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# ─── 1. Infrastructure ───────────────────────────────────────────────────────
+header "1. Infrastructure"
+
+HEALTH=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/api/v1/healthz")
+check "GET /api/v1/healthz → 200" "200" "$HEALTH"
+
+READYZ=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/api/v1/readyz")
+check "GET /api/v1/readyz → 200" "200" "$READYZ"
+
+# ─── 2. UI pages ─────────────────────────────────────────────────────────────
+header "2. UI pages"
+
+for page in /login /register /lab /factory; do
+  CODE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL$page")
+  check "GET $page → 200" "200" "$CODE"
+done
+
+# ─── 3. Auth — register + login ──────────────────────────────────────────────
+header "3. Auth"
+
+REG=$(curl -s -X POST "$BASE_URL/api/v1/auth/register" \
+  -H "Content-Type: application/json" \
+  -d "{\"email\":\"$TEST_EMAIL\",\"password\":\"$TEST_PASS\"}")
+
+TOKEN=$(echo "$REG" | grep -o '"accessToken":"[^"]*"' | cut -d'"' -f4)
+WS_ID=$(echo "$REG" | grep -o '"workspaceId":"[^"]*"' | cut -d'"' -f4)
+
+if [[ -n "$TOKEN" ]]; then
+  green "POST /auth/register → accessToken received"
+  ((PASS++))
+else
+  red "POST /auth/register → no accessToken (response: $REG)"
+  ((FAIL++))
+fi
+
+if [[ -n "$WS_ID" ]]; then
+  green "POST /auth/register → workspaceId received"
+  ((PASS++))
+else
+  red "POST /auth/register → no workspaceId"
+  ((FAIL++))
+fi
+
+LOGIN=$(curl -s -X POST "$BASE_URL/api/v1/auth/login" \
+  -H "Content-Type: application/json" \
+  -d "{\"email\":\"$TEST_EMAIL\",\"password\":\"$TEST_PASS\"}")
+
+LOGIN_TOKEN=$(echo "$LOGIN" | grep -o '"accessToken":"[^"]*"' | cut -d'"' -f4)
+if [[ -n "$LOGIN_TOKEN" ]]; then
+  green "POST /auth/login → accessToken received"
+  ((PASS++))
+else
+  red "POST /auth/login → failed (response: $LOGIN)"
+  ((FAIL++))
+fi
+
+# Wrong password → 401
+WRONG=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE_URL/api/v1/auth/login" \
+  -H "Content-Type: application/json" \
+  -d "{\"email\":\"$TEST_EMAIL\",\"password\":\"wrongpass\"}")
+check "POST /auth/login wrong password → 401" "401" "$WRONG"
+
+# ─── 4. Protected endpoints ───────────────────────────────────────────────────
+header "4. Auth protection"
+
+ME_AUTH=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/api/v1/auth/me" \
+  -H "Authorization: Bearer $TOKEN")
+check "GET /auth/me with token → 200" "200" "$ME_AUTH"
+
+ME_UNAUTH=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/api/v1/auth/me")
+check "GET /auth/me without token → 401" "401" "$ME_UNAUTH"
+
+# ─── 5. Rate limiting ─────────────────────────────────────────────────────────
+header "5. Rate limiting"
+
+# Hit /auth/register 7 times quickly — should get 429 on 6th+ attempt
+RL_HIT=0
+for i in $(seq 1 7); do
+  CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE_URL/api/v1/auth/register" \
+    -H "Content-Type: application/json" \
+    -d "{\"email\":\"rl_test_${i}_$(date +%s)@test.com\",\"password\":\"Test1234!\"}")
+  if [[ "$CODE" == "429" ]]; then
+    RL_HIT=1
+    break
+  fi
+done
+if [[ $RL_HIT -eq 1 ]]; then
+  green "Rate limiting on /auth/register → 429 triggered"
+  ((PASS++))
+else
+  red "Rate limiting on /auth/register → 429 NOT triggered after 7 requests"
+  ((FAIL++))
+fi
+
+# ─── 6. Stop-all endpoint ─────────────────────────────────────────────────────
+header "6. Stop-all endpoint"
+
+STOP_ALL=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE_URL/api/v1/runs/stop-all" \
+  -H "X-Workspace-Id: $WS_ID")
+# 200 = success (0 active runs is fine), 4xx = problem
+if [[ "$STOP_ALL" == "200" ]]; then
+  green "POST /runs/stop-all → 200"
+  ((PASS++))
+else
+  red "POST /runs/stop-all → $STOP_ALL (expected 200)"
+  ((FAIL++))
+fi
+
+# ─── 7. Bot worker ───────────────────────────────────────────────────────────
+header "7. Bot Worker"
+
+if journalctl -u botmarket-api -n 100 --no-pager 2>/dev/null | grep -q "botWorker.*started"; then
+  green "Bot worker started line found in API logs"
+  ((PASS++))
+else
+  red "Bot worker start line NOT found in API logs"
+  ((FAIL++))
+fi
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+TOTAL=$((PASS + FAIL))
+echo "  Results: $PASS/$TOTAL passed"
+if [[ $FAIL -eq 0 ]]; then
+  printf "  \033[32mALL TESTS PASSED ✓\033[0m\n"
+else
+  printf "  \033[31m$FAIL TEST(S) FAILED ✗\033[0m\n"
+fi
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+exit $FAIL

--- a/docs/steps/06-stage-6-hardening.md
+++ b/docs/steps/06-stage-6-hardening.md
@@ -1,0 +1,53 @@
+# Stage 6 — Hardening & Release Readiness
+
+## Цель
+
+Подготовить проект к MVP-релизу:
+- rate limiting на чувствительных эндпоинтах
+- max duration enforcement (TIMED_OUT) для зависших ботов
+- Stop All для экстренной остановки всех активных ботов
+- ежедневный бэкап PostgreSQL через systemd timer
+- smoke-test checklist для проверки деплоя
+
+## Acceptance Criteria
+
+- [ ] Rate limiting: POST /auth/register, POST /bots/:id/runs, POST /lab/backtest
+- [ ] Bot Run автоматически переводится в TIMED_OUT если работает дольше MAX_RUN_DURATION_MS
+- [ ] POST /api/v1/runs/stop-all останавливает все активные боты в workspace
+- [ ] Ежедневный бэкап БД настроен через systemd timer
+- [ ] smoke-test.sh успешно проходит все проверки на продакшне
+
+## Архитектура
+
+### Rate Limiting (`@fastify/rate-limit`)
+- Глобальный лимит: 200 req/min per IP
+- POST /auth/register: 5 req / 15 min per IP
+- POST /bots/:id/runs: 10 req / min per IP
+- POST /lab/backtest: 5 req / min per IP
+
+### Max Run Duration
+- `MAX_RUN_DURATION_MS` из env (дефолт: 4 часа = 14 400 000 мс)
+- В `botWorker.ts`: каждый цикл проверяет RUNNING runs с `startedAt < now - MAX_RUN_DURATION_MS`
+- Если превышено → `transition(runId, "TIMED_OUT", { errorCode: "MAX_DURATION_EXCEEDED" })`
+
+### Stop All
+- `POST /api/v1/runs/stop-all` — останавливает все активные (не-терминальные) runs в workspace
+- Возвращает: `{ stopped: string[], errors: string[] }`
+
+### DB Backup
+- `deploy/backup.sh` — pg_dump → сжатый .sql.gz с датой
+- `deploy/botmarket-backup.service` + `deploy/botmarket-backup.timer` — systemd timer (ежедневно в 03:00)
+- Хранит последние 7 бэкапов
+
+## Файлы
+
+```
+apps/api/src/app.ts                     (rate limiting)
+apps/api/src/lib/botWorker.ts           (max duration)
+apps/api/src/routes/runs.ts             (stop-all endpoint)
+deploy/backup.sh                        (новый)
+deploy/botmarket-backup.service         (новый)
+deploy/botmarket-backup.timer           (новый)
+deploy/smoke-test.sh                    (новый)
+docs/steps/06-stage-6-hardening.md     (этот файл)
+```


### PR DESCRIPTION
Rate limiting (@fastify/rate-limit):
- Global baseline: 200 req/min per IP
- POST /auth/register: 5 req / 15 min (brute-force protection)
- POST /bots/:id/runs: 10 req / min
- POST /lab/backtest: 5 req / min

Max run duration enforcement (botWorker):
- Reads MAX_RUN_DURATION_MS from env (default 4h)
- Every poll cycle: marks RUNNING runs exceeding limit as TIMED_OUT
- errorCode: MAX_DURATION_EXCEEDED

Stop All endpoint:
- POST /api/v1/runs/stop-all
- Stops all non-terminal runs in workspace atomically
- Returns { stopped[], errors[], total }

Daily DB backup (systemd):
- deploy/backup.sh — pg_dump → gzip, keeps 7 days
- deploy/botmarket-backup.service + .timer — fires at 03:00 daily
- setup.sh updated to install and enable backup timer

Smoke test script:
- deploy/smoke-test.sh — 7 test groups, colored output
- Tests: healthz, UI pages, register/login, auth protection, rate limiting (429), stop-all, bot worker in logs
- Exit code 1 on any failure

https://claude.ai/code/session_01F1Ph6zmDTqcsTRbunpoJZY