### PR TITLE
feat(stage-15a): add lightweight-charts dep + auth UX fix on /terminal

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,14 +8,15 @@
     "start": "next start"
   },
   "dependencies": {
+    "lightweight-charts": "^5.1.0",
     "next": "^15.3.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
-    "typescript": "^5.7.0",
     "@types/node": "^22.0.0",
     "@types/react": "^19.1.0",
-    "@types/react-dom": "^19.1.0"
+    "@types/react-dom": "^19.1.0",
+    "typescript": "^5.7.0"
   }
 }

--- a/apps/web/src/app/terminal/page.tsx
+++ b/apps/web/src/app/terminal/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { apiFetchNoWorkspace, apiFetch } from "../factory/api";
+import { useRouter } from "next/navigation";
+import { apiFetchNoWorkspace, apiFetch, getToken } from "../factory/api";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -64,6 +65,15 @@ const DEFAULT_INTERVAL = "15";
 // ---------------------------------------------------------------------------
 
 export default function TerminalPage() {
+  const router = useRouter();
+
+  // --- Auth state ---
+  const [hasToken, setHasToken] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    setHasToken(!!getToken());
+  }, []);
+
   // --- Market Data state ---
   const [symbol, setSymbol] = useState(DEFAULT_SYMBOL);
   const [interval, setInterval] = useState(DEFAULT_INTERVAL);
@@ -140,6 +150,10 @@ export default function TerminalPage() {
   }
 
   async function loadAll() {
+    if (!getToken()) {
+      router.push("/login");
+      return;
+    }
     await Promise.all([loadTicker(), loadCandles()]);
   }
 
@@ -217,6 +231,31 @@ export default function TerminalPage() {
   // ---------------------------------------------------------------------------
   // Render
   // ---------------------------------------------------------------------------
+
+  // Auth gate: show Login CTA while token status is loading or if no token
+  if (hasToken === null) {
+    return (
+      <div style={{ padding: "32px 24px", maxWidth: 960, margin: "0 auto" }}>
+        <p style={hint}>Loading...</p>
+      </div>
+    );
+  }
+
+  if (hasToken === false) {
+    return (
+      <div style={loginCtaWrap}>
+        <div style={loginCtaBox}>
+          <h1 style={{ fontSize: 26, marginBottom: 12 }}>Terminal</h1>
+          <p style={{ color: "var(--text-secondary)", marginBottom: 24, fontSize: 15 }}>
+            Sign in to load market data, view charts, and place orders.
+          </p>
+          <button style={loginCtaBtn} onClick={() => router.push("/login")}>
+            Login to load market data
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div style={{ padding: "32px 24px", maxWidth: 960, margin: "0 auto" }}>
@@ -607,4 +646,28 @@ const td: React.CSSProperties = {
   textAlign: "right",
   borderBottom: "1px solid var(--border)",
   fontFamily: "monospace",
+};
+
+const loginCtaWrap: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  minHeight: "60vh",
+  padding: "32px 24px",
+};
+
+const loginCtaBox: React.CSSProperties = {
+  textAlign: "center",
+  maxWidth: 400,
+};
+
+const loginCtaBtn: React.CSSProperties = {
+  padding: "12px 32px",
+  background: "var(--accent)",
+  color: "#fff",
+  border: "none",
+  borderRadius: 8,
+  cursor: "pointer",
+  fontSize: 16,
+  fontWeight: 600,
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
 
   apps/web:
     dependencies:
+      lightweight-charts:
+        specifier: ^5.1.0
+        version: 5.1.0
       next:
         specifier: ^15.3.0
         version: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -647,6 +650,9 @@ packages:
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
 
+  fancy-canvas@2.1.0:
+    resolution: {integrity: sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ==}
+
   fast-check@3.23.2:
     resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
     engines: {node: '>=8.0.0'}
@@ -724,6 +730,9 @@ packages:
 
   light-my-request@6.6.0:
     resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
+
+  lightweight-charts@5.1.0:
+    resolution: {integrity: sha512-jEAYR4ODYeyNZcWUigsoLTl52rbPmgXnvd5FLIv/ZoA/2sSDw63YKnef8n4yhzum7W926yHeFwlm7ididKb7YQ==}
 
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
@@ -1393,6 +1402,8 @@ snapshots:
 
   exsolve@1.0.8: {}
 
+  fancy-canvas@2.1.0: {}
+
   fast-check@3.23.2:
     dependencies:
       pure-rand: 6.1.0
@@ -1500,6 +1511,10 @@ snapshots:
       cookie: 1.1.1
       process-warning: 4.0.1
       set-cookie-parser: 2.7.2
+
+  lightweight-charts@5.1.0:
+    dependencies:
+      fancy-canvas: 2.1.0
 
   minimalistic-assert@1.0.1: {}
 


### PR DESCRIPTION
- Install lightweight-charts@^5.1.0 (pnpm add)
- /terminal: check localStorage token on mount (hasToken state)
  - hasToken=null → brief "Loading..." guard (avoids SSR mismatch)
  - hasToken=false → full Login CTA screen ("Login to load market data" button → /login)
  - hasToken=true → existing terminal UI rendered as before
- loadAll(): redirect to /login if no token instead of firing API calls that would return 401 and display red error text as primary UI

No chart code changes in this PR (15b scope).

https://claude.ai/code/session_01GiWFRY2GYYE2RB3GQpoYoN