### PR TITLE
feat(stage-8): Exchange Connections — CRUD + secret encryption + worker auth fix

### DIFF
--- a/apps/api/prisma/migrations/20260221a_add_exchange_connections/migration.sql
+++ b/apps/api/prisma/migrations/20260221a_add_exchange_connections/migration.sql
@@ -1,0 +1,27 @@
+-- CreateEnum
+CREATE TYPE "ExchangeConnectionStatus" AS ENUM ('UNKNOWN', 'CONNECTED', 'FAILED');
+
+-- CreateTable
+CREATE TABLE "ExchangeConnection" (
+    "id"              TEXT NOT NULL,
+    "workspaceId"     TEXT NOT NULL,
+    "exchange"        TEXT NOT NULL,
+    "name"            TEXT NOT NULL,
+    "apiKey"          TEXT NOT NULL,
+    "encryptedSecret" TEXT NOT NULL,
+    "status"          "ExchangeConnectionStatus" NOT NULL DEFAULT 'UNKNOWN',
+    "createdAt"       TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt"       TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ExchangeConnection_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ExchangeConnection_workspaceId_name_key" ON "ExchangeConnection"("workspaceId", "name");
+
+-- CreateIndex
+CREATE INDEX "ExchangeConnection_workspaceId_idx" ON "ExchangeConnection"("workspaceId");
+
+-- AddForeignKey
+ALTER TABLE "ExchangeConnection" ADD CONSTRAINT "ExchangeConnection_workspaceId_fkey"
+    FOREIGN KEY ("workspaceId") REFERENCES "Workspace"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -29,11 +29,12 @@ model Workspace {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  members    WorkspaceMember[]
-  strategies Strategy[]
-  bots       Bot[]
-  botRuns    BotRun[]
-  backtests  BacktestResult[]
+  members             WorkspaceMember[]
+  strategies          Strategy[]
+  bots                Bot[]
+  botRuns             BotRun[]
+  backtests           BacktestResult[]
+  exchangeConnections ExchangeConnection[]
 }
 
 model WorkspaceMember {
@@ -231,6 +232,31 @@ model BotIntent {
   @@index([botRunId])
   @@index([orderLinkId])
   @@index([botRunId, state])
+}
+
+// ── Exchange Connections ─────────────────────────────────────────
+
+enum ExchangeConnectionStatus {
+  UNKNOWN
+  CONNECTED
+  FAILED
+}
+
+model ExchangeConnection {
+  id               String                    @id @default(uuid())
+  workspaceId      String
+  exchange         String
+  name             String
+  apiKey           String
+  encryptedSecret  String
+  status           ExchangeConnectionStatus  @default(UNKNOWN)
+  createdAt        DateTime                  @default(now())
+  updatedAt        DateTime                  @updatedAt
+
+  workspace Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+
+  @@unique([workspaceId, name])
+  @@index([workspaceId])
 }
 
 // ── Research Lab ─────────────────────────────────────────────────

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -11,6 +11,7 @@ import { runRoutes } from "./routes/runs.js";
 import { intentRoutes } from "./routes/intents.js";
 import { workspacesRoutes } from "./routes/workspaces.js";
 import { labRoutes } from "./routes/lab.js";
+import { exchangeRoutes } from "./routes/exchanges.js";
 
 /** Registers all domain routes. */
 async function registerRoutes(scope: import("fastify").FastifyInstance) {
@@ -23,6 +24,7 @@ async function registerRoutes(scope: import("fastify").FastifyInstance) {
   await scope.register(runRoutes);
   await scope.register(intentRoutes);
   await scope.register(labRoutes);
+  await scope.register(exchangeRoutes);
 }
 
 export async function buildApp() {

--- a/apps/api/src/lib/crypto.ts
+++ b/apps/api/src/lib/crypto.ts
@@ -1,0 +1,54 @@
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+import type { FastifyReply } from "fastify";
+import { problem } from "./problem.js";
+
+const ALGORITHM = "aes-256-gcm";
+const KEY_HEX_LENGTH = 64; // 32 bytes = 64 hex chars
+
+/**
+ * Get the encryption key from env.
+ * Returns null and sends a 500 Problem Details if key is missing or invalid.
+ */
+export function getEncryptionKey(reply: FastifyReply): Buffer | null {
+  const raw = process.env.SECRET_ENCRYPTION_KEY;
+  if (!raw) {
+    reply.log.error("SECRET_ENCRYPTION_KEY is not set — cannot proceed with secret encryption");
+    problem(reply, 500, "Server Configuration Error", "Secret encryption key is not configured. Set SECRET_ENCRYPTION_KEY env variable.");
+    return null;
+  }
+  if (raw.length !== KEY_HEX_LENGTH) {
+    reply.log.error({ keyLength: raw.length }, "SECRET_ENCRYPTION_KEY has wrong length — expected 64 hex chars (32 bytes)");
+    problem(reply, 500, "Server Configuration Error", "SECRET_ENCRYPTION_KEY must be a 64-character hex string (32 bytes).");
+    return null;
+  }
+  return Buffer.from(raw, "hex");
+}
+
+/**
+ * Encrypt a plaintext string with AES-256-GCM.
+ * Returns a base64-encoded payload: iv:authTag:ciphertext (colon-separated).
+ */
+export function encrypt(plaintext: string, key: Buffer): string {
+  const iv = randomBytes(12); // 96-bit IV recommended for GCM
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  // Format: base64(iv):base64(authTag):base64(ciphertext)
+  return [iv.toString("base64"), authTag.toString("base64"), encrypted.toString("base64")].join(":");
+}
+
+/**
+ * Decrypt a payload produced by encrypt().
+ * Throws on any tampering / wrong key.
+ */
+export function decrypt(payload: string, key: Buffer): string {
+  const parts = payload.split(":");
+  if (parts.length !== 3) throw new Error("Invalid encrypted payload format");
+  const [ivB64, authTagB64, ciphertextB64] = parts;
+  const iv = Buffer.from(ivB64, "base64");
+  const authTag = Buffer.from(authTagB64, "base64");
+  const ciphertext = Buffer.from(ciphertextB64, "base64");
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString("utf8");
+}

--- a/apps/api/src/routes/exchanges.ts
+++ b/apps/api/src/routes/exchanges.ts
@@ -1,0 +1,227 @@
+import type { FastifyInstance } from "fastify";
+import { prisma } from "../lib/prisma.js";
+import { problem } from "../lib/problem.js";
+import { resolveWorkspace } from "../lib/workspace.js";
+import { getEncryptionKey, encrypt, decrypt } from "../lib/crypto.js";
+
+// ---------------------------------------------------------------------------
+// Safe projection — never return encryptedSecret or apiKey in responses
+// ---------------------------------------------------------------------------
+
+function safeView(conn: {
+  id: string;
+  workspaceId: string;
+  exchange: string;
+  name: string;
+  status: string;
+  createdAt: Date;
+  updatedAt: Date;
+}) {
+  return {
+    id: conn.id,
+    workspaceId: conn.workspaceId,
+    exchange: conn.exchange,
+    name: conn.name,
+    status: conn.status,
+    createdAt: conn.createdAt,
+    updatedAt: conn.updatedAt,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Body shapes
+// ---------------------------------------------------------------------------
+
+interface CreateBody {
+  exchange: string;
+  name: string;
+  apiKey: string;
+  secret: string;
+}
+
+interface PatchBody {
+  name?: string;
+  apiKey?: string;
+  secret?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Routes
+// ---------------------------------------------------------------------------
+
+export async function exchangeRoutes(app: FastifyInstance) {
+  // POST /exchanges — create a connection
+  app.post<{ Body: CreateBody }>("/exchanges", { onRequest: [app.authenticate] }, async (request, reply) => {
+    const workspace = await resolveWorkspace(request, reply);
+    if (!workspace) return;
+
+    const key = getEncryptionKey(reply);
+    if (!key) return;
+
+    const { exchange, name, apiKey, secret } = request.body ?? {};
+
+    const errors: Array<{ field: string; message: string }> = [];
+    if (!exchange || typeof exchange !== "string") errors.push({ field: "exchange", message: "exchange is required" });
+    if (!name || typeof name !== "string") errors.push({ field: "name", message: "name is required" });
+    if (!apiKey || typeof apiKey !== "string") errors.push({ field: "apiKey", message: "apiKey is required" });
+    if (!secret || typeof secret !== "string") errors.push({ field: "secret", message: "secret is required" });
+    if (errors.length > 0) {
+      return problem(reply, 400, "Validation Error", "Invalid exchange connection payload", { errors });
+    }
+
+    // Unique check within workspace
+    const existing = await prisma.exchangeConnection.findUnique({
+      where: { workspaceId_name: { workspaceId: workspace.id, name } },
+    });
+    if (existing) {
+      return problem(reply, 409, "Conflict", `Exchange connection "${name}" already exists in this workspace`);
+    }
+
+    const encryptedSecret = encrypt(secret, key);
+
+    const conn = await prisma.exchangeConnection.create({
+      data: {
+        workspaceId: workspace.id,
+        exchange: exchange.toUpperCase(),
+        name,
+        apiKey,
+        encryptedSecret,
+        status: "UNKNOWN",
+      },
+    });
+
+    return reply.status(201).send(safeView(conn));
+  });
+
+  // GET /exchanges — list connections for workspace (no secrets)
+  app.get("/exchanges", { onRequest: [app.authenticate] }, async (request, reply) => {
+    const workspace = await resolveWorkspace(request, reply);
+    if (!workspace) return;
+
+    const connections = await prisma.exchangeConnection.findMany({
+      where: { workspaceId: workspace.id },
+      orderBy: { createdAt: "desc" },
+    });
+
+    return reply.send(connections.map(safeView));
+  });
+
+  // GET /exchanges/:id — single connection (no secrets)
+  app.get<{ Params: { id: string } }>("/exchanges/:id", { onRequest: [app.authenticate] }, async (request, reply) => {
+    const workspace = await resolveWorkspace(request, reply);
+    if (!workspace) return;
+
+    const conn = await prisma.exchangeConnection.findUnique({
+      where: { id: request.params.id },
+    });
+    if (!conn || conn.workspaceId !== workspace.id) {
+      return problem(reply, 404, "Not Found", "Exchange connection not found");
+    }
+
+    return reply.send(safeView(conn));
+  });
+
+  // PATCH /exchanges/:id — update name / apiKey / secret
+  app.patch<{ Params: { id: string }; Body: PatchBody }>("/exchanges/:id", { onRequest: [app.authenticate] }, async (request, reply) => {
+    const workspace = await resolveWorkspace(request, reply);
+    if (!workspace) return;
+
+    const conn = await prisma.exchangeConnection.findUnique({
+      where: { id: request.params.id },
+    });
+    if (!conn || conn.workspaceId !== workspace.id) {
+      return problem(reply, 404, "Not Found", "Exchange connection not found");
+    }
+
+    const { name, apiKey, secret } = request.body ?? {};
+
+    // If secret is being updated we need the encryption key
+    let encryptedSecret: string | undefined;
+    if (secret !== undefined) {
+      if (typeof secret !== "string" || !secret) {
+        return problem(reply, 400, "Validation Error", "secret must be a non-empty string");
+      }
+      const key = getEncryptionKey(reply);
+      if (!key) return;
+      encryptedSecret = encrypt(secret, key);
+    }
+
+    const updateData: Record<string, unknown> = {};
+    if (name !== undefined) updateData.name = name;
+    if (apiKey !== undefined) updateData.apiKey = apiKey;
+    if (encryptedSecret !== undefined) updateData.encryptedSecret = encryptedSecret;
+    // Reset status to UNKNOWN whenever credentials change
+    if (apiKey !== undefined || secret !== undefined) updateData.status = "UNKNOWN";
+
+    const updated = await prisma.exchangeConnection.update({
+      where: { id: conn.id },
+      data: updateData,
+    });
+
+    return reply.send(safeView(updated));
+  });
+
+  // DELETE /exchanges/:id
+  app.delete<{ Params: { id: string } }>("/exchanges/:id", { onRequest: [app.authenticate] }, async (request, reply) => {
+    const workspace = await resolveWorkspace(request, reply);
+    if (!workspace) return;
+
+    const conn = await prisma.exchangeConnection.findUnique({
+      where: { id: request.params.id },
+    });
+    if (!conn || conn.workspaceId !== workspace.id) {
+      return problem(reply, 404, "Not Found", "Exchange connection not found");
+    }
+
+    await prisma.exchangeConnection.delete({ where: { id: conn.id } });
+    return reply.status(204).send();
+  });
+
+  // POST /exchanges/:id/test — demo-first connectivity check
+  app.post<{ Params: { id: string } }>("/exchanges/:id/test", { onRequest: [app.authenticate] }, async (request, reply) => {
+    const workspace = await resolveWorkspace(request, reply);
+    if (!workspace) return;
+
+    const conn = await prisma.exchangeConnection.findUnique({
+      where: { id: request.params.id },
+    });
+    if (!conn || conn.workspaceId !== workspace.id) {
+      return problem(reply, 404, "Not Found", "Exchange connection not found");
+    }
+
+    const key = getEncryptionKey(reply);
+    if (!key) return;
+
+    let decryptedSecret: string;
+    try {
+      decryptedSecret = decrypt(conn.encryptedSecret, key);
+    } catch (err) {
+      request.log.error({ connectionId: conn.id, err }, "Failed to decrypt exchange secret");
+      return problem(reply, 500, "Internal Server Error", "Failed to decrypt exchange credentials");
+    }
+
+    // Demo-first: validate that credentials are non-empty and perform a lightweight
+    // reachability check. A real exchange call (e.g. GET /v5/account/info on Bybit)
+    // would be wired in Stage 9b.
+    let status: "CONNECTED" | "FAILED" = "FAILED";
+    let detail = "Connection test failed";
+
+    if (conn.apiKey && decryptedSecret) {
+      // Demo placeholder: credentials present → optimistically mark CONNECTED.
+      // Stage 9b will replace this with a real exchange API call.
+      status = "CONNECTED";
+      detail = "Credentials verified (demo-first — real exchange call deferred to Stage 9b)";
+    }
+
+    await prisma.exchangeConnection.update({
+      where: { id: conn.id },
+      data: { status },
+    });
+
+    return reply.send({
+      id: conn.id,
+      status,
+      detail,
+    });
+  });
+}

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -168,6 +168,162 @@ paths:
         "404":
           $ref: "#/components/responses/Problem"
 
+  # ── Exchange Connections (Stage 8) ─────────────────────────────────────────
+
+  /exchanges:
+    get:
+      operationId: exchangesList
+      summary: List exchange connections (no secrets returned)
+      parameters:
+        - $ref: "#/components/parameters/XWorkspaceId"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ExchangeConnectionView"
+        "400":
+          $ref: "#/components/responses/Problem"
+        "401":
+          $ref: "#/components/responses/Problem"
+        "403":
+          $ref: "#/components/responses/Problem"
+    post:
+      operationId: exchangesCreate
+      summary: Create exchange connection
+      parameters:
+        - $ref: "#/components/parameters/XWorkspaceId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExchangeConnectionCreateRequest"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExchangeConnectionView"
+        "400":
+          $ref: "#/components/responses/Problem"
+        "401":
+          $ref: "#/components/responses/Problem"
+        "403":
+          $ref: "#/components/responses/Problem"
+        "409":
+          $ref: "#/components/responses/Problem"
+        "500":
+          $ref: "#/components/responses/Problem"
+
+  /exchanges/{connectionId}:
+    get:
+      operationId: exchangesGet
+      summary: Get exchange connection (no secrets returned)
+      parameters:
+        - $ref: "#/components/parameters/XWorkspaceId"
+        - name: connectionId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExchangeConnectionView"
+        "401":
+          $ref: "#/components/responses/Problem"
+        "403":
+          $ref: "#/components/responses/Problem"
+        "404":
+          $ref: "#/components/responses/Problem"
+    patch:
+      operationId: exchangesPatch
+      summary: Update exchange connection (re-encrypts secret if provided)
+      parameters:
+        - $ref: "#/components/parameters/XWorkspaceId"
+        - name: connectionId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExchangeConnectionPatchRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExchangeConnectionView"
+        "400":
+          $ref: "#/components/responses/Problem"
+        "401":
+          $ref: "#/components/responses/Problem"
+        "403":
+          $ref: "#/components/responses/Problem"
+        "404":
+          $ref: "#/components/responses/Problem"
+        "500":
+          $ref: "#/components/responses/Problem"
+    delete:
+      operationId: exchangesDelete
+      summary: Delete exchange connection
+      parameters:
+        - $ref: "#/components/parameters/XWorkspaceId"
+        - name: connectionId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: No Content
+        "401":
+          $ref: "#/components/responses/Problem"
+        "403":
+          $ref: "#/components/responses/Problem"
+        "404":
+          $ref: "#/components/responses/Problem"
+
+  /exchanges/{connectionId}/test:
+    post:
+      operationId: exchangesTest
+      summary: Test exchange connection (demo-first)
+      parameters:
+        - $ref: "#/components/parameters/XWorkspaceId"
+        - name: connectionId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Test result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExchangeConnectionTestResult"
+        "401":
+          $ref: "#/components/responses/Problem"
+        "403":
+          $ref: "#/components/responses/Problem"
+        "404":
+          $ref: "#/components/responses/Problem"
+        "500":
+          $ref: "#/components/responses/Problem"
+
   /signals/webhook/{strategyId}:
     post:
       operationId: signalWebhook
@@ -196,6 +352,15 @@ components:
     bearerAuth:
       type: http
       scheme: bearer
+
+  parameters:
+    XWorkspaceId:
+      name: X-Workspace-Id
+      in: header
+      required: true
+      schema:
+        type: string
+      description: Workspace ID (membership is enforced server-side)
 
   responses:
     Problem:
@@ -243,6 +408,52 @@ components:
       properties:
         strategyId: { type: string }
         note: { type: string }
+
+    ExchangeConnectionView:
+      type: object
+      description: >
+        Safe view of an exchange connection — never includes apiKey, secret, or encryptedSecret.
+      additionalProperties: false
+      required: [id, workspaceId, exchange, name, status, createdAt, updatedAt]
+      properties:
+        id: { type: string }
+        workspaceId: { type: string }
+        exchange: { type: string, example: "BYBIT" }
+        name: { type: string, example: "Main Bybit account" }
+        status:
+          type: string
+          enum: [UNKNOWN, CONNECTED, FAILED]
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+
+    ExchangeConnectionCreateRequest:
+      type: object
+      additionalProperties: false
+      required: [exchange, name, apiKey, secret]
+      properties:
+        exchange: { type: string, example: "BYBIT" }
+        name: { type: string, example: "Main Bybit account" }
+        apiKey: { type: string, minLength: 1 }
+        secret: { type: string, minLength: 1, description: "Raw secret — stored encrypted, never returned" }
+
+    ExchangeConnectionPatchRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        name: { type: string }
+        apiKey: { type: string, minLength: 1 }
+        secret: { type: string, minLength: 1, description: "Raw secret — re-encrypted on update, never returned" }
+
+    ExchangeConnectionTestResult:
+      type: object
+      additionalProperties: false
+      required: [id, status, detail]
+      properties:
+        id: { type: string }
+        status:
+          type: string
+          enum: [CONNECTED, FAILED]
+        detail: { type: string }
 
     SignalRequest:
       type: object

--- a/docs/steps/08-stage-8-exchange-connections.md
+++ b/docs/steps/08-stage-8-exchange-connections.md
@@ -1,0 +1,203 @@
+# Stage 8 — Exchange Connections (demo-first)
+
+## Status: DONE
+
+## 1) Scope
+
+- CRUD `ExchangeConnection` (create / list / get / patch / delete)
+- `POST /exchanges/:id/test` — demo-first connectivity check
+- AES-256-GCM secret encryption via `SECRET_ENCRYPTION_KEY` env
+- All endpoints: `authenticate` + `resolveWorkspace()` enforcement
+- API never returns `apiKey`, `secret`, or `encryptedSecret`
+- OpenAPI contract updated
+
+## 2) Scope boundaries (что НЕ сделано)
+
+- Нет Vault / KMS / pgcrypto
+- Нет production-grade secret manager
+- Нет real-money execution или биржевых вызовов (Stage 9b)
+- Нет RBAC
+- Нет UI (backend + OpenAPI контракт)
+
+## 3) Environment requirements
+
+`SECRET_ENCRYPTION_KEY` — обязательная переменная окружения для Stage 8.
+Формат: 64 hex-символа (32 bytes).
+
+Генерация:
+```sh
+node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+```
+
+При отсутствии или неверном формате все endpoints, требующие шифрования (`POST /exchanges`, `PATCH /exchanges/:id` с `secret`, `POST /exchanges/:id/test`), вернут:
+
+```json
+{
+  "type": "about:blank",
+  "title": "Server Configuration Error",
+  "status": 500,
+  "detail": "Secret encryption key is not configured. Set SECRET_ENCRYPTION_KEY env variable."
+}
+```
+
+## 4) Файлы изменений
+
+| Файл | Тип |
+|------|-----|
+| `apps/api/prisma/schema.prisma` | добавлена модель `ExchangeConnection` + enum `ExchangeConnectionStatus` |
+| `apps/api/prisma/migrations/20260221a_add_exchange_connections/migration.sql` | новая миграция |
+| `apps/api/src/lib/crypto.ts` | новый: AES-256-GCM encrypt/decrypt + `getEncryptionKey()` |
+| `apps/api/src/routes/exchanges.ts` | новый: CRUD + test connection |
+| `apps/api/src/app.ts` | регистрация `exchangeRoutes` |
+| `docs/openapi/openapi.yaml` | добавлены Exchange Connection endpoints + schemas |
+| `docs/steps/08-stage-8-exchange-connections.md` | этот файл |
+
+## 5) Verification commands
+
+### Предварительно
+
+```sh
+export BASE=http://localhost:3000/api/v1
+export SECRET_ENCRYPTION_KEY=$(node -e "console.log(require('crypto').randomBytes(32).toString('hex'))")
+
+# Зарегистрировать / залогиниться
+TOKEN=$(curl -s -X POST $BASE/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"test@example.com","password":"secret"}' | jq -r '.accessToken')
+
+WORKSPACE_ID=<your-workspace-id>
+```
+
+### CREATE
+```sh
+curl -s -X POST $BASE/exchanges \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Workspace-Id: $WORKSPACE_ID" \
+  -H "Content-Type: application/json" \
+  -d '{"exchange":"BYBIT","name":"Main","apiKey":"key123","secret":"sec456"}' | jq .
+# → 201, содержит id/exchange/name/status=UNKNOWN, НЕТ secret/encryptedSecret/apiKey
+```
+
+### LIST
+```sh
+curl -s $BASE/exchanges \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Workspace-Id: $WORKSPACE_ID" | jq .
+# → 200, массив без секретов
+```
+
+### GET
+```sh
+CONN_ID=<id из CREATE>
+curl -s $BASE/exchanges/$CONN_ID \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Workspace-Id: $WORKSPACE_ID" | jq .
+# → 200, без секретов
+```
+
+### PATCH (перешифрование)
+```sh
+curl -s -X PATCH $BASE/exchanges/$CONN_ID \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Workspace-Id: $WORKSPACE_ID" \
+  -H "Content-Type: application/json" \
+  -d '{"secret":"newsecret789"}' | jq .
+# → 200, status сброшен в UNKNOWN, secretов нет в ответе
+```
+
+### TEST CONNECTION
+```sh
+curl -s -X POST $BASE/exchanges/$CONN_ID/test \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Workspace-Id: $WORKSPACE_ID" | jq .
+# → 200, {"id":"...","status":"CONNECTED","detail":"Credentials verified (demo-first...)"}
+```
+
+### DELETE
+```sh
+curl -s -X DELETE $BASE/exchanges/$CONN_ID \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Workspace-Id: $WORKSPACE_ID"
+# → 204
+```
+
+### Cross-workspace → 403
+```sh
+curl -s $BASE/exchanges \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Workspace-Id: <OTHER_WORKSPACE_ID>" | jq .
+# → 403
+```
+
+### Without auth → 401
+```sh
+curl -s $BASE/exchanges | jq .
+# → 401
+```
+
+### Missing SECRET_ENCRYPTION_KEY → 500
+```sh
+SECRET_ENCRYPTION_KEY="" node ... # запустить сервер без ключа
+curl -s -X POST $BASE/exchanges \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Workspace-Id: $WORKSPACE_ID" \
+  -H "Content-Type: application/json" \
+  -d '{"exchange":"BYBIT","name":"Test","apiKey":"k","secret":"s"}' | jq .
+# → 500, "Server Configuration Error"
+```
+
+## 6) Acceptance checklist
+
+- [x] CRUD exchange connections работает
+- [x] Все endpoints защищены `authenticate`
+- [x] Везде используется `resolveWorkspace()`
+- [x] Секрет хранится в `encryptedSecret` (AES-256-GCM)
+- [x] Используется `SECRET_ENCRYPTION_KEY`
+- [x] Секреты не возвращаются в API (redaction через `safeView()`)
+- [x] `test connection` реализован (demo-first)
+- [x] OpenAPI обновлён
+- [x] Handover notes для Stage 9b добавлены
+- [x] Нет scope creep
+
+## 7) Handover для Stage 9b (Terminal Manual Order Flow)
+
+### Как использовать `ExchangeConnection`
+
+Stage 9b получает готовую сущность подключения к бирже.
+
+**Получить подключение для выполнения ордера:**
+```typescript
+import { prisma } from "../lib/prisma.js";
+import { decrypt } from "../lib/crypto.js";
+
+const conn = await prisma.exchangeConnection.findUnique({ where: { id: connectionId } });
+// conn.workspaceId === workspace.id (уже проверено resolveWorkspace)
+
+const key = Buffer.from(process.env.SECRET_ENCRYPTION_KEY!, "hex");
+const secret = decrypt(conn.encryptedSecret, key);
+// → используй conn.apiKey + secret для инициализации Bybit SDK
+```
+
+**Доступные поля:**
+- `id`, `workspaceId`, `exchange` (например `"BYBIT"`), `name`, `apiKey`
+- `encryptedSecret` — расшифровать через `decrypt()`
+- `status` — `UNKNOWN | CONNECTED | FAILED` (обновлять после реального вызова)
+
+**Паттерн обновления статуса после реального вызова:**
+```typescript
+await prisma.exchangeConnection.update({
+  where: { id: conn.id },
+  data: { status: "CONNECTED" }, // или "FAILED"
+});
+```
+
+### Ограничения demo-first (остаются к Stage 9b)
+
+- `POST /exchanges/:id/test` не делает реальный биржевой вызов — Stage 9b должен заменить stub на `GET /v5/account/info` (Bybit) или аналог
+- `apiKey` хранится в plain text — для production потребует отдельного решения (deferred)
+- Нет ротации ключей и key versioning
+
+## 8) Deviations
+
+Нет отклонений от заявленного scope Stage 8.
+`apiKey` хранится plain (по условию задачи: "apiKey можно хранить как обычное поле (demo-first)").


### PR DESCRIPTION
## Summary

- **Stage 8**: Exchange Connections (demo-first) — CRUD для подключений к биржам (AES-256-GCM шифрование)
- **Worker Auth fix**: guard PATCH /runs/:id/state, POST heartbeat & reconcile с BOT_WORKER_SECRET
- **Smoke test fix**: Bearer токен в POST /runs/stop-all
- **Deploy**: предупреждение если BOT_WORKER_SECRET missing/placeholder

## Test plan

- [ ] Миграция БД проходит
- [ ] CRUD /exchanges работает, секреты шифруются
- [ ] Worker routes защищены
- [ ] Smoke test проходит

https://claude.ai/code/session_01LAnFKVySmygJghUAW6JN59