### PR TITLE
feat(stage-9a): Terminal Market Data Flow — read-only ticker + candles

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -12,6 +12,7 @@ import { intentRoutes } from "./routes/intents.js";
 import { workspacesRoutes } from "./routes/workspaces.js";
 import { labRoutes } from "./routes/lab.js";
 import { exchangeRoutes } from "./routes/exchanges.js";
+import { terminalRoutes } from "./routes/terminal.js";
 
 /** Registers all domain routes. */
 async function registerRoutes(scope: import("fastify").FastifyInstance) {
@@ -25,6 +26,7 @@ async function registerRoutes(scope: import("fastify").FastifyInstance) {
   await scope.register(intentRoutes);
   await scope.register(labRoutes);
   await scope.register(exchangeRoutes);
+  await scope.register(terminalRoutes);
 }
 
 export async function buildApp() {

--- a/apps/api/src/routes/terminal.ts
+++ b/apps/api/src/routes/terminal.ts
@@ -1,0 +1,161 @@
+import type { FastifyInstance } from "fastify";
+import { problem } from "../lib/problem.js";
+import { fetchTicker } from "../lib/bybitCandles.js";
+import { fetchCandles } from "../lib/bybitCandles.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Supported Bybit kline intervals for Terminal read-only view.
+ * Superset of lab.ts intervals; includes intraday + daily.
+ */
+const VALID_INTERVALS = ["1", "5", "15", "30", "60", "240", "D"] as const;
+type TerminalInterval = (typeof VALID_INTERVALS)[number];
+
+const DEFAULT_LIMIT = 200;
+const MAX_LIMIT = 1000; // Bybit single-page cap
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isValidInterval(v: string): v is TerminalInterval {
+  return (VALID_INTERVALS as readonly string[]).includes(v);
+}
+
+/** Map an error from the Bybit helper to a stable Problem Details response. */
+function bybitErrorToProblem(
+  reply: import("fastify").FastifyReply,
+  err: unknown,
+  context: string,
+) {
+  const msg = err instanceof Error ? err.message : String(err);
+
+  // "Symbol not found" → 422
+  if (msg.toLowerCase().includes("symbol not found") || msg.includes("not found")) {
+    return problem(reply, 422, "Unprocessable Content", `Unknown symbol. ${msg}`);
+  }
+
+  // Bybit API-level error (retCode ≠ 0) → 502
+  if (msg.startsWith("Bybit API error")) {
+    return problem(reply, 502, "Bad Gateway", `Upstream market data error: ${msg}`);
+  }
+
+  // Bybit HTTP error → 502
+  if (msg.startsWith("Bybit ")) {
+    return problem(reply, 502, "Bad Gateway", `Upstream request failed: ${msg}`);
+  }
+
+  // Fallback
+  return problem(reply, 500, "Internal Server Error", `Failed to fetch ${context}`);
+}
+
+// ---------------------------------------------------------------------------
+// Routes
+// ---------------------------------------------------------------------------
+
+export async function terminalRoutes(app: FastifyInstance) {
+  /**
+   * GET /terminal/ticker?symbol=BTCUSDT
+   *
+   * Returns current ticker data for a linear perpetual symbol.
+   * Requires authentication (JWT). No workspace required — Bybit data is public.
+   */
+  app.get<{ Querystring: { symbol?: string } }>(
+    "/terminal/ticker",
+    { onRequest: [app.authenticate] },
+    async (request, reply) => {
+      const { symbol } = request.query;
+
+      if (!symbol || typeof symbol !== "string" || !symbol.trim()) {
+        return problem(reply, 400, "Bad Request", "Query parameter 'symbol' is required");
+      }
+
+      const sym = symbol.trim().toUpperCase();
+
+      try {
+        const ticker = await fetchTicker(sym);
+        return reply.send(ticker);
+      } catch (err) {
+        request.log.warn({ symbol: sym, err }, "terminal ticker fetch failed");
+        return bybitErrorToProblem(reply, err, "ticker");
+      }
+    },
+  );
+
+  /**
+   * GET /terminal/candles?symbol=BTCUSDT&interval=15&limit=200
+   *
+   * Returns recent OHLCV candles for a linear perpetual symbol.
+   * Requires authentication (JWT). No workspace required — Bybit data is public.
+   *
+   * Parameters:
+   *   symbol   — required; e.g. "BTCUSDT"
+   *   interval — optional; one of: 1, 5, 15, 30, 60, 240, D (default: 15)
+   *   limit    — optional; 1–1000 (default: 200)
+   */
+  app.get<{ Querystring: { symbol?: string; interval?: string; limit?: string } }>(
+    "/terminal/candles",
+    { onRequest: [app.authenticate] },
+    async (request, reply) => {
+      const { symbol, interval: intervalParam, limit: limitParam } = request.query;
+
+      // --- Validate symbol ---
+      if (!symbol || typeof symbol !== "string" || !symbol.trim()) {
+        return problem(reply, 400, "Bad Request", "Query parameter 'symbol' is required");
+      }
+      const sym = symbol.trim().toUpperCase();
+
+      // --- Validate interval ---
+      const interval = (intervalParam ?? "15").trim();
+      if (!isValidInterval(interval)) {
+        return problem(
+          reply,
+          400,
+          "Bad Request",
+          `Invalid 'interval'. Allowed values: ${VALID_INTERVALS.join(", ")}`,
+        );
+      }
+
+      // --- Validate limit ---
+      const limitRaw = limitParam !== undefined ? Number(limitParam) : DEFAULT_LIMIT;
+      if (!Number.isInteger(limitRaw) || limitRaw < 1 || limitRaw > MAX_LIMIT) {
+        return problem(
+          reply,
+          400,
+          "Bad Request",
+          `Invalid 'limit'. Must be an integer between 1 and ${MAX_LIMIT}`,
+        );
+      }
+      const limit = limitRaw;
+
+      // --- Fetch candles ---
+      // Use a rolling window ending now, sized by interval × limit
+      const toMs = Date.now();
+      const intervalMs = intervalToMs(interval);
+      const fromMs = toMs - intervalMs * limit * 2; // fetch 2× to ensure enough data after dedup
+
+      try {
+        const candles = await fetchCandles(sym, interval, fromMs, toMs, limit);
+        return reply.send(candles);
+      } catch (err) {
+        request.log.warn({ symbol: sym, interval, limit, err }, "terminal candles fetch failed");
+        return bybitErrorToProblem(reply, err, "candles");
+      }
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Convert Bybit interval string to approximate milliseconds (for window sizing). */
+function intervalToMs(interval: string): number {
+  if (interval === "D") return 24 * 60 * 60 * 1000;
+  const mins = Number(interval);
+  if (Number.isFinite(mins) && mins > 0) return mins * 60 * 1000;
+  return 15 * 60 * 1000; // fallback
+}

--- a/apps/web/src/app/terminal/page.tsx
+++ b/apps/web/src/app/terminal/page.tsx
@@ -1,10 +1,314 @@
+"use client";
+
+import { useState } from "react";
+import { apiFetchNoWorkspace } from "../factory/api";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface Ticker {
+  symbol: string;
+  lastPrice: number;
+  bidPrice: number;
+  askPrice: number;
+  prevPrice24h: number;
+  price24hPcnt: number;
+  highPrice24h: number;
+  lowPrice24h: number;
+  volume24h: number;
+}
+
+interface Candle {
+  openTime: number;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+type LoadState = "idle" | "loading" | "success" | "error";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const INTERVALS = ["1", "5", "15", "30", "60", "240", "D"] as const;
+const DEFAULT_SYMBOL = "BTCUSDT";
+const DEFAULT_INTERVAL = "15";
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
 export default function TerminalPage() {
+  const [symbol, setSymbol] = useState(DEFAULT_SYMBOL);
+  const [interval, setInterval] = useState(DEFAULT_INTERVAL);
+  const [limit, setLimit] = useState("50");
+
+  const [tickerState, setTickerState] = useState<LoadState>("idle");
+  const [ticker, setTicker] = useState<Ticker | null>(null);
+  const [tickerError, setTickerError] = useState<string | null>(null);
+
+  const [candlesState, setCandlesState] = useState<LoadState>("idle");
+  const [candles, setCandles] = useState<Candle[]>([]);
+  const [candlesError, setCandlesError] = useState<string | null>(null);
+
+  // --- Actions ---
+
+  async function loadTicker() {
+    const sym = symbol.trim().toUpperCase();
+    if (!sym) return;
+    setTickerState("loading");
+    setTickerError(null);
+    setTicker(null);
+
+    const res = await apiFetchNoWorkspace<Ticker>(
+      `/terminal/ticker?symbol=${encodeURIComponent(sym)}`,
+    );
+    if (res.ok) {
+      setTicker(res.data);
+      setTickerState("success");
+    } else {
+      setTickerError(`${res.problem.title}: ${res.problem.detail}`);
+      setTickerState("error");
+    }
+  }
+
+  async function loadCandles() {
+    const sym = symbol.trim().toUpperCase();
+    if (!sym) return;
+    setCandlesState("loading");
+    setCandlesError(null);
+    setCandles([]);
+
+    const lim = Math.min(Math.max(1, Number(limit) || 50), 1000);
+    const res = await apiFetchNoWorkspace<Candle[]>(
+      `/terminal/candles?symbol=${encodeURIComponent(sym)}&interval=${interval}&limit=${lim}`,
+    );
+    if (res.ok) {
+      setCandles(res.data);
+      setCandlesState("success");
+    } else {
+      setCandlesError(`${res.problem.title}: ${res.problem.detail}`);
+      setCandlesState("error");
+    }
+  }
+
+  async function loadAll() {
+    await Promise.all([loadTicker(), loadCandles()]);
+  }
+
+  // --- Helpers ---
+
+  function pctColor(pct: number) {
+    if (pct > 0) return "#3fb950";
+    if (pct < 0) return "#f85149";
+    return "var(--text-secondary)";
+  }
+
+  function fmt(n: number) {
+    return n.toLocaleString(undefined, { maximumFractionDigits: 6 });
+  }
+
+  const loading = tickerState === "loading" || candlesState === "loading";
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
   return (
-    <div style={{ padding: "48px 24px", textAlign: "center" }}>
-      <h1 style={{ fontSize: "28px", marginBottom: "16px" }}>Terminal</h1>
-      <p style={{ color: "var(--text-secondary)" }}>
-        Trading terminal with charts, orders and positions — coming in Stage 2.
-      </p>
+    <div style={{ padding: "32px 24px", maxWidth: 900, margin: "0 auto" }}>
+      <h1 style={{ fontSize: 26, marginBottom: 24 }}>Terminal — Market Data</h1>
+
+      {/* ── Controls ── */}
+      <div style={{ ...card, marginBottom: 20 }}>
+        <div style={{ display: "flex", gap: 10, flexWrap: "wrap", alignItems: "center" }}>
+          <input
+            style={{ ...input, width: 140 }}
+            placeholder="Symbol (e.g. BTCUSDT)"
+            value={symbol}
+            onChange={(e) => setSymbol(e.target.value.toUpperCase())}
+            onKeyDown={(e) => e.key === "Enter" && loadAll()}
+          />
+          <select
+            style={{ ...input, width: 100 }}
+            value={interval}
+            onChange={(e) => setInterval(e.target.value)}
+          >
+            {INTERVALS.map((iv) => (
+              <option key={iv} value={iv}>
+                {iv === "D" ? "1D" : `${iv}m`}
+              </option>
+            ))}
+          </select>
+          <input
+            style={{ ...input, width: 80 }}
+            type="number"
+            min={1}
+            max={1000}
+            placeholder="Limit"
+            value={limit}
+            onChange={(e) => setLimit(e.target.value)}
+          />
+          <button style={btn} onClick={loadAll} disabled={loading}>
+            {loading ? "Loading..." : "Load"}
+          </button>
+        </div>
+      </div>
+
+      {/* ── Ticker ── */}
+      <div style={{ ...card, marginBottom: 20 }}>
+        <h2 style={{ fontSize: 16, marginBottom: 12 }}>Ticker</h2>
+
+        {tickerState === "idle" && (
+          <p style={hint}>Select a symbol and click Load.</p>
+        )}
+        {tickerState === "loading" && <p style={hint}>Loading ticker...</p>}
+        {tickerState === "error" && (
+          <p style={{ color: "#f85149", fontSize: 13 }}>{tickerError}</p>
+        )}
+        {tickerState === "success" && ticker && (
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(160px, 1fr))", gap: 12 }}>
+            <TickerCell label="Last Price" value={fmt(ticker.lastPrice)} />
+            <TickerCell label="Bid" value={fmt(ticker.bidPrice)} />
+            <TickerCell label="Ask" value={fmt(ticker.askPrice)} />
+            <TickerCell
+              label="24h Change"
+              value={`${(ticker.price24hPcnt * 100).toFixed(2)}%`}
+              color={pctColor(ticker.price24hPcnt)}
+            />
+            <TickerCell label="24h High" value={fmt(ticker.highPrice24h)} />
+            <TickerCell label="24h Low" value={fmt(ticker.lowPrice24h)} />
+            <TickerCell label="24h Volume" value={fmt(ticker.volume24h)} />
+            <TickerCell label="Prev Close" value={fmt(ticker.prevPrice24h)} />
+          </div>
+        )}
+      </div>
+
+      {/* ── Candles ── */}
+      <div style={card}>
+        <h2 style={{ fontSize: 16, marginBottom: 12 }}>
+          Candles{candlesState === "success" ? ` (${candles.length})` : ""}
+        </h2>
+
+        {candlesState === "idle" && <p style={hint}>Click Load to fetch candles.</p>}
+        {candlesState === "loading" && <p style={hint}>Loading candles...</p>}
+        {candlesState === "error" && (
+          <p style={{ color: "#f85149", fontSize: 13 }}>{candlesError}</p>
+        )}
+        {candlesState === "success" && candles.length === 0 && (
+          <p style={hint}>No candles returned.</p>
+        )}
+        {candlesState === "success" && candles.length > 0 && (
+          <div style={{ overflowX: "auto" }}>
+            <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
+              <thead>
+                <tr>
+                  {["Time", "Open", "High", "Low", "Close", "Volume"].map((h) => (
+                    <th
+                      key={h}
+                      style={{
+                        textAlign: "right",
+                        padding: "4px 8px",
+                        borderBottom: "1px solid var(--border)",
+                        color: "var(--text-secondary)",
+                        fontWeight: 600,
+                      }}
+                    >
+                      {h}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {[...candles].reverse().map((c) => {
+                  const bullish = c.close >= c.open;
+                  return (
+                    <tr key={c.openTime}>
+                      <td style={td}>{new Date(c.openTime).toLocaleString()}</td>
+                      <td style={td}>{fmt(c.open)}</td>
+                      <td style={td}>{fmt(c.high)}</td>
+                      <td style={td}>{fmt(c.low)}</td>
+                      <td style={{ ...td, color: bullish ? "#3fb950" : "#f85149" }}>
+                        {fmt(c.close)}
+                      </td>
+                      <td style={td}>{fmt(c.volume)}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
     </div>
   );
 }
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function TickerCell({
+  label,
+  value,
+  color,
+}: {
+  label: string;
+  value: string;
+  color?: string;
+}) {
+  return (
+    <div style={{ padding: "10px 12px", background: "var(--bg-secondary)", borderRadius: 6 }}>
+      <div style={{ fontSize: 11, color: "var(--text-secondary)", marginBottom: 4 }}>{label}</div>
+      <div style={{ fontSize: 16, fontWeight: 600, color: color ?? "var(--text-primary)" }}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const card: React.CSSProperties = {
+  background: "var(--bg-card)",
+  border: "1px solid var(--border)",
+  borderRadius: 8,
+  padding: 16,
+};
+
+const input: React.CSSProperties = {
+  padding: "8px 12px",
+  background: "var(--bg-secondary)",
+  border: "1px solid var(--border)",
+  borderRadius: 6,
+  color: "var(--text-primary)",
+  fontSize: 14,
+};
+
+const btn: React.CSSProperties = {
+  padding: "8px 20px",
+  background: "var(--accent)",
+  color: "#fff",
+  border: "none",
+  borderRadius: 6,
+  cursor: "pointer",
+  fontSize: 14,
+  fontWeight: 600,
+};
+
+const hint: React.CSSProperties = {
+  color: "var(--text-secondary)",
+  fontSize: 13,
+};
+
+const td: React.CSSProperties = {
+  padding: "4px 8px",
+  textAlign: "right",
+  borderBottom: "1px solid var(--border)",
+  fontFamily: "monospace",
+};

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -324,6 +324,90 @@ paths:
         "500":
           $ref: "#/components/responses/Problem"
 
+  # ── Terminal — Market Data (Stage 9a, read-only) ────────────────────────────
+
+  /terminal/ticker:
+    get:
+      operationId: terminalTicker
+      summary: Get current ticker for a symbol
+      description: >
+        Returns live ticker data (last price, bid/ask, 24h stats) for a Bybit linear
+        perpetual symbol. Requires authentication. Market data is public (Bybit); no
+        workspace is required.
+      parameters:
+        - name: symbol
+          in: query
+          required: true
+          schema:
+            type: string
+            example: BTCUSDT
+          description: Linear perpetual symbol (e.g. BTCUSDT)
+      responses:
+        "200":
+          description: Ticker data
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Ticker"
+        "400":
+          $ref: "#/components/responses/Problem"
+        "401":
+          $ref: "#/components/responses/Problem"
+        "422":
+          $ref: "#/components/responses/Problem"
+        "502":
+          $ref: "#/components/responses/Problem"
+
+  /terminal/candles:
+    get:
+      operationId: terminalCandles
+      summary: Get recent OHLCV candles for a symbol
+      description: >
+        Returns a list of OHLCV candles from Bybit for a linear perpetual symbol.
+        Requires authentication. Market data is public (Bybit); no workspace is required.
+      parameters:
+        - name: symbol
+          in: query
+          required: true
+          schema:
+            type: string
+            example: BTCUSDT
+          description: Linear perpetual symbol (e.g. BTCUSDT)
+        - name: interval
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: ["1", "5", "15", "30", "60", "240", "D"]
+            default: "15"
+          description: Kline interval
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            default: 200
+          description: Number of candles to return (max 1000)
+      responses:
+        "200":
+          description: Candles array (ascending by openTime)
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Candle"
+        "400":
+          $ref: "#/components/responses/Problem"
+        "401":
+          $ref: "#/components/responses/Problem"
+        "422":
+          $ref: "#/components/responses/Problem"
+        "502":
+          $ref: "#/components/responses/Problem"
+
   /signals/webhook/{strategyId}:
     post:
       operationId: signalWebhook
@@ -454,6 +538,38 @@ components:
           type: string
           enum: [CONNECTED, FAILED]
         detail: { type: string }
+
+    Ticker:
+      type: object
+      description: Current market ticker for a linear perpetual symbol.
+      additionalProperties: false
+      required:
+        [symbol, lastPrice, bidPrice, askPrice, prevPrice24h, price24hPcnt,
+         highPrice24h, lowPrice24h, volume24h, turnover24h]
+      properties:
+        symbol: { type: string, example: BTCUSDT }
+        lastPrice: { type: number, description: Last traded price }
+        bidPrice: { type: number, description: Best bid price }
+        askPrice: { type: number, description: Best ask price }
+        prevPrice24h: { type: number, description: Price 24h ago }
+        price24hPcnt: { type: number, description: 24h price change fraction (e.g. 0.02 = +2%) }
+        highPrice24h: { type: number, description: 24h high }
+        lowPrice24h: { type: number, description: 24h low }
+        volume24h: { type: number, description: 24h volume in base currency }
+        turnover24h: { type: number, description: 24h turnover in quote currency }
+
+    Candle:
+      type: object
+      description: OHLCV candle (ascending openTime order).
+      additionalProperties: false
+      required: [openTime, open, high, low, close, volume]
+      properties:
+        openTime: { type: integer, description: Candle open timestamp in milliseconds }
+        open: { type: number }
+        high: { type: number }
+        low: { type: number }
+        close: { type: number }
+        volume: { type: number, description: Volume in base currency }
 
     SignalRequest:
       type: object

--- a/docs/steps/09a-stage-9a-terminal-market-data.md
+++ b/docs/steps/09a-stage-9a-terminal-market-data.md
@@ -1,0 +1,191 @@
+# Stage 9a — Terminal Market Data Flow (read-only)
+
+## Status: DONE
+
+## 1) Scope
+
+- `GET /terminal/ticker?symbol=...` — live ticker (lastPrice, bid/ask, 24h stats)
+- `GET /terminal/candles?symbol=...&interval=...&limit=...` — OHLCV candles
+- Both endpoints: `authenticate` (JWT required), **no workspace** (Bybit data is public)
+- Stable error handling via Problem Details (RFC 9457):
+  - 400 — missing/invalid query params
+  - 401 — no/invalid JWT
+  - 422 — unknown symbol
+  - 502 — upstream Bybit error
+- Terminal UI page: symbol selector, interval selector, ticker grid, candles table
+  (loading / error / success states)
+- `fetchTicker()` added to `bybitCandles.ts`
+- OpenAPI contract updated: `Ticker` + `Candle` schemas, two new path entries
+
+## 2) Scope boundaries (что НЕ сделано)
+
+- Нет размещения ордеров (Stage 9b)
+- Нет SL/TP
+- Нет WebSocket streaming
+- Нет symbol search / instruments catalogue
+- Нет workspace enforcement на market data (публичные данные, не нужно)
+- Нет UI charts (только таблица candles)
+- Нет интеграции с ExchangeConnection (Stage 9b)
+
+## 3) Security decision (market data vs workspace)
+
+`/terminal/ticker` и `/terminal/candles` — **authenticated, not workspace-scoped**.
+
+Обоснование:
+- Биржевые market data — публичный API Bybit; данные не принадлежат workspace.
+- Обязательная аутентификация (JWT) соответствует общему паттерну приложения:
+  только залогиненные пользователи работают с терминалом.
+- Stage 9b (orders) будет workspace-scoped, так как ордера выполняются через
+  `ExchangeConnection` конкретного workspace.
+
+## 4) Файлы изменений
+
+| Файл | Тип |
+|------|-----|
+| `apps/api/src/lib/bybitCandles.ts` | добавлен `fetchTicker()` + `Ticker` interface |
+| `apps/api/src/routes/terminal.ts` | новый: `/terminal/ticker` + `/terminal/candles` |
+| `apps/api/src/app.ts` | регистрация `terminalRoutes` |
+| `apps/web/src/app/terminal/page.tsx` | полная замена заглушки на market data UI |
+| `docs/openapi/openapi.yaml` | добавлены endpoints + схемы `Ticker`, `Candle` |
+| `docs/steps/09a-stage-9a-terminal-market-data.md` | этот файл |
+
+## 5) Verification commands
+
+### Предварительно
+
+```sh
+export BASE=http://localhost:3000/api/v1
+
+# Получить токен
+TOKEN=$(curl -s -X POST $BASE/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"test@example.com","password":"secret"}' | jq -r '.accessToken')
+```
+
+### Ticker — valid symbol → 200
+
+```sh
+curl -s "$BASE/terminal/ticker?symbol=BTCUSDT" \
+  -H "Authorization: Bearer $TOKEN" | jq .
+# → 200, {symbol, lastPrice, bidPrice, askPrice, price24hPcnt, ...}
+```
+
+### Candles — valid params → 200
+
+```sh
+curl -s "$BASE/terminal/candles?symbol=BTCUSDT&interval=15&limit=10" \
+  -H "Authorization: Bearer $TOKEN" | jq .
+# → 200, array of {openTime, open, high, low, close, volume}
+```
+
+### Ticker — missing symbol → 400
+
+```sh
+curl -s "$BASE/terminal/ticker" \
+  -H "Authorization: Bearer $TOKEN" | jq .
+# → 400, Problem Details: "Query parameter 'symbol' is required"
+```
+
+### Candles — invalid interval → 400
+
+```sh
+curl -s "$BASE/terminal/candles?symbol=BTCUSDT&interval=999" \
+  -H "Authorization: Bearer $TOKEN" | jq .
+# → 400, Problem Details: "Invalid 'interval'. Allowed values: 1, 5, 15, 30, 60, 240, D"
+```
+
+### Candles — invalid limit → 400
+
+```sh
+curl -s "$BASE/terminal/candles?symbol=BTCUSDT&limit=9999" \
+  -H "Authorization: Bearer $TOKEN" | jq .
+# → 400, Problem Details: "Invalid 'limit'. Must be an integer between 1 and 1000"
+```
+
+### Ticker — invalid/unknown symbol → 422
+
+```sh
+curl -s "$BASE/terminal/ticker?symbol=FAKESYMBOLABC" \
+  -H "Authorization: Bearer $TOKEN" | jq .
+# → 422, Problem Details: "Unknown symbol..."
+```
+
+### Without auth → 401
+
+```sh
+curl -s "$BASE/terminal/ticker?symbol=BTCUSDT" | jq .
+# → 401, Problem Details: "Valid Bearer token required"
+```
+
+### Cross-workspace — N/A (endpoint не workspace-scoped по дизайну)
+
+## 6) Acceptance checklist (Stage 9a)
+
+- [x] Read-only market flow реализован (ticker + candles)
+- [x] Выбор инструмента/symbol flow определён (query param + UI input)
+- [x] Ошибки обрабатываются стабильно (400/401/422/502 с Problem Details)
+- [x] OpenAPI обновлён (Ticker, Candle schemas + endpoints)
+- [x] Нет scope creep в ордеры/SL/TP
+- [x] Handover notes для Stage 9b добавлены (см. раздел 7)
+- [x] Verification воспроизводим (curl команды выше)
+
+## 7) Handover для Stage 9b (Terminal Manual Order Flow)
+
+### Что готово после Stage 9a
+
+- `GET /terminal/ticker?symbol=...` — live market price (обязательно для order form)
+- `GET /terminal/candles?symbol=...&interval=...&limit=...` — candle data
+- UI `/terminal` — symbol selector + ticker + candles table готовы к расширению
+
+### Как использовать ExchangeConnection из Stage 8 в ордерном flow
+
+```typescript
+// В Stage 9b route handler (e.g. POST /terminal/orders):
+import { prisma } from "../lib/prisma.js";
+import { decrypt } from "../lib/crypto.js";
+
+// 1. resolveWorkspace(request, reply) — обязательно для ордеров
+const workspace = await resolveWorkspace(request, reply);
+if (!workspace) return;
+
+// 2. Получить connectionId из body
+const conn = await prisma.exchangeConnection.findUnique({
+  where: { id: request.body.connectionId },
+});
+if (!conn || conn.workspaceId !== workspace.id) {
+  return problem(reply, 404, "Not Found", "Exchange connection not found");
+}
+
+// 3. Расшифровать секрет
+const key = Buffer.from(process.env.SECRET_ENCRYPTION_KEY!, "hex");
+const secret = decrypt(conn.encryptedSecret, key);
+
+// 4. Вызвать Bybit SDK/API с conn.apiKey + secret
+// e.g. POST /v5/order/create (Bybit Unified Trading Account)
+```
+
+### Что делать в Stage 9b (без повторения Stage 9a)
+
+- `POST /terminal/orders` — создание Market/Limit ордера через Bybit API
+  - body: `{ connectionId, symbol, side, type, qty, price? }`
+  - Требует: `authenticate` + `resolveWorkspace`
+  - Дешифрует `encryptedSecret`, вызывает `POST /v5/order/create`
+- `GET /terminal/orders?connectionId=...` — список открытых ордеров/позиций
+- `GET /terminal/position?connectionId=...&symbol=...` — текущая позиция
+- UI: order form (side/type/qty/price), order list/status panel
+- Обновить `status` ExchangeConnection на `CONNECTED` после первого успешного ордерного вызова
+  (это также заменит demo-first заглушку в `POST /exchanges/:id/test`)
+
+### Ограничения, остающиеся к Stage 9b
+
+- `POST /exchanges/:id/test` всё ещё demo-first (без реального биржевого вызова)
+- `apiKey` хранится plain text (deferred production improvement)
+
+## 8) Deviations
+
+Нет отклонений от Stage 9a scope.
+
+Одно архитектурное решение задокументировано явно:
+- `/terminal/ticker` и `/terminal/candles` — **authenticated, not workspace-scoped**
+  (поскольку market data публично, workspace enforcement был бы избыточным coupling'ом).
+  Это явно описано в разделе 3 и соответствует архитектуре проекта.


### PR DESCRIPTION
## Summary

- **New:** `GET /terminal/ticker?symbol=...` — live ticker (lastPrice, bid/ask, 24h stats); authenticated, no workspace
- **New:** `GET /terminal/candles?symbol=...&interval=...&limit=...` — OHLCV candles; authenticated, no workspace
- **Extended:** `fetchTicker()` added to `bybitCandles.ts` (Bybit /v5/market/tickers)
- **UI:** Terminal page replaced from placeholder → working market data view (symbol/interval selector, ticker grid, candles table with loading/error/success states)
- **OpenAPI:** `Ticker` + `Candle` schemas + two new path entries
- **Docs:** `docs/steps/09a-stage-9a-terminal-market-data.md` with handover for Stage 9b

## Security

Endpoints are **authenticated (JWT) but not workspace-scoped** — Bybit market data is public. Stage 9b orders will be workspace-scoped (ExchangeConnection).

## Error handling

| Scenario | Status |
|---|---|
| Missing symbol | 400 |
| Invalid interval | 400 |
| Invalid limit | 400 |
| Unknown symbol | 422 |
| Bybit upstream error | 502 |
| No JWT | 401 |

## Scope (Stage 9a only)

- No orders (Stage 9b)
- No SL/TP
- No WebSocket
- No charts (table only)

https://claude.ai/code/session_01LAnFKVySmygJghUAW6JN59