### PR TITLE
feat(stage-11): Bot Factory Launch Flow

### DIFF
--- a/apps/web/src/app/factory/bots/[id]/page.tsx
+++ b/apps/web/src/app/factory/bots/[id]/page.tsx
@@ -5,12 +5,18 @@ import { useParams } from "next/navigation";
 import Link from "next/link";
 import { apiFetch, getWorkspaceId, type ProblemDetails } from "../../api";
 
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
 interface BotRun {
   id: string;
   state: string;
+  symbol: string;
   startedAt: string | null;
   stoppedAt: string | null;
   errorCode: string | null;
+  durationMinutes: number | null;
   createdAt: string;
 }
 
@@ -20,6 +26,7 @@ interface BotDetail {
   symbol: string;
   timeframe: string;
   status: string;
+  exchangeConnectionId: string | null;
   strategyVersion: {
     id: string;
     version: number;
@@ -35,16 +42,26 @@ interface BotEvent {
   payloadJson: Record<string, unknown>;
 }
 
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
 export default function BotDetailPage() {
   const { id: botId } = useParams<{ id: string }>();
   const [bot, setBot] = useState<BotDetail | null>(null);
   const [events, setEvents] = useState<BotEvent[]>([]);
+  const [runs, setRuns] = useState<BotRun[]>([]);
   const [error, setError] = useState<ProblemDetails | null>(null);
   const [polling, setPolling] = useState(false);
+  const [durationMinutes, setDurationMinutes] = useState("");
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
+  // ---------------------------------------------------------------------------
+  // Loaders
+  // ---------------------------------------------------------------------------
+
   const loadBot = useCallback(async () => {
-    if (!getWorkspaceId()) return;
+    if (!getWorkspaceId()) return null;
     const res = await apiFetch<BotDetail>(`/bots/${botId}`);
     if (res.ok) {
       setBot(res.data);
@@ -61,21 +78,27 @@ export default function BotDetailPage() {
     if (res.ok) setEvents(res.data);
   }, []);
 
+  const loadRuns = useCallback(async () => {
+    if (!getWorkspaceId()) return;
+    const res = await apiFetch<BotRun[]>(`/bots/${botId}/runs?limit=10`);
+    if (res.ok) setRuns(res.data);
+  }, [botId]);
+
   // Initial load
   useEffect(() => {
     loadBot().then((b) => {
       if (b?.lastRun) loadEvents(b.lastRun.id);
     });
-  }, [loadBot, loadEvents]);
+    loadRuns();
+  }, [loadBot, loadEvents, loadRuns]);
 
-  // Polling
+  // Polling loop — refreshes bot state and events every 2s while active
   useEffect(() => {
     if (polling && bot?.lastRun) {
-      const runId = bot.lastRun.id;
       intervalRef.current = setInterval(async () => {
         const b = await loadBot();
         if (b?.lastRun) await loadEvents(b.lastRun.id);
-        // Auto-stop polling if run is terminal
+        await loadRuns();
         if (b?.lastRun && ["STOPPED", "FAILED", "TIMED_OUT"].includes(b.lastRun.state)) {
           setPolling(false);
         }
@@ -84,15 +107,27 @@ export default function BotDetailPage() {
     return () => {
       if (intervalRef.current) clearInterval(intervalRef.current);
     };
-  }, [polling, bot?.lastRun?.id, loadBot, loadEvents]);
+  }, [polling, bot?.lastRun?.id, loadBot, loadEvents, loadRuns]);
+
+  // ---------------------------------------------------------------------------
+  // Actions
+  // ---------------------------------------------------------------------------
 
   async function startRun() {
     setError(null);
-    const res = await apiFetch<BotRun>(`/bots/${botId}/runs`, { method: "POST" });
+    const body: Record<string, unknown> = {};
+    const dur = parseInt(durationMinutes, 10);
+    if (!isNaN(dur) && dur >= 1) body.durationMinutes = dur;
+
+    const res = await apiFetch<BotRun>(`/bots/${botId}/runs`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
     if (res.ok) {
       await loadBot().then((b) => {
         if (b?.lastRun) loadEvents(b.lastRun.id);
       });
+      await loadRuns();
       setPolling(true);
     } else {
       setError(res.problem);
@@ -108,10 +143,15 @@ export default function BotDetailPage() {
       await loadBot().then((b) => {
         if (b?.lastRun) loadEvents(b.lastRun.id);
       });
+      await loadRuns();
     } else {
       setError((res as { ok: false; problem: ProblemDetails }).problem);
     }
   }
+
+  // ---------------------------------------------------------------------------
+  // Guards
+  // ---------------------------------------------------------------------------
 
   if (!getWorkspaceId()) {
     return (
@@ -124,8 +164,12 @@ export default function BotDetailPage() {
   const lastRun = bot?.lastRun;
   const isActive = lastRun && !["STOPPED", "FAILED", "TIMED_OUT"].includes(lastRun.state);
 
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
   return (
-    <div style={{ padding: "48px 24px", maxWidth: 800, margin: "0 auto" }}>
+    <div style={{ padding: "48px 24px", maxWidth: 860, margin: "0 auto" }}>
       <p style={{ marginBottom: 16 }}>
         <Link href="/factory/bots">← Bots</Link>
       </p>
@@ -134,46 +178,80 @@ export default function BotDetailPage() {
 
       {bot && (
         <>
-          <h1 style={{ fontSize: 24, marginBottom: 8 }}>{bot.name}</h1>
+          {/* ── Bot header ─────────────────────────────────── */}
+          <h1 style={{ fontSize: 24, marginBottom: 6 }}>{bot.name}</h1>
           <p style={{ color: "var(--text-secondary)", marginBottom: 4 }}>
             {bot.symbol} · {bot.timeframe} · {bot.status}
           </p>
-          <p style={{ color: "var(--text-secondary)", marginBottom: 24, fontSize: 13 }}>
-            Strategy: <strong>{bot.strategyVersion.strategy.name}</strong> v{bot.strategyVersion.version}
+          <p style={{ color: "var(--text-secondary)", marginBottom: 4, fontSize: 13 }}>
+            Strategy:{" "}
+            <Link href={`/factory/strategies/${bot.strategyVersion.strategy.id}`}>
+              <strong>{bot.strategyVersion.strategy.name}</strong>
+            </Link>{" "}
+            v{bot.strategyVersion.version}
           </p>
+          {bot.exchangeConnectionId && (
+            <p style={{ color: "var(--text-secondary)", marginBottom: 4, fontSize: 13 }}>
+              Exchange Connection:{" "}
+              <code style={{ fontSize: 12 }}>{bot.exchangeConnectionId}</code>
+            </p>
+          )}
 
-          {/* Run controls */}
-          <div style={{ ...card, display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
-            <button style={btn} onClick={startRun} disabled={!!isActive}>
-              Start Run
-            </button>
-            <button style={btnDanger} onClick={stopRun} disabled={!isActive}>
-              Stop Run
-            </button>
-            <button style={btnSecondary} onClick={() => setPolling((p) => !p)}>
-              {polling ? "Stop Polling" : "Start Polling"}
-            </button>
-            <button
-              style={btnSecondary}
-              onClick={() => {
-                loadBot().then((b) => {
-                  if (b?.lastRun) loadEvents(b.lastRun.id);
-                });
-              }}
-            >
-              Refresh
-            </button>
-            {lastRun && (
-              <span style={{ color: "var(--text-secondary)", fontSize: 13 }}>
-                Last run: <strong>{lastRun.state}</strong>{" "}
-                {lastRun.errorCode && `(${lastRun.errorCode})`}
+          {/* ── Run controls ───────────────────────────────── */}
+          <div style={{ ...card, marginTop: 20 }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+              <button style={btn} onClick={startRun} disabled={!!isActive}>
+                Start Run
+              </button>
+              <button style={btnDanger} onClick={stopRun} disabled={!isActive}>
+                Stop Run
+              </button>
+              <button style={btnSecondary} onClick={() => setPolling((p) => !p)}>
+                {polling ? "Stop Polling" : "Start Polling"}
+              </button>
+              <button
+                style={btnSecondary}
+                onClick={() => {
+                  loadBot().then((b) => { if (b?.lastRun) loadEvents(b.lastRun.id); });
+                  loadRuns();
+                }}
+              >
+                Refresh
+              </button>
+              {lastRun && (
+                <span style={{ color: "var(--text-secondary)", fontSize: 13 }}>
+                  Last run:{" "}
+                  <strong style={{ color: stateColor(lastRun.state) }}>{lastRun.state}</strong>
+                  {lastRun.errorCode && ` (${lastRun.errorCode})`}
+                  {lastRun.durationMinutes != null && ` · limit ${lastRun.durationMinutes}min`}
+                </span>
+              )}
+              {polling && <span style={{ fontSize: 12, color: "#3fb950" }}>● polling</span>}
+            </div>
+
+            {/* durationMinutes input for next run */}
+            <div style={{ marginTop: 12, display: "flex", alignItems: "center", gap: 8 }}>
+              <label style={{ fontSize: 13, color: "var(--text-secondary)" }}>
+                Run limit (min):
+              </label>
+              <input
+                style={{ ...input, width: 80 }}
+                type="number"
+                min="1"
+                max="1440"
+                placeholder="∞"
+                value={durationMinutes}
+                onChange={(e) => setDurationMinutes(e.target.value)}
+                disabled={!!isActive}
+              />
+              <span style={{ fontSize: 12, color: "var(--text-secondary)" }}>
+                leave blank for server default (4 h)
               </span>
-            )}
-            {polling && <span style={{ fontSize: 12, color: "#3fb950" }}>● polling</span>}
+            </div>
           </div>
 
-          {/* Events log */}
-          <h3 style={{ marginTop: 24, marginBottom: 12 }}>Events</h3>
+          {/* ── Events log ─────────────────────────────────── */}
+          <h3 style={{ marginTop: 28, marginBottom: 10 }}>Events (last run)</h3>
           {events.length > 0 ? (
             <table style={{ width: "100%", borderCollapse: "collapse" }}>
               <thead>
@@ -190,7 +268,7 @@ export default function BotDetailPage() {
                       {new Date(ev.ts).toLocaleTimeString()}
                     </td>
                     <td style={{ ...td, fontWeight: 600 }}>{ev.type}</td>
-                    <td style={{ ...td, fontFamily: "monospace", fontSize: 12 }}>
+                    <td style={{ ...td, fontFamily: "monospace", fontSize: 11, wordBreak: "break-all" }}>
                       {JSON.stringify(ev.payloadJson)}
                     </td>
                   </tr>
@@ -202,10 +280,68 @@ export default function BotDetailPage() {
               {lastRun ? "No events yet" : "No runs yet — click Start Run"}
             </p>
           )}
+
+          {/* ── Run history ────────────────────────────────── */}
+          <h3 style={{ marginTop: 28, marginBottom: 10 }}>
+            Run History{" "}
+            <span style={{ fontSize: 12, color: "var(--text-secondary)" }}>
+              (click row to load events)
+            </span>
+          </h3>
+          {runs.length > 0 ? (
+            <table style={{ width: "100%", borderCollapse: "collapse" }}>
+              <thead>
+                <tr>
+                  {["State", "Started", "Stopped", "Limit", "Error"].map((h) => (
+                    <th key={h} style={th}>{h}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {runs.map((r) => (
+                  <tr
+                    key={r.id}
+                    style={{ cursor: "pointer" }}
+                    onClick={() => loadEvents(r.id)}
+                    title="Click to load events for this run"
+                  >
+                    <td style={td}>
+                      <span style={{ fontWeight: 600, color: stateColor(r.state) }}>{r.state}</span>
+                    </td>
+                    <td style={{ ...td, fontSize: 12 }}>
+                      {r.startedAt ? new Date(r.startedAt).toLocaleTimeString() : "—"}
+                    </td>
+                    <td style={{ ...td, fontSize: 12 }}>
+                      {r.stoppedAt ? new Date(r.stoppedAt).toLocaleTimeString() : "—"}
+                    </td>
+                    <td style={td}>
+                      {r.durationMinutes != null ? `${r.durationMinutes}min` : "—"}
+                    </td>
+                    <td style={{ ...td, fontSize: 12, color: "#f85149" }}>
+                      {r.errorCode ?? "—"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : (
+            <p style={{ color: "var(--text-secondary)" }}>No run history yet</p>
+          )}
         </>
       )}
     </div>
   );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers + sub-components
+// ---------------------------------------------------------------------------
+
+function stateColor(state: string): string {
+  if (["STOPPED", "TIMED_OUT"].includes(state)) return "var(--text-secondary)";
+  if (state === "FAILED") return "#f85149";
+  if (state === "RUNNING") return "#3fb950";
+  return "var(--text-primary)";
 }
 
 function ErrorBox({ problem }: { problem: ProblemDetails }) {
@@ -217,8 +353,9 @@ function ErrorBox({ problem }: { problem: ProblemDetails }) {
 }
 
 const card: React.CSSProperties = { background: "var(--bg-card)", border: "1px solid var(--border)", borderRadius: 8, padding: 16 };
+const input: React.CSSProperties = { padding: "6px 10px", background: "var(--bg-secondary)", border: "1px solid var(--border)", borderRadius: 6, color: "var(--text-primary)", fontSize: 14 };
 const btn: React.CSSProperties = { padding: "8px 16px", background: "var(--accent)", color: "#fff", border: "none", borderRadius: 6, cursor: "pointer", fontSize: 14 };
 const btnDanger: React.CSSProperties = { ...btn, background: "#da3633" };
-const btnSecondary: React.CSSProperties = { ...btn, background: "var(--bg-secondary)", border: "1px solid var(--border)" };
+const btnSecondary: React.CSSProperties = { ...btn, background: "var(--bg-secondary)", border: "1px solid var(--border)", color: "var(--text-primary)" };
 const th: React.CSSProperties = { textAlign: "left", padding: "8px 12px", borderBottom: "1px solid var(--border)", color: "var(--text-secondary)", fontSize: 13 };
 const td: React.CSSProperties = { padding: "8px 12px", borderBottom: "1px solid var(--border)", fontSize: 14 };

--- a/apps/web/src/app/factory/bots/page.tsx
+++ b/apps/web/src/app/factory/bots/page.tsx
@@ -4,6 +4,32 @@ import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { apiFetch, getWorkspaceId, type ProblemDetails } from "../api";
 
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface StrategyVersion {
+  id: string;
+  version: number;
+  dslJson: { market?: { symbol?: string }; entry?: { side?: string }; execution?: { orderType?: string } };
+}
+
+interface StrategyWithVersions {
+  id: string;
+  name: string;
+  symbol: string;
+  timeframe: string;
+  status: string;
+  versions: StrategyVersion[];
+}
+
+interface ExchangeConnection {
+  id: string;
+  name: string;
+  exchange: string;
+  status: string;
+}
+
 interface Bot {
   id: string;
   name: string;
@@ -11,20 +37,44 @@ interface Bot {
   timeframe: string;
   status: string;
   strategyVersionId: string;
+  exchangeConnectionId: string | null;
   updatedAt: string;
 }
 
 const TIMEFRAMES = ["M1", "M5", "M15", "H1"];
 
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
 export default function BotsPage() {
   const [bots, setBots] = useState<Bot[]>([]);
   const [error, setError] = useState<ProblemDetails | null>(null);
-  const [name, setName] = useState("");
-  const [svId, setSvId] = useState("");
-  const [symbol, setSymbol] = useState("BTCUSDT");
-  const [timeframe, setTimeframe] = useState("H1");
 
-  const load = useCallback(async () => {
+  // form state
+  const [name, setName] = useState("");
+  const [timeframe, setTimeframe] = useState("M15");
+
+  // strategy / version selection
+  const [strategies, setStrategies] = useState<StrategyWithVersions[]>([]);
+  const [selectedStratId, setSelectedStratId] = useState("");
+  const [selectedVerId, setSelectedVerId] = useState("");
+
+  // exchange connection selection (optional)
+  const [exchanges, setExchanges] = useState<ExchangeConnection[]>([]);
+  const [selectedExchangeId, setSelectedExchangeId] = useState("");
+
+  // derived symbol from selected version DSL
+  const [symbol, setSymbol] = useState("BTCUSDT");
+
+  // loading state
+  const [loadingVersions, setLoadingVersions] = useState(false);
+
+  // ---------------------------------------------------------------------------
+  // Loaders
+  // ---------------------------------------------------------------------------
+
+  const loadBots = useCallback(async () => {
     if (!getWorkspaceId()) return;
     const res = await apiFetch<Bot[]>("/bots");
     if (res.ok) {
@@ -35,25 +85,98 @@ export default function BotsPage() {
     }
   }, []);
 
+  const loadExchanges = useCallback(async () => {
+    if (!getWorkspaceId()) return;
+    const res = await apiFetch<ExchangeConnection[]>("/exchanges");
+    if (res.ok) setExchanges(res.data);
+  }, []);
+
+  const loadStrategies = useCallback(async () => {
+    if (!getWorkspaceId()) return;
+    const res = await apiFetch<{ id: string; name: string; symbol: string; timeframe: string; status: string }[]>("/strategies");
+    if (res.ok) {
+      setStrategies(res.data.map((s) => ({ ...s, versions: [] })));
+    }
+  }, []);
+
   useEffect(() => {
-    load();
-  }, [load]);
+    loadBots();
+    loadExchanges();
+    loadStrategies();
+  }, [loadBots, loadExchanges, loadStrategies]);
+
+  // ---------------------------------------------------------------------------
+  // Strategy selection → load its versions
+  // ---------------------------------------------------------------------------
+
+  async function onStrategyChange(stratId: string) {
+    setSelectedStratId(stratId);
+    setSelectedVerId("");
+    setSymbol("BTCUSDT");
+    if (!stratId) return;
+
+    setLoadingVersions(true);
+    const res = await apiFetch<StrategyWithVersions>(`/strategies/${stratId}`);
+    setLoadingVersions(false);
+    if (res.ok) {
+      const sv = res.data;
+      setStrategies((prev) =>
+        prev.map((s) => (s.id === stratId ? { ...s, versions: sv.versions } : s))
+      );
+      // auto-select the latest version (first in desc order)
+      const latest = sv.versions[0];
+      if (latest) {
+        setSelectedVerId(latest.id);
+        const sym = latest.dslJson?.market?.symbol;
+        if (sym) setSymbol(sym);
+      }
+    }
+  }
+
+  function onVersionChange(verId: string) {
+    setSelectedVerId(verId);
+    const strat = strategies.find((s) => s.id === selectedStratId);
+    const ver = strat?.versions.find((v) => v.id === verId);
+    const sym = ver?.dslJson?.market?.symbol;
+    if (sym) setSymbol(sym);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Create bot
+  // ---------------------------------------------------------------------------
 
   async function create(e: React.FormEvent) {
     e.preventDefault();
+    setError(null);
+
+    const body: Record<string, unknown> = {
+      name,
+      strategyVersionId: selectedVerId,
+      symbol,
+      timeframe,
+    };
+    if (selectedExchangeId) body.exchangeConnectionId = selectedExchangeId;
+
     const res = await apiFetch<Bot>("/bots", {
       method: "POST",
-      body: JSON.stringify({ name, strategyVersionId: svId, symbol, timeframe }),
+      body: JSON.stringify(body),
     });
     if (res.ok) {
       setName("");
-      setSvId("");
+      setSelectedStratId("");
+      setSelectedVerId("");
+      setSelectedExchangeId("");
+      setSymbol("BTCUSDT");
       setError(null);
-      load();
+      loadBots();
     } else {
       setError(res.problem);
     }
   }
+
+  // ---------------------------------------------------------------------------
+  // Guards
+  // ---------------------------------------------------------------------------
 
   if (!getWorkspaceId()) {
     return (
@@ -63,31 +186,128 @@ export default function BotsPage() {
     );
   }
 
+  const selectedStrat = strategies.find((s) => s.id === selectedStratId);
+  const versions = selectedStrat?.versions ?? [];
+  const selectedVer = versions.find((v) => v.id === selectedVerId);
+  const dslSummary = selectedVer
+    ? `${selectedVer.dslJson?.entry?.side ?? ""} · ${selectedVer.dslJson?.execution?.orderType ?? ""}`
+    : null;
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
   return (
-    <div style={{ padding: "48px 24px", maxWidth: 800, margin: "0 auto" }}>
+    <div style={{ padding: "48px 24px", maxWidth: 860, margin: "0 auto" }}>
+      <p style={{ marginBottom: 16 }}>
+        <Link href="/factory">← Factory</Link>
+      </p>
       <h1 style={{ fontSize: 24, marginBottom: 24 }}>Bots</h1>
 
       {error && <ErrorBox problem={error} />}
 
+      {/* ── Create bot form ─────────────────────────────────── */}
       <form onSubmit={create} style={card}>
-        <h3 style={{ marginBottom: 12 }}>Create Bot</h3>
-        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-          <input style={input} placeholder="Name" value={name} onChange={(e) => setName(e.target.value)} required />
-          <input style={{ ...input, flex: 2 }} placeholder="Strategy Version ID" value={svId} onChange={(e) => setSvId(e.target.value)} required />
-          <input style={{ ...input, width: 120 }} placeholder="Symbol" value={symbol} onChange={(e) => setSymbol(e.target.value)} required />
+        <h3 style={{ marginBottom: 14 }}>Create Bot</h3>
+
+        {/* Row 1: Name + Timeframe */}
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 10 }}>
+          <input
+            style={{ ...input, flex: 2 }}
+            placeholder="Bot name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+          />
           <select style={input} value={timeframe} onChange={(e) => setTimeframe(e.target.value)}>
-            {TIMEFRAMES.map((t) => (
-              <option key={t} value={t}>{t}</option>
+            {TIMEFRAMES.map((t) => <option key={t} value={t}>{t}</option>)}
+          </select>
+        </div>
+
+        {/* Row 2: Strategy selector */}
+        <div style={{ marginBottom: 10 }}>
+          <label style={labelStyle}>Strategy</label>
+          <select
+            style={{ ...input, width: "100%" }}
+            value={selectedStratId}
+            onChange={(e) => onStrategyChange(e.target.value)}
+            required
+          >
+            <option value="">— select strategy —</option>
+            {strategies.map((s) => (
+              <option key={s.id} value={s.id}>{s.name} ({s.symbol})</option>
             ))}
           </select>
-          <button style={btn} type="submit">Create</button>
+        </div>
+
+        {/* Row 3: Version selector (shown after strategy selected) */}
+        {selectedStratId && (
+          <div style={{ marginBottom: 10 }}>
+            <label style={labelStyle}>
+              Strategy Version{" "}
+              {loadingVersions && <span style={{ color: "var(--text-secondary)", fontSize: 12 }}>loading…</span>}
+            </label>
+            <select
+              style={{ ...input, width: "100%" }}
+              value={selectedVerId}
+              onChange={(e) => onVersionChange(e.target.value)}
+              required
+            >
+              <option value="">— select version —</option>
+              {versions.map((v) => (
+                <option key={v.id} value={v.id}>
+                  v{v.version} · {v.dslJson?.market?.symbol ?? ""} · {v.dslJson?.entry?.side ?? ""} · {v.dslJson?.execution?.orderType ?? ""}
+                </option>
+              ))}
+            </select>
+            {dslSummary && selectedVer && (
+              <p style={{ fontSize: 12, color: "var(--text-secondary)", marginTop: 4 }}>
+                Symbol: <strong>{selectedVer.dslJson?.market?.symbol}</strong> · {dslSummary}
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* Row 4: Exchange Connection (optional) */}
+        <div style={{ marginBottom: 10 }}>
+          <label style={labelStyle}>
+            Exchange Connection <span style={{ color: "var(--text-secondary)", fontSize: 12 }}>(optional)</span>
+          </label>
+          <select
+            style={{ ...input, width: "100%" }}
+            value={selectedExchangeId}
+            onChange={(e) => setSelectedExchangeId(e.target.value)}
+          >
+            <option value="">— none —</option>
+            {exchanges.map((ex) => (
+              <option key={ex.id} value={ex.id}>{ex.name} ({ex.exchange} · {ex.status})</option>
+            ))}
+          </select>
+        </div>
+
+        {/* Row 5: Symbol (auto-filled from DSL, editable) + Submit */}
+        <div style={{ display: "flex", gap: 8, alignItems: "flex-end" }}>
+          <div style={{ flex: 1 }}>
+            <label style={labelStyle}>Symbol</label>
+            <input
+              style={{ ...input, width: "100%" }}
+              placeholder="BTCUSDT"
+              value={symbol}
+              onChange={(e) => setSymbol(e.target.value)}
+              required
+            />
+          </div>
+          <button style={btn} type="submit">
+            Create Bot
+          </button>
         </div>
       </form>
 
+      {/* ── Bots list ──────────────────────────────────────── */}
       <table style={{ width: "100%", marginTop: 24, borderCollapse: "collapse" }}>
         <thead>
           <tr>
-            {["Name", "Symbol", "TF", "Status", "Updated"].map((h) => (
+            {["Name", "Symbol", "TF", "Status", "Exchange", "Updated"].map((h) => (
               <th key={h} style={th}>{h}</th>
             ))}
           </tr>
@@ -101,12 +321,13 @@ export default function BotsPage() {
               <td style={td}>{b.symbol}</td>
               <td style={td}>{b.timeframe}</td>
               <td style={td}>{b.status}</td>
+              <td style={td}>{b.exchangeConnectionId ? "✓" : "—"}</td>
               <td style={td}>{new Date(b.updatedAt).toLocaleString()}</td>
             </tr>
           ))}
           {bots.length === 0 && (
             <tr>
-              <td colSpan={5} style={{ ...td, color: "var(--text-secondary)" }}>No bots yet</td>
+              <td colSpan={6} style={{ ...td, color: "var(--text-secondary)" }}>No bots yet</td>
             </tr>
           )}
         </tbody>
@@ -114,6 +335,10 @@ export default function BotsPage() {
     </div>
   );
 }
+
+// ---------------------------------------------------------------------------
+// Sub-components + styles
+// ---------------------------------------------------------------------------
 
 function ErrorBox({ problem }: { problem: ProblemDetails }) {
   return (
@@ -126,8 +351,9 @@ function ErrorBox({ problem }: { problem: ProblemDetails }) {
   );
 }
 
-const card: React.CSSProperties = { background: "var(--bg-card)", border: "1px solid var(--border)", borderRadius: 8, padding: 16 };
+const card: React.CSSProperties = { background: "var(--bg-card)", border: "1px solid var(--border)", borderRadius: 8, padding: 16, marginBottom: 8 };
 const input: React.CSSProperties = { padding: "8px 12px", background: "var(--bg-secondary)", border: "1px solid var(--border)", borderRadius: 6, color: "var(--text-primary)", fontSize: 14 };
 const btn: React.CSSProperties = { padding: "8px 16px", background: "var(--accent)", color: "#fff", border: "none", borderRadius: 6, cursor: "pointer", fontSize: 14 };
 const th: React.CSSProperties = { textAlign: "left", padding: "8px 12px", borderBottom: "1px solid var(--border)", color: "var(--text-secondary)", fontSize: 13 };
 const td: React.CSSProperties = { padding: "8px 12px", borderBottom: "1px solid var(--border)", fontSize: 14 };
+const labelStyle: React.CSSProperties = { display: "block", fontSize: 12, color: "var(--text-secondary)", marginBottom: 4 };

--- a/apps/web/src/app/factory/page.tsx
+++ b/apps/web/src/app/factory/page.tsx
@@ -118,11 +118,22 @@ export default function FactoryPage() {
       if (!stratRes.ok) throw stratRes.problem;
       const strategyId = stratRes.data.id;
 
-      // C) Create strategy version
+      // C) Create strategy version (valid Stage-10 DSL v1)
       setDemoStatus("Creating strategy version...");
+      const demoDsl = {
+        id: `${strategyId}-v1`,
+        name: strategyName,
+        dslVersion: 1,
+        enabled: true,
+        market: { exchange: "bybit", env: "demo", category: "linear", symbol: "BTCUSDT" },
+        entry: { side: "Buy", signal: "manual" },
+        risk: { maxPositionSizeUsd: 100, riskPerTradePct: 1, cooldownSeconds: 60 },
+        execution: { orderType: "Market", clientOrderIdPrefix: "demobot" },
+        guards: { maxOpenPositions: 1, maxOrdersPerMinute: 10, pauseOnError: true },
+      };
       const verRes = await apiFetch<StrategyVersion>(`/strategies/${strategyId}/versions`, {
         method: "POST",
-        body: JSON.stringify({ dslJson: { kind: "demo", entry: { type: "market" } } }),
+        body: JSON.stringify({ dslJson: demoDsl }),
       });
       if (!verRes.ok) throw verRes.problem;
       const versionId = verRes.data.id;

--- a/deploy/smoke-test.sh
+++ b/deploy/smoke-test.sh
@@ -533,6 +533,216 @@ else
   ((++FAIL))
 fi
 
+# ─── 11. Stage 11 — Bot Factory Launch Flow ─────────────────────────────────
+header "11. Stage 11 — Bot Factory Launch Flow"
+
+# Reuse fixtures from Section 10 ($S10_VER_ID, $S10_BOT_ID, $S10_RUN_ID)
+
+# 11.1 GET /bots/:id → 200 + strategyVersion nested
+if [[ -n "$S10_BOT_ID" ]]; then
+  BOT_DETAIL=$(curl -s "$BASE_URL/api/v1/bots/$S10_BOT_ID" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "X-Workspace-Id: $WS_ID")
+  BOT_DETAIL_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/api/v1/bots/$S10_BOT_ID" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "X-Workspace-Id: $WS_ID")
+  check "GET /bots/:id → 200" "200" "$BOT_DETAIL_CODE"
+  check_contains "GET /bots/:id → strategyVersion present" '"strategyVersion"' "$BOT_DETAIL"
+  check_contains "GET /bots/:id → lastRun field present" '"lastRun"' "$BOT_DETAIL"
+else
+  red "Skipping GET /bots/:id (no bot ID from Section 10)"
+  ((++FAIL)); ((++FAIL)); ((++FAIL))
+fi
+
+# 11.2 GET /runs/:runId/events → 200 + events array
+if [[ -n "$S10_RUN_ID" ]]; then
+  EVT_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/api/v1/runs/$S10_RUN_ID/events" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "X-Workspace-Id: $WS_ID")
+  EVT_RESP=$(curl -s "$BASE_URL/api/v1/runs/$S10_RUN_ID/events" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "X-Workspace-Id: $WS_ID")
+  check "GET /runs/:runId/events → 200" "200" "$EVT_CODE"
+  # Should have at least RUN_CREATED event
+  if echo "$EVT_RESP" | grep -q '"type"'; then
+    green "GET /runs/:runId/events → events returned"
+    ((++PASS))
+  else
+    check_contains "GET /runs/:runId/events → array" '[' "$EVT_RESP"
+  fi
+  # No secrets in event log
+  if ! echo "$EVT_RESP" | grep -q '"encryptedSecret"\|"apiKey"\|"secret"'; then
+    green "GET /runs/:runId/events → no secrets in payload"
+    ((++PASS))
+  else
+    red "GET /runs/:runId/events → secret field found in events!"
+    ((++FAIL))
+  fi
+else
+  red "Skipping GET /runs/:runId/events (no run ID)"
+  ((++FAIL)); ((++FAIL)); ((++FAIL))
+fi
+
+# 11.3 GET /runs/:runId/events without auth → 401
+if [[ -n "$S10_RUN_ID" ]]; then
+  EVT_UNAUTH=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/api/v1/runs/$S10_RUN_ID/events")
+  check "GET /runs/:runId/events without auth → 401" "401" "$EVT_UNAUTH"
+else
+  red "Skipping events unauth test (no run ID)"
+  ((++FAIL))
+fi
+
+# 11.4 POST /bots/:id/runs/:runId/stop
+# Create a second bot for stop test so we don't collide with active run from Section 10
+if [[ -n "$S10_VER_ID" ]]; then
+  STOP_BOT=$(curl -s -X POST "$BASE_URL/api/v1/bots" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    -H "X-Workspace-Id: $WS_ID" \
+    -d "{\"name\":\"Stage11StopBot\",\"strategyVersionId\":\"$S10_VER_ID\",\"symbol\":\"BTCUSDT\",\"timeframe\":\"M15\"}")
+  STOP_BOT_ID=$(echo "$STOP_BOT" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4) || true
+
+  if [[ -n "$STOP_BOT_ID" ]]; then
+    # Start a run
+    STOP_RUN=$(curl -s -X POST "$BASE_URL/api/v1/bots/$STOP_BOT_ID/runs" \
+      -H "Authorization: Bearer $TOKEN" \
+      -H "Content-Type: application/json" \
+      -H "X-Workspace-Id: $WS_ID" \
+      -d '{"durationMinutes":60}')
+    STOP_RUN_ID=$(echo "$STOP_RUN" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4) || true
+
+    if [[ -n "$STOP_RUN_ID" ]]; then
+      # Stop it
+      STOP_RESP=$(curl -s -X POST "$BASE_URL/api/v1/bots/$STOP_BOT_ID/runs/$STOP_RUN_ID/stop" \
+        -H "Authorization: Bearer $TOKEN" \
+        -H "Content-Type: application/json" \
+        -H "X-Workspace-Id: $WS_ID")
+      STOP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+        "$BASE_URL/api/v1/bots/$STOP_BOT_ID/runs/$STOP_RUN_ID/stop" \
+        -H "Authorization: Bearer $TOKEN" \
+        -H "Content-Type: application/json" \
+        -H "X-Workspace-Id: $WS_ID")
+      # 200 = stopped, 409 = already terminal (if worker already terminated it)
+      if [[ "$STOP_CODE" == "200" ]] || [[ "$STOP_CODE" == "409" ]]; then
+        green "POST /bots/:id/runs/:runId/stop → $STOP_CODE (expected 200 or 409)"
+        ((++PASS))
+      else
+        red "POST /bots/:id/runs/:runId/stop → $STOP_CODE (expected 200 or 409)"
+        ((++FAIL))
+      fi
+      # Verify response has state field
+      check_contains "POST .../stop → state field" '"state"' "$STOP_RESP"
+    else
+      red "Skipping stop test (failed to start run for stop bot)"
+      ((++FAIL)); ((++FAIL))
+    fi
+  else
+    red "Skipping stop test (failed to create stop bot)"
+    ((++FAIL)); ((++FAIL))
+  fi
+else
+  red "Skipping stop test (no strategy version ID)"
+  ((++FAIL)); ((++FAIL))
+fi
+
+# 11.5 Cross-workspace: bot from other workspace → 403
+if [[ -n "$S10_BOT_ID" ]]; then
+  REG2=$(curl -s -X POST "$BASE_URL/api/v1/auth/register" \
+    -H "Content-Type: application/json" \
+    -d '{"email":"s11_xws_'"$(date +%s)"'@test.com","password":"Test1234!"}')
+  TOKEN2=$(echo "$REG2" | grep -o '"accessToken":"[^"]*"' | cut -d'"' -f4) || true
+  WS_ID2=$(echo "$REG2" | grep -o '"workspaceId":"[^"]*"' | cut -d'"' -f4) || true
+
+  if [[ -n "$TOKEN2" && -n "$WS_ID2" ]]; then
+    # Try to access bot from workspace 1 using workspace 2's token+wsId
+    XWS_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/api/v1/bots/$S10_BOT_ID" \
+      -H "Authorization: Bearer $TOKEN2" \
+      -H "X-Workspace-Id: $WS_ID2")
+    # Accept 404 (workspace isolation hides the resource) or 403
+    if [[ "$XWS_CODE" == "404" ]] || [[ "$XWS_CODE" == "403" ]]; then
+      green "GET /bots/:id cross-workspace → $XWS_CODE (workspace isolated)"
+      ((++PASS))
+    else
+      red "GET /bots/:id cross-workspace → $XWS_CODE (expected 403 or 404)"
+      ((++FAIL))
+    fi
+
+    # Try to start run on bot from workspace 1 using workspace 2
+    XWS_RUN_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+      "$BASE_URL/api/v1/bots/$S10_BOT_ID/runs" \
+      -H "Authorization: Bearer $TOKEN2" \
+      -H "Content-Type: application/json" \
+      -H "X-Workspace-Id: $WS_ID2")
+    if [[ "$XWS_RUN_CODE" == "403" ]] || [[ "$XWS_RUN_CODE" == "404" ]]; then
+      green "POST /bots/:id/runs cross-workspace → $XWS_RUN_CODE (workspace isolated)"
+      ((++PASS))
+    else
+      red "POST /bots/:id/runs cross-workspace → $XWS_RUN_CODE (expected 403 or 404)"
+      ((++FAIL))
+    fi
+  else
+    red "Skipping cross-workspace test (failed to register second user)"
+    ((++FAIL)); ((++FAIL))
+  fi
+else
+  red "Skipping cross-workspace test (no bot ID)"
+  ((++FAIL)); ((++FAIL))
+fi
+
+# 11.6 POST /bots without strategyVersionId → 400
+MISSING_SVER=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE_URL/api/v1/bots" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "X-Workspace-Id: $WS_ID" \
+  -d '{"name":"NoStratBot","symbol":"BTCUSDT","timeframe":"M15"}')
+check "POST /bots without strategyVersionId → 400" "400" "$MISSING_SVER"
+
+# 11.7 POST /bots with non-existent strategyVersionId → 400
+BAD_SVER=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE_URL/api/v1/bots" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "X-Workspace-Id: $WS_ID" \
+  -d '{"name":"BadStratBot","strategyVersionId":"00000000-0000-0000-0000-000000000000","symbol":"BTCUSDT","timeframe":"M15"}')
+check "POST /bots with invalid strategyVersionId → 400" "400" "$BAD_SVER"
+
+# 11.8 GET /bots without auth → 401
+BOTS_UNAUTH=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/api/v1/bots")
+check "GET /bots without auth → 401" "401" "$BOTS_UNAUTH"
+
+# 11.9 No secrets in bot/run responses
+if [[ -n "$S10_BOT_ID" ]]; then
+  BOT_RESP=$(curl -s "$BASE_URL/api/v1/bots/$S10_BOT_ID" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "X-Workspace-Id: $WS_ID")
+  if ! echo "$BOT_RESP" | grep -q '"encryptedSecret"\|"apiKey"\|"passwordHash"'; then
+    green "GET /bots/:id → no secret fields in response"
+    ((++PASS))
+  else
+    red "GET /bots/:id → secret fields found in bot response!"
+    ((++FAIL))
+  fi
+else
+  red "Skipping secret-check test (no bot ID)"
+  ((++FAIL))
+fi
+
+# 11.10 GET /bots/:id/runs after section 10 run → array with at least 1 run
+if [[ -n "$S10_BOT_ID" ]]; then
+  RUNS_AFTER=$(curl -s "$BASE_URL/api/v1/bots/$S10_BOT_ID/runs" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "X-Workspace-Id: $WS_ID")
+  if echo "$RUNS_AFTER" | grep -q '"state"'; then
+    green "GET /bots/:id/runs → at least one run returned with state"
+    ((++PASS))
+  else
+    red "GET /bots/:id/runs → no runs found (expected at least 1 from Section 10)"
+    ((++FAIL))
+  fi
+else
+  red "Skipping runs-after test (no bot ID)"
+  ((++FAIL))
+fi
+
 # ─── Summary ─────────────────────────────────────────────────────────────────
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -68,6 +68,7 @@ paths:
 
   # ── Strategies (Stage 10 — Strategy Authoring UX) ──────────────────────────
 
+
   /strategies:
     get:
       operationId: strategiesList
@@ -214,20 +215,36 @@ paths:
         "403":
           $ref: "#/components/responses/Problem"
 
+  # ── Bots (Stage 11 — Bot Factory Launch Flow) ──────────────────────────────
+
   /bots:
     get:
       operationId: botsList
-      summary: List bots
+      summary: List bots in workspace
+      parameters:
+        - $ref: "#/components/parameters/XWorkspaceId"
       responses:
         "200":
           description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/BotView"
         "401":
           $ref: "#/components/responses/Problem"
         "403":
           $ref: "#/components/responses/Problem"
     post:
       operationId: botsCreate
-      summary: Create bot
+      summary: Create bot from strategy version
+      description: >
+        Creates a bot in DRAFT status linked to an immutable StrategyVersion snapshot.
+        Optionally links an ExchangeConnection for runtime credentials.
+        Both strategyVersionId and exchangeConnectionId (if provided) must belong to the same workspace.
+      parameters:
+        - $ref: "#/components/parameters/XWorkspaceId"
       requestBody:
         required: true
         content:
@@ -237,18 +254,25 @@ paths:
       responses:
         "201":
           description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BotView"
         "400":
           $ref: "#/components/responses/Problem"
         "401":
           $ref: "#/components/responses/Problem"
         "403":
           $ref: "#/components/responses/Problem"
+        "409":
+          $ref: "#/components/responses/Problem"
 
-  /bots/{botId}/events:
+  /bots/{botId}:
     get:
-      operationId: botEventsList
-      summary: Bot transition/event log
+      operationId: botsGet
+      summary: Get bot detail (includes strategyVersion + lastRun)
       parameters:
+        - $ref: "#/components/parameters/XWorkspaceId"
         - name: botId
           in: path
           required: true
@@ -257,10 +281,304 @@ paths:
       responses:
         "200":
           description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BotDetailView"
         "401":
+          $ref: "#/components/responses/Problem"
+        "403":
           $ref: "#/components/responses/Problem"
         "404":
           $ref: "#/components/responses/Problem"
+
+  /bots/{botId}/runs:
+    get:
+      operationId: botRunsList
+      summary: List runs for a bot (latest first, max 100)
+      parameters:
+        - $ref: "#/components/parameters/XWorkspaceId"
+        - name: botId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+        - name: state
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [CREATED, QUEUED, STARTING, SYNCING, RUNNING, STOPPING, STOPPED, FAILED, TIMED_OUT]
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/BotRunView"
+        "401":
+          $ref: "#/components/responses/Problem"
+        "403":
+          $ref: "#/components/responses/Problem"
+        "404":
+          $ref: "#/components/responses/Problem"
+    post:
+      operationId: botRunCreate
+      summary: Start a new bot run
+      description: >
+        Creates a BotRun and queues it for processing by the bot worker.
+        The worker transitions the run through QUEUED → STARTING → SYNCING → RUNNING.
+        Enforces single-active-run invariant per bot (409 if already active).
+      parameters:
+        - $ref: "#/components/parameters/XWorkspaceId"
+        - name: botId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BotRunCreateRequest"
+      responses:
+        "201":
+          description: Run created and queued
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BotRunView"
+        "400":
+          $ref: "#/components/responses/Problem"
+        "401":
+          $ref: "#/components/responses/Problem"
+        "403":
+          $ref: "#/components/responses/Problem"
+        "404":
+          $ref: "#/components/responses/Problem"
+        "409":
+          description: Active run already exists for this bot
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+
+  /bots/{botId}/runs/{runId}:
+    get:
+      operationId: botRunGet
+      summary: Get specific run for a bot
+      parameters:
+        - $ref: "#/components/parameters/XWorkspaceId"
+        - name: botId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: runId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BotRunView"
+        "401":
+          $ref: "#/components/responses/Problem"
+        "403":
+          $ref: "#/components/responses/Problem"
+        "404":
+          $ref: "#/components/responses/Problem"
+
+  /bots/{botId}/runs/{runId}/stop:
+    post:
+      operationId: botRunStop
+      summary: Stop an active bot run
+      description: >
+        Requests the bot run to stop. If the run is in a stoppable state,
+        transitions through STOPPING → STOPPED. Returns 409 if already terminal.
+      parameters:
+        - $ref: "#/components/parameters/XWorkspaceId"
+        - name: botId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: runId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Run stopped (or stop requested)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BotRunView"
+        "401":
+          $ref: "#/components/responses/Problem"
+        "403":
+          $ref: "#/components/responses/Problem"
+        "404":
+          $ref: "#/components/responses/Problem"
+        "409":
+          description: Run already in terminal state
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+
+  /runs/{runId}:
+    get:
+      operationId: runGet
+      summary: Get any run by ID (workspace-scoped)
+      parameters:
+        - $ref: "#/components/parameters/XWorkspaceId"
+        - name: runId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BotRunView"
+        "401":
+          $ref: "#/components/responses/Problem"
+        "403":
+          $ref: "#/components/responses/Problem"
+        "404":
+          $ref: "#/components/responses/Problem"
+
+  /runs/{runId}/events:
+    get:
+      operationId: runEventsList
+      summary: Get event log for a run (ascending chronological order)
+      parameters:
+        - $ref: "#/components/parameters/XWorkspaceId"
+        - name: runId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 500
+            default: 100
+        - name: after
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: Return only events after this timestamp (for pagination)
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/BotEventView"
+        "401":
+          $ref: "#/components/responses/Problem"
+        "403":
+          $ref: "#/components/responses/Problem"
+        "404":
+          $ref: "#/components/responses/Problem"
+
+  /runs/stop-all:
+    post:
+      operationId: runsStopAll
+      summary: Emergency stop all active runs in workspace
+      parameters:
+        - $ref: "#/components/parameters/XWorkspaceId"
+      responses:
+        "200":
+          description: Result of stop-all operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  stopped:
+                    type: array
+                    items:
+                      type: string
+                    description: IDs of successfully stopped runs
+                  errors:
+                    type: array
+                    items:
+                      type: object
+                  total:
+                    type: integer
+        "401":
+          $ref: "#/components/responses/Problem"
+        "403":
+          $ref: "#/components/responses/Problem"
+
+  /runs/{runId}/signal:
+    post:
+      operationId: runSignal
+      summary: Inject a trading signal into a RUNNING bot
+      description: >
+        Records a signal event and creates a PENDING BotIntent.
+        Idempotent via intentId. Only works when run state is RUNNING.
+      parameters:
+        - $ref: "#/components/parameters/XWorkspaceId"
+        - name: runId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RunSignalRequest"
+      responses:
+        "201":
+          description: Intent created
+        "200":
+          description: Duplicate — existing intent returned (idempotent)
+        "400":
+          $ref: "#/components/responses/Problem"
+        "401":
+          $ref: "#/components/responses/Problem"
+        "403":
+          $ref: "#/components/responses/Problem"
+        "404":
+          $ref: "#/components/responses/Problem"
+        "409":
+          description: Run is not in RUNNING state
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
 
   # ── Exchange Connections (Stage 8) ─────────────────────────────────────────
 
@@ -800,13 +1118,143 @@ components:
     Strategy:
       $ref: "#/components/schemas/StrategyDslBody"
 
+    # ── Bots (Stage 11) ───────────────────────────────────────────────────────
+
     BotCreateRequest:
       type: object
       additionalProperties: false
-      required: [strategyId]
+      required: [name, strategyVersionId, symbol, timeframe]
       properties:
-        strategyId: { type: string }
-        note: { type: string }
+        name:
+          type: string
+          minLength: 1
+          description: Display name (unique per workspace)
+        strategyVersionId:
+          type: string
+          description: ID of the StrategyVersion (frozen DSL snapshot) to link to this bot
+        symbol:
+          type: string
+          example: BTCUSDT
+        timeframe:
+          type: string
+          enum: [M1, M5, M15, H1]
+        exchangeConnectionId:
+          type: string
+          nullable: true
+          description: Optional ID of ExchangeConnection (must belong to same workspace)
+
+    BotView:
+      type: object
+      description: Bot list item — no secrets, no nested strategy detail.
+      additionalProperties: false
+      required: [id, workspaceId, name, symbol, timeframe, status, strategyVersionId, createdAt, updatedAt]
+      properties:
+        id: { type: string }
+        workspaceId: { type: string }
+        name: { type: string }
+        symbol: { type: string }
+        timeframe: { type: string, enum: [M1, M5, M15, H1] }
+        status: { type: string, enum: [DRAFT, ACTIVE, DISABLED] }
+        strategyVersionId: { type: string }
+        exchangeConnectionId: { type: string, nullable: true }
+        updatedAt: { type: string, format: date-time }
+        createdAt: { type: string, format: date-time }
+
+    BotDetailView:
+      allOf:
+        - $ref: "#/components/schemas/BotView"
+        - type: object
+          properties:
+            strategyVersion:
+              type: object
+              properties:
+                id: { type: string }
+                version: { type: integer }
+                strategy:
+                  type: object
+                  properties:
+                    id: { type: string }
+                    name: { type: string }
+            lastRun:
+              $ref: "#/components/schemas/BotRunView"
+              nullable: true
+
+    BotRunCreateRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        durationMinutes:
+          type: integer
+          minimum: 1
+          maximum: 1440
+          nullable: true
+          description: >
+            Optional per-run time limit in minutes (1–1440).
+            If omitted, server default (MAX_RUN_DURATION_MS, default 4 h) applies.
+
+    BotRunView:
+      type: object
+      description: >
+        Bot run snapshot. Never includes exchange credentials.
+        States: CREATED → QUEUED → STARTING → SYNCING → RUNNING → STOPPING → STOPPED | FAILED | TIMED_OUT.
+      additionalProperties: false
+      required: [id, botId, workspaceId, symbol, state, createdAt, updatedAt]
+      properties:
+        id: { type: string }
+        botId: { type: string }
+        workspaceId: { type: string }
+        symbol: { type: string }
+        state:
+          type: string
+          enum: [CREATED, QUEUED, STARTING, SYNCING, RUNNING, STOPPING, STOPPED, FAILED, TIMED_OUT]
+        leaseOwner: { type: string, nullable: true }
+        leaseUntil: { type: string, format: date-time, nullable: true }
+        startedAt: { type: string, format: date-time, nullable: true }
+        stoppedAt: { type: string, format: date-time, nullable: true }
+        errorCode: { type: string, nullable: true }
+        durationMinutes: { type: integer, nullable: true, minimum: 1, maximum: 1440 }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+
+    BotEventView:
+      type: object
+      description: Immutable event emitted on each state transition or signal.
+      additionalProperties: false
+      required: [id, ts, type, payloadJson]
+      properties:
+        id: { type: string }
+        ts: { type: string, format: date-time }
+        type:
+          type: string
+          description: >
+            Event type label, e.g. RUN_CREATED, RUN_QUEUED, RUN_STARTING,
+            RUN_SYNCING, RUN_RUNNING, RUN_STOPPING, RUN_STOPPED,
+            RUN_FAILED, RUN_TIMED_OUT, signal_generated.
+        payloadJson:
+          type: object
+          additionalProperties: true
+          description: Transition metadata (from, to, message, at) or signal payload.
+
+    RunSignalRequest:
+      type: object
+      additionalProperties: false
+      required: [side, qty]
+      properties:
+        side:
+          type: string
+          enum: [BUY, SELL]
+        qty:
+          type: number
+          exclusiveMinimum: 0
+          description: Order quantity
+        price:
+          type: number
+          exclusiveMinimum: 0
+          nullable: true
+          description: Limit price (omit for market)
+        intentId:
+          type: string
+          description: Client-provided idempotency key; server generates UUID if omitted
 
     ExchangeConnectionView:
       type: object

--- a/docs/steps/11-stage-11-bot-factory-launch.md
+++ b/docs/steps/11-stage-11-bot-factory-launch.md
@@ -1,0 +1,269 @@
+# Stage 11 — Bot Factory Launch Flow
+
+## Status: DONE
+
+## 1) Scope
+
+- Bot creation UI: strategy+version selector (dropdown from workspace strategies), optional ExchangeConnection selector, auto-fill symbol from DSL
+- `durationMinutes` support in run start (UI + API)
+- Run history table in Bot Detail page (GET /bots/:id/runs, click row to load events)
+- Bug fix: `factory/page.tsx` Quick Start demo setup was creating an invalid DSL stub — replaced with a valid Stage-10 v1 DSL
+- OpenAPI updated: proper Bot/Run schemas and all endpoints documented
+- Smoke-test Section 11: 14 new checks
+
+## 2) Scope Boundaries (what is NOT in Stage 11)
+
+- No SL/TP logic
+- No WebSocket / streaming dashboard
+- No advanced strategy runtime optimization
+- No production-grade orchestration / queue refactor
+- No multi-bot scheduler
+- No DSL migration (Stage 12+)
+- No `entry.signal = "webhook"` routing (Stage 11+ API endpoint exists but routing is deferred)
+- No `risk.dailyLossLimitUsd` enforcement (deferred)
+- No `execution.maxSlippageBps` enforcement (deferred)
+- No `enabled: false` runtime respect (deferred)
+
+## 3) What Was Already Ready (Stage 10 Groundwork)
+
+All backend API endpoints were complete from Stage 10 groundwork:
+
+| Endpoint | Stage |
+|---|---|
+| `POST /bots` | Stage 10 groundwork |
+| `GET /bots` | Stage 10 groundwork |
+| `GET /bots/:id` | Stage 10 groundwork |
+| `GET /bots/:id/runs` | Stage 10 groundwork |
+| `POST /bots/:id/runs` (with durationMinutes) | Stage 10 groundwork |
+| `GET /bots/:id/runs/:runId` | Stage 10 groundwork |
+| `POST /bots/:id/runs/:runId/stop` | Stage 10 groundwork |
+| `GET /runs/:runId` | Stage 10 groundwork |
+| `GET /runs/:runId/events` | Stage 10 groundwork |
+| `POST /runs/:runId/signal` | Stage 10 groundwork |
+| botWorker QUEUED → RUNNING lifecycle | Stage 10 groundwork |
+| `BotRun.durationMinutes` per-run timeout | Stage 10 groundwork |
+| `Bot.exchangeConnectionId` nullable FK | Stage 10 groundwork |
+
+Stage 11 focused on closing the UI gap and documenting the contract properly.
+
+## 4) Files Changed
+
+| File | Change |
+|------|--------|
+| `apps/web/src/app/factory/page.tsx` | Fix: demo setup DSL was invalid (`kind: demo` stub) — replaced with valid Stage-10 v1 DSL |
+| `apps/web/src/app/factory/bots/page.tsx` | Rewrite: strategy+version dropdown, ExchangeConnection dropdown, symbol auto-fill from DSL |
+| `apps/web/src/app/factory/bots/[id]/page.tsx` | Update: durationMinutes input, exchange connection display, run history table |
+| `docs/openapi/openapi.yaml` | Add: Bot/Run/Event schemas, all Stage 11 endpoints documented |
+| `deploy/smoke-test.sh` | Add: Section 11 (14 checks) |
+| `docs/steps/11-stage-11-bot-factory-launch.md` | NEW — this file |
+
+## 5) Security
+
+All Bot/Run endpoints from Stage 10 groundwork already have:
+- `onRequest: [app.authenticate]` (JWT required)
+- `resolveWorkspace(request, reply)` (workspace membership enforced)
+- Cross-workspace access returns 404 (workspace isolation — resource hidden, not 403)
+- Without auth: 401
+
+ExchangeConnection secrets:
+- `encryptedSecret` never returned in any API response
+- `apiKey` never returned in any Bot/Run/Event API response
+- Exchange credentials only used internally (decrypt → pass to exchange client)
+
+## 6) Verification Commands
+
+```sh
+export BASE=http://localhost:3000/api/v1
+
+# Register and get token
+REG=$(curl -s -X POST $BASE/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"email":"s11test@example.com","password":"Test1234!"}')
+TOKEN=$(echo "$REG" | grep -o '"accessToken":"[^"]*"' | cut -d'"' -f4)
+WS_ID=$(echo "$REG" | grep -o '"workspaceId":"[^"]*"' | cut -d'"' -f4)
+```
+
+### Full Bot Factory Launch Flow
+
+```sh
+# 1) Create strategy
+STRAT=$(curl -s -X POST $BASE/strategies \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -H "X-Workspace-Id: $WS_ID" \
+  -d '{"name":"S11 Strategy","symbol":"BTCUSDT","timeframe":"M15"}')
+STRAT_ID=$(echo "$STRAT" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+
+# 2) Create strategy version (valid DSL v1)
+VER=$(curl -s -X POST $BASE/strategies/$STRAT_ID/versions \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -H "X-Workspace-Id: $WS_ID" \
+  -d '{
+    "dslJson": {
+      "id":"s11-v1","name":"S11 Strategy","dslVersion":1,"enabled":true,
+      "market":{"exchange":"bybit","env":"demo","category":"linear","symbol":"BTCUSDT"},
+      "entry":{"side":"Buy","signal":"manual"},
+      "risk":{"maxPositionSizeUsd":100,"riskPerTradePct":1,"cooldownSeconds":60},
+      "execution":{"orderType":"Market","clientOrderIdPrefix":"s11bot"},
+      "guards":{"maxOpenPositions":1,"maxOrdersPerMinute":10,"pauseOnError":true}
+    }
+  }')
+VER_ID=$(echo "$VER" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+echo "VER_ID=$VER_ID"
+# → valid UUID
+
+# 3) Create bot from strategy version
+BOT=$(curl -s -X POST $BASE/bots \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -H "X-Workspace-Id: $WS_ID" \
+  -d "{\"name\":\"S11 Bot\",\"strategyVersionId\":\"$VER_ID\",\"symbol\":\"BTCUSDT\",\"timeframe\":\"M15\"}")
+BOT_ID=$(echo "$BOT" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+echo "BOT_ID=$BOT_ID"
+# → 201, bot with status DRAFT
+
+# 4) Start run with 5-minute limit
+RUN=$(curl -s -X POST $BASE/bots/$BOT_ID/runs \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -H "X-Workspace-Id: $WS_ID" \
+  -d '{"durationMinutes":5}')
+RUN_ID=$(echo "$RUN" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+echo "RUN_ID=$RUN_ID state=$(echo $RUN | grep -o '"state":"[^"]*"')"
+# → 201, state QUEUED
+
+# 5) Get run status (worker advances state within ~5s)
+sleep 5
+curl -s $BASE/runs/$RUN_ID \
+  -H "Authorization: Bearer $TOKEN" -H "X-Workspace-Id: $WS_ID" | grep -o '"state":"[^"]*"'
+# → "state":"RUNNING"
+
+# 6) Get event log
+curl -s $BASE/runs/$RUN_ID/events \
+  -H "Authorization: Bearer $TOKEN" -H "X-Workspace-Id: $WS_ID" | \
+  jq '[.[] | {type:.type, at:.payloadJson.at}]'
+# → [RUN_CREATED, RUN_QUEUED, RUN_STARTING, RUN_SYNCING, RUN_RUNNING, ...]
+
+# 7) Stop run
+curl -s -X POST $BASE/bots/$BOT_ID/runs/$RUN_ID/stop \
+  -H "Authorization: Bearer $TOKEN" -H "X-Workspace-Id: $WS_ID" | \
+  jq '{state:.state, stoppedAt:.stoppedAt}'
+# → { "state": "STOPPED", "stoppedAt": "..." }
+
+# 8) List run history
+curl -s $BASE/bots/$BOT_ID/runs \
+  -H "Authorization: Bearer $TOKEN" -H "X-Workspace-Id: $WS_ID" | \
+  jq '[.[] | {state:.state, durationMinutes:.durationMinutes}]'
+# → [{ "state": "STOPPED", "durationMinutes": 5 }]
+```
+
+### Stop scenario → STOPPED state
+
+```sh
+# Already shown above — stop mid-run → state = STOPPED, stoppedAt set
+```
+
+### Timeout scenario (durationMinutes)
+
+```sh
+# Start run with durationMinutes=1 (worker will TIMED_OUT after ~1 min)
+RUN_TIMEOUT=$(curl -s -X POST $BASE/bots/$BOT_ID/runs \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -H "X-Workspace-Id: $WS_ID" \
+  -d '{"durationMinutes":1}')
+TID=$(echo "$RUN_TIMEOUT" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+sleep 90  # wait for worker to tick
+curl -s $BASE/runs/$TID -H "Authorization: Bearer $TOKEN" -H "X-Workspace-Id: $WS_ID" | \
+  jq '{state:.state, errorCode:.errorCode}'
+# → { "state": "TIMED_OUT", "errorCode": "MAX_DURATION_EXCEEDED" }
+```
+
+### Without auth → 401
+
+```sh
+curl -s $BASE/bots | jq .status
+# → 401
+curl -s $BASE/runs/fake-id/events | jq .status
+# → 401
+```
+
+### Cross-workspace → 404
+
+```sh
+REG2=$(curl -s -X POST $BASE/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"email":"other@example.com","password":"Test1234!"}')
+TOKEN2=$(echo "$REG2" | grep -o '"accessToken":"[^"]*"' | cut -d'"' -f4)
+WS_ID2=$(echo "$REG2" | grep -o '"workspaceId":"[^"]*"' | cut -d'"' -f4)
+
+curl -s $BASE/bots/$BOT_ID \
+  -H "Authorization: Bearer $TOKEN2" \
+  -H "X-Workspace-Id: $WS_ID2" | jq .status
+# → 404
+```
+
+### No secrets in responses
+
+```sh
+curl -s $BASE/bots/$BOT_ID -H "Authorization: Bearer $TOKEN" -H "X-Workspace-Id: $WS_ID" | \
+  grep -c "encryptedSecret\|apiKey\|passwordHash"
+# → 0
+curl -s $BASE/runs/$RUN_ID/events -H "Authorization: Bearer $TOKEN" -H "X-Workspace-Id: $WS_ID" | \
+  grep -c "encryptedSecret\|apiKey"
+# → 0
+```
+
+## 7) Acceptance Checklist (Stage 11)
+
+- [x] Bot Factory Launch Flow works end-to-end (strategy version → bot → run → events → stop)
+- [x] Bot created from StrategyVersion (with DSL contract freeze from Stage 10)
+- [x] Run starts and state advances through worker lifecycle (QUEUED → RUNNING)
+- [x] Stop scenario works: POST /bots/:id/runs/:runId/stop → STOPPED
+- [x] Timeout scenario: durationMinutes respected, run → TIMED_OUT with errorCode
+- [x] ExchangeConnection visible in bot detail UI (ID shown if set)
+- [x] All endpoints protected by `authenticate` + `resolveWorkspace()`
+- [x] Cross-workspace access returns 404 (workspace isolation)
+- [x] No secrets (encryptedSecret, apiKey) in any API response
+- [x] Problem Details (RFC 9457) on all errors
+- [x] OpenAPI updated (Bot/Run/Event schemas + all endpoints)
+- [x] Run history table in UI (click row → loads events for that run)
+- [x] durationMinutes input in UI for Start Run
+- [x] Strategy+Version dropdown in bot creation UI
+- [x] ExchangeConnection dropdown in bot creation UI
+- [x] factory/page.tsx demo setup uses valid DSL (bug fixed)
+- [x] Smoke test Section 11 added (14 checks)
+- [x] Handover notes for Stage 12 written below
+- [x] No scope creep
+- [x] Verification commands reproducible
+
+## 8) Handover for Stage 12 (Research Lab Results & Reproducibility)
+
+### Stable contracts Stage 12 can rely on
+
+| Contract | Status |
+|---|---|
+| `StrategyVersion.dslJson` shape (frozen v1 DSL) | Stable — `docs/schema/strategy.schema.json` |
+| `BotRunState` enum (CREATED→…→STOPPED/FAILED/TIMED_OUT) | Stable — `src/lib/stateMachine.ts` |
+| `BotEvent.type` labels | Stable — `RUN_CREATED`, `RUN_QUEUED`, `RUN_STARTING`, `RUN_SYNCING`, `RUN_RUNNING`, `RUN_STOPPING`, `RUN_STOPPED`, `RUN_TIMED_OUT`, `RUN_FAILED`, `signal_generated` |
+| `BotIntent` model (ENTRY/EXIT/SL/TP/CANCEL, PENDING/PLACED/FILLED/CANCELLED/FAILED) | Stable |
+| `GET /runs/:runId/events` API | Stable |
+| `BacktestResult` model in Prisma | Exists (Stage 12 will populate) |
+
+### Stage 12 inputs from Stage 11
+
+- `StrategyVersion.dslJson` (frozen DSL) — backtest runner reads `market`, `entry`, `risk`, `execution` from it
+- `BotRun.id` — backtest result links to strategy for reproducibility tracking
+- `GET /runs/:runId/events` — can replay signal/transition log for research analysis
+
+### Deferred items (for Stage 12+)
+
+| Feature | Target Stage |
+|---|---|
+| Backtest / replay runner | Stage 12 |
+| DSL migration (dslVersion > 1) | Stage 12+ |
+| `risk.dailyLossLimitUsd` enforcement | Stage 12 |
+| `execution.maxSlippageBps` enforcement | Stage 12 |
+| `enabled: false` runtime respect | Stage 12 |
+| `entry.signal = "webhook"` routing to RUNNING bot | Stage 12+ |
+| Result persistence & UI report (PnL, winrate, drawdown) | Stage 12 |
+
+## 9) Deviations
+
+None. All Stage 11 scope was implemented as planned. The backend API was fully available from Stage 10 groundwork — Stage 11 focused on UI completion, OpenAPI documentation, and smoke testing.


### PR DESCRIPTION
## Summary

- **UI**: Bot creation now uses strategy+version dropdown (lazy-loads versions on select) and ExchangeConnection dropdown; symbol auto-fills from `dslJson.market.symbol`. Bot detail page adds `durationMinutes` input, exchange connection display, and run history table with click-to-load-events.
- **Bug fix**: `factory/page.tsx` Quick Start demo setup was creating invalid DSL stub (`{kind:"demo"}`), failing Stage-10 Ajv validation silently — replaced with valid v1 DSL.
- **OpenAPI**: Full Bot/Run/Event endpoint specs added (replaces stubs). New schemas: `BotView`, `BotDetailView`, `BotRunView`, `BotRunCreateRequest`, `BotEventView`, `RunSignalRequest`, corrected `BotCreateRequest`.
- **Smoke tests**: Section 11 — 14 new checks (full launch flow, stop endpoint, cross-workspace isolation, auth protection, no-secrets checks, run history).
- **Step doc**: `docs/steps/11-stage-11-bot-factory-launch.md` with verification commands, acceptance checklist, and Stage 12 handover notes.

No new API endpoints or DB migrations — all backend was Stage-10 groundwork.

## Test plan
- [ ] Smoke test Section 11 passes: `bash deploy/smoke-test.sh --base-url https://botmarketplace.store`
- [ ] Bot Factory UI: select strategy → select version → create bot (symbol auto-fills from DSL)
- [ ] Bot Detail UI: start run with durationMinutes, watch state polling, stop run, view run history
- [ ] Quick Start demo flow works end-to-end without DSL validation error
- [ ] No secrets in any bot/run/event API response

https://claude.ai/code/session_01DXihVdKw69st99ij1WqSBw