### PR TITLE
fix(smoke): replace grep -c false-positive with grep -q in secret-leak check

### DIFF
--- a/deploy/smoke-test.sh
+++ b/deploy/smoke-test.sh
@@ -304,8 +304,7 @@ DAILY=$(curl -s -o /dev/null -w "%{http_code}" \
 check "GET /terminal/candles interval=D → 200" "200" "$DAILY"
 
 # 9.11 no secrets leaked in ticker response
-SECRET_COUNT=$(echo "$TICKER_RESP" | grep -c "encryptedSecret\|\"secret\"\|\"apiKey\"" || echo "0")
-if [[ "$SECRET_COUNT" == "0" ]]; then
+if ! echo "$TICKER_RESP" | grep -q "encryptedSecret\|\"secret\"\|\"apiKey\""; then
   green "/terminal/ticker → no secret fields in response"
   ((++PASS))
 else


### PR DESCRIPTION
## Summary
- `grep -c ... || echo "0"` давал `"0\n0"` вместо `"0"` когда совпадений нет — тест 9.11 всегда падал с false-positive
- Заменено на `if ! grep -q` — корректно и проще

## Обнаружено
При деплое Stage 9b на VPS (hotfix `cc8da20`), теперь синхронизировано в ветку

## Test plan
- [x] smoke-test.sh 34/34 на VPS после применения fix

https://claude.ai/code/session_01LAnFKVySmygJghUAW6JN59