### PR TITLE
feat(stage-19a): datasets layer — MarketCandle + MarketDataset + quality + hash

### DIFF
--- a/apps/api/prisma/migrations/20260304a_stage19a_market_candles/migration.sql
+++ b/apps/api/prisma/migrations/20260304a_stage19a_market_candles/migration.sql
@@ -1,0 +1,57 @@
+-- Stage 19a: Market candle layer + dataset freeze + deterministic hash + quality
+-- Adds: CandleInterval enum, DatasetStatus enum, MarketCandle (shared), MarketDataset (workspace-scoped)
+
+CREATE TYPE "CandleInterval" AS ENUM ('M1', 'M5', 'M15', 'M30', 'H1', 'H4', 'D1');
+CREATE TYPE "DatasetStatus"  AS ENUM ('READY', 'PARTIAL', 'FAILED');
+
+-- Shared market candle storage (no workspaceId — exchange/symbol/interval/time is global)
+CREATE TABLE "MarketCandle" (
+  "id"         TEXT          NOT NULL,
+  "exchange"   TEXT          NOT NULL,
+  "symbol"     TEXT          NOT NULL,
+  "interval"   "CandleInterval" NOT NULL,
+  "openTimeMs" BIGINT        NOT NULL,
+  "open"       DECIMAL(18,8) NOT NULL,
+  "high"       DECIMAL(18,8) NOT NULL,
+  "low"        DECIMAL(18,8) NOT NULL,
+  "close"      DECIMAL(18,8) NOT NULL,
+  "volume"     DECIMAL(18,8) NOT NULL,
+  "createdAt"  TIMESTAMP(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "MarketCandle_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "MarketCandle_exchange_symbol_interval_openTimeMs_key"
+  ON "MarketCandle"("exchange", "symbol", "interval", "openTimeMs");
+
+CREATE INDEX "MarketCandle_exchange_symbol_interval_openTimeMs_idx"
+  ON "MarketCandle"("exchange", "symbol", "interval", "openTimeMs" DESC);
+
+-- Workspace-scoped dataset snapshot (frozen range + deterministic hash)
+CREATE TABLE "MarketDataset" (
+  "id"            TEXT             NOT NULL,
+  "workspaceId"   TEXT             NOT NULL,
+  "exchange"      TEXT             NOT NULL,
+  "symbol"        TEXT             NOT NULL,
+  "interval"      "CandleInterval" NOT NULL,
+  "fromTsMs"      BIGINT           NOT NULL,
+  "toTsMs"        BIGINT           NOT NULL,
+  "fetchedAt"     TIMESTAMP(3)     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "datasetHash"   TEXT             NOT NULL,
+  "candleCount"   INTEGER          NOT NULL,
+  "qualityJson"   JSONB            NOT NULL,
+  "engineVersion" TEXT             NOT NULL,
+  "status"        "DatasetStatus"  NOT NULL,
+  "createdAt"     TIMESTAMP(3)     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "MarketDataset_pkey" PRIMARY KEY ("id")
+);
+
+ALTER TABLE "MarketDataset"
+  ADD CONSTRAINT "MarketDataset_workspaceId_fkey"
+  FOREIGN KEY ("workspaceId") REFERENCES "Workspace"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+CREATE UNIQUE INDEX "MarketDataset_workspaceId_exchange_symbol_interval_fromTsMs_toTsMs_key"
+  ON "MarketDataset"("workspaceId", "exchange", "symbol", "interval", "fromTsMs", "toTsMs");
+
+CREATE INDEX "MarketDataset_workspaceId_createdAt_idx"
+  ON "MarketDataset"("workspaceId", "createdAt" DESC);

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -38,6 +38,7 @@ model Workspace {
   terminalOrders      TerminalOrder[]
   aiPlans             AiPlan[]
   aiActionAudits      AiActionAudit[]
+  datasets            MarketDataset[]
 }
 
 model WorkspaceMember {
@@ -362,6 +363,65 @@ model AiActionAudit {
   workspace Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
 
   @@index([planId])
+  @@index([workspaceId, createdAt(sort: Desc)])
+}
+
+// ── Market Data (Stage 19a) ──────────────────────────────────────
+
+enum CandleInterval {
+  M1
+  M5
+  M15
+  M30
+  H1
+  H4
+  D1
+}
+
+enum DatasetStatus {
+  READY
+  PARTIAL
+  FAILED
+}
+
+/// Shared (non-workspace-scoped) candle storage. Deduped by unique key.
+model MarketCandle {
+  id         String         @id @default(uuid())
+  exchange   String
+  symbol     String
+  interval   CandleInterval
+  openTimeMs BigInt
+  open       Decimal        @db.Decimal(18, 8)
+  high       Decimal        @db.Decimal(18, 8)
+  low        Decimal        @db.Decimal(18, 8)
+  close      Decimal        @db.Decimal(18, 8)
+  volume     Decimal        @db.Decimal(18, 8)
+  createdAt  DateTime       @default(now())
+
+  @@unique([exchange, symbol, interval, openTimeMs])
+  @@index([exchange, symbol, interval, openTimeMs(sort: Desc)])
+}
+
+/// Workspace-scoped snapshot of a market data range. Immutable hash for reproducibility.
+model MarketDataset {
+  id            String         @id @default(uuid())
+  workspaceId   String
+  exchange      String
+  symbol        String
+  interval      CandleInterval
+  fromTsMs      BigInt
+  toTsMs        BigInt
+  fetchedAt     DateTime       @default(now())
+  datasetHash   String
+  candleCount   Int
+  qualityJson   Json
+  engineVersion String
+  status        DatasetStatus
+  createdAt     DateTime       @default(now())
+
+  workspace Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+
+  @@unique([workspaceId, exchange, symbol, interval, fromTsMs, toTsMs])
   @@index([workspaceId, createdAt(sort: Desc)])
 }
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -12,6 +12,7 @@ import { runRoutes } from "./routes/runs.js";
 import { intentRoutes } from "./routes/intents.js";
 import { workspacesRoutes } from "./routes/workspaces.js";
 import { labRoutes } from "./routes/lab.js";
+import { datasetRoutes } from "./routes/datasets.js";
 import { exchangeRoutes } from "./routes/exchanges.js";
 import { terminalRoutes } from "./routes/terminal.js";
 import { aiRoutes } from "./routes/ai.js";
@@ -27,6 +28,7 @@ async function registerRoutes(scope: import("fastify").FastifyInstance) {
   await scope.register(runRoutes);
   await scope.register(intentRoutes);
   await scope.register(labRoutes);
+  await scope.register(datasetRoutes);
   await scope.register(exchangeRoutes);
   await scope.register(terminalRoutes);
   await scope.register(aiRoutes);

--- a/apps/api/src/lib/dataQuality.ts
+++ b/apps/api/src/lib/dataQuality.ts
@@ -1,0 +1,109 @@
+/**
+ * Data quality analysis for market candle datasets (Stage 19a).
+ *
+ * qualityJson schema (7 fixed fields):
+ *   intervalMs        — expected interval between candles in ms
+ *   candleCount       — number of candles in DB range
+ *   dupeAttempts      — candles that were already in DB (skipped on insert)
+ *   gapsCount         — number of gaps > intervalMs between consecutive candles
+ *   maxGapMs          — largest gap found (0 if no gaps)
+ *   sanityIssuesCount — candles failing OHLCV sanity checks
+ *   sanityDetails     — per-candle issue list
+ *
+ * Status rules:
+ *   FAILED  — sanityIssuesCount > 0 OR maxGapMs > 5 * intervalMs
+ *   PARTIAL — sanityIssuesCount == 0 AND gapsCount > 0
+ *   READY   — sanityIssuesCount == 0 AND gapsCount == 0
+ */
+
+import type { Prisma } from "@prisma/client";
+
+export interface QualityJson {
+  intervalMs: number;
+  candleCount: number;
+  dupeAttempts: number;
+  gapsCount: number;
+  maxGapMs: number;
+  sanityIssuesCount: number;
+  sanityDetails: Array<{ openTimeMs: number; issue: string }>;
+}
+
+export type DatasetStatus = "READY" | "PARTIAL" | "FAILED";
+
+export interface QualityResult {
+  qualityJson: QualityJson;
+  status: DatasetStatus;
+}
+
+export interface QualityCandle {
+  openTimeMs: bigint;
+  open: Prisma.Decimal;
+  high: Prisma.Decimal;
+  low: Prisma.Decimal;
+  close: Prisma.Decimal;
+  volume: Prisma.Decimal;
+}
+
+export function computeDataQuality(
+  candles: QualityCandle[],
+  intervalMs: number,
+  dupeAttempts: number,
+): QualityResult {
+  const sorted = [...candles].sort((a, b) =>
+    a.openTimeMs < b.openTimeMs ? -1 : a.openTimeMs > b.openTimeMs ? 1 : 0,
+  );
+
+  let gapsCount = 0;
+  let maxGapMs = 0;
+  const sanityDetails: Array<{ openTimeMs: number; issue: string }> = [];
+
+  // Gap detection
+  for (let i = 1; i < sorted.length; i++) {
+    const gap = Number(sorted[i].openTimeMs - sorted[i - 1].openTimeMs);
+    if (gap > intervalMs) {
+      gapsCount++;
+      if (gap > maxGapMs) maxGapMs = gap;
+    }
+  }
+
+  // Sanity checks per candle: high >= open/close, low <= open/close, volume >= 0
+  for (const c of sorted) {
+    const o = c.open.toNumber();
+    const h = c.high.toNumber();
+    const l = c.low.toNumber();
+    const cl = c.close.toNumber();
+    const v = c.volume.toNumber();
+    const ts = Number(c.openTimeMs);
+
+    if (!Number.isFinite(o) || !Number.isFinite(h) || !Number.isFinite(l) || !Number.isFinite(cl)) {
+      sanityDetails.push({ openTimeMs: ts, issue: "non_finite_price" });
+    } else if (h < o || h < cl) {
+      sanityDetails.push({ openTimeMs: ts, issue: "high_below_open_or_close" });
+    } else if (l > o || l > cl) {
+      sanityDetails.push({ openTimeMs: ts, issue: "low_above_open_or_close" });
+    } else if (v < 0) {
+      sanityDetails.push({ openTimeMs: ts, issue: "negative_volume" });
+    }
+  }
+
+  const qualityJson: QualityJson = {
+    intervalMs,
+    candleCount: sorted.length,
+    dupeAttempts,
+    gapsCount,
+    maxGapMs,
+    sanityIssuesCount: sanityDetails.length,
+    sanityDetails,
+  };
+
+  let status: DatasetStatus;
+  if (sanityDetails.length > 0 || maxGapMs > 5 * intervalMs) {
+    status = "FAILED";
+  } else if (gapsCount > 0) {
+    status = "PARTIAL";
+  } else {
+    status = "READY";
+  }
+
+  return { qualityJson, status };
+}

--- a/apps/api/src/lib/datasetHash.ts
+++ b/apps/api/src/lib/datasetHash.ts
@@ -1,0 +1,35 @@
+/**
+ * Deterministic dataset hash (Stage 19a).
+ *
+ * Canonical string: candles sorted by openTimeMs ASC, one line per candle:
+ *   openTimeMs|open|high|low|close|volume
+ * where each DECIMAL field is formatted with .toFixed(8) (exactly 8 decimal places),
+ * computed from DB-read Prisma.Decimal values (NOT from intermediate Number()).
+ *
+ * Lines joined with '\n', then sha256 hex.
+ */
+
+import { createHash } from "node:crypto";
+import type { Prisma } from "@prisma/client";
+
+export interface HashableCandle {
+  openTimeMs: bigint;
+  open: Prisma.Decimal;
+  high: Prisma.Decimal;
+  low: Prisma.Decimal;
+  close: Prisma.Decimal;
+  volume: Prisma.Decimal;
+}
+
+export function computeDatasetHash(candles: HashableCandle[]): string {
+  const sorted = [...candles].sort((a, b) =>
+    a.openTimeMs < b.openTimeMs ? -1 : a.openTimeMs > b.openTimeMs ? 1 : 0,
+  );
+
+  const lines = sorted.map(
+    (c) =>
+      `${c.openTimeMs}|${c.open.toFixed(8)}|${c.high.toFixed(8)}|${c.low.toFixed(8)}|${c.close.toFixed(8)}|${c.volume.toFixed(8)}`,
+  );
+
+  return createHash("sha256").update(lines.join("\n"), "utf8").digest("hex");
+}

--- a/apps/api/src/routes/datasets.ts
+++ b/apps/api/src/routes/datasets.ts
@@ -1,0 +1,261 @@
+/**
+ * Dataset routes — Stage 19a
+ *
+ * POST /lab/datasets  — create (or retrieve existing) frozen market dataset
+ * GET  /lab/datasets/:id — retrieve dataset metadata + qualityJson
+ *
+ * Rate limits:
+ *   POST  10 req/min
+ *   GET   60 req/min
+ */
+
+import type { FastifyInstance } from "fastify";
+import type { CandleInterval } from "@prisma/client";
+import { prisma } from "../lib/prisma.js";
+import { problem } from "../lib/problem.js";
+import { resolveWorkspace } from "../lib/workspace.js";
+import { fetchCandles } from "../lib/bybitCandles.js";
+import { computeDatasetHash } from "../lib/datasetHash.js";
+import { computeDataQuality } from "../lib/dataQuality.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MAX_RANGE_MS = 365 * 24 * 60 * 60 * 1000; // 365 days
+const MAX_CANDLES = 100_000;
+const CHUNK_SIZE = 1_000;
+
+/** Maps CandleInterval → Bybit API interval string + duration in ms */
+const INTERVAL_META: Record<string, { bybitInterval: string; intervalMs: number }> = {
+  M1:  { bybitInterval: "1",   intervalMs: 60_000 },
+  M5:  { bybitInterval: "5",   intervalMs: 300_000 },
+  M15: { bybitInterval: "15",  intervalMs: 900_000 },
+  M30: { bybitInterval: "30",  intervalMs: 1_800_000 },
+  H1:  { bybitInterval: "60",  intervalMs: 3_600_000 },
+  H4:  { bybitInterval: "240", intervalMs: 14_400_000 },
+  D1:  { bybitInterval: "D",   intervalMs: 86_400_000 },
+};
+
+const VALID_INTERVALS = Object.keys(INTERVAL_META) as CandleInterval[];
+
+// ---------------------------------------------------------------------------
+// Request types
+// ---------------------------------------------------------------------------
+
+interface CreateDatasetBody {
+  exchange: string;
+  symbol: string;
+  interval: string;
+  /** ISO date string (alternative to fromTsMs) */
+  fromTs?: string;
+  /** ISO date string (alternative to toTsMs) */
+  toTs?: string;
+  fromTsMs?: number;
+  toTsMs?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Routes
+// ---------------------------------------------------------------------------
+
+export async function datasetRoutes(app: FastifyInstance) {
+  // ── POST /lab/datasets ─────────────────────────────────────────────────────
+  app.post<{ Body: CreateDatasetBody }>("/lab/datasets", {
+    config: { rateLimit: { max: 10, timeWindow: "1 minute" } },
+    onRequest: [app.authenticate],
+  }, async (request, reply) => {
+    const workspace = await resolveWorkspace(request, reply);
+    if (!workspace) return;
+
+    const {
+      exchange,
+      symbol,
+      interval,
+      fromTs,
+      toTs,
+      fromTsMs: bodyFromMs,
+      toTsMs: bodyToMs,
+    } = request.body ?? {};
+
+    // ── Validation ────────────────────────────────────────────────────────────
+    const errors: Array<{ field: string; message: string }> = [];
+    if (!exchange) errors.push({ field: "exchange", message: "exchange is required" });
+    if (!symbol)   errors.push({ field: "symbol",   message: "symbol is required" });
+    if (!interval) {
+      errors.push({ field: "interval", message: "interval is required" });
+    } else if (!VALID_INTERVALS.includes(interval as CandleInterval)) {
+      errors.push({
+        field: "interval",
+        message: `interval must be one of: ${VALID_INTERVALS.join(", ")}`,
+      });
+    }
+    if (bodyFromMs == null && !fromTs) {
+      errors.push({ field: "fromTs", message: "fromTs (ISO) or fromTsMs (ms) is required" });
+    }
+    if (bodyToMs == null && !toTs) {
+      errors.push({ field: "toTs", message: "toTs (ISO) or toTsMs (ms) is required" });
+    }
+    if (errors.length > 0) {
+      return problem(reply, 400, "Validation Error", "Invalid dataset request", { errors });
+    }
+
+    const fromMs = bodyFromMs ?? new Date(fromTs!).getTime();
+    const toMs   = bodyToMs   ?? new Date(toTs!).getTime();
+
+    if (!Number.isFinite(fromMs) || !Number.isFinite(toMs)) {
+      return problem(reply, 400, "Validation Error", "fromTs / toTs must be valid ISO dates");
+    }
+    if (fromMs >= toMs) {
+      return problem(reply, 400, "Validation Error", "fromTs must be before toTs");
+    }
+
+    const rangeMs = toMs - fromMs;
+    if (rangeMs > MAX_RANGE_MS) {
+      return problem(reply, 400, "Range Too Large", "Date range must not exceed 365 days");
+    }
+
+    const meta = INTERVAL_META[interval]!;
+    const estimatedCandles = Math.ceil(rangeMs / meta.intervalMs);
+    if (estimatedCandles > MAX_CANDLES) {
+      return problem(
+        reply, 400, "Too Many Candles",
+        `Requested range would produce ~${estimatedCandles} candles, exceeding the 100,000 limit`,
+      );
+    }
+
+    const exchangeUpper = exchange.toUpperCase();
+
+    // ── Fetch from exchange ───────────────────────────────────────────────────
+    let fetched: Awaited<ReturnType<typeof fetchCandles>>;
+    try {
+      fetched = await fetchCandles(symbol, meta.bybitInterval, fromMs, toMs, MAX_CANDLES);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return problem(reply, 502, "Bad Gateway", `Failed to fetch candles: ${msg}`);
+    }
+
+    const engineVersion = process.env.COMMIT_SHA ?? "unknown";
+
+    // ── Transactional upsert (30 s timeout) ──────────────────────────────────
+    const dataset = await prisma.$transaction(async (tx) => {
+      // Chunked createMany (skipDuplicates = ON CONFLICT DO NOTHING)
+      let totalCreated = 0;
+      for (let i = 0; i < fetched.length; i += CHUNK_SIZE) {
+        const chunk = fetched.slice(i, i + CHUNK_SIZE);
+        const result = await tx.marketCandle.createMany({
+          data: chunk.map((c) => ({
+            exchange:   exchangeUpper,
+            symbol,
+            interval:   interval as CandleInterval,
+            openTimeMs: BigInt(c.openTime),
+            open:       c.open,
+            high:       c.high,
+            low:        c.low,
+            close:      c.close,
+            volume:     c.volume,
+          })),
+          skipDuplicates: true,
+        });
+        totalCreated += result.count;
+      }
+
+      const dupeAttempts = fetched.length - totalCreated;
+
+      // Query candles from DB in exact range (source of truth for hash + quality)
+      const dbCandles = await tx.marketCandle.findMany({
+        where: {
+          exchange:   exchangeUpper,
+          symbol,
+          interval:   interval as CandleInterval,
+          openTimeMs: { gte: BigInt(fromMs), lte: BigInt(toMs) },
+        },
+        orderBy: { openTimeMs: "asc" },
+      });
+
+      // Compute quality + hash strictly from DB Decimal values
+      const { qualityJson, status } = computeDataQuality(dbCandles, meta.intervalMs, dupeAttempts);
+      const datasetHash = computeDatasetHash(dbCandles);
+
+      // Upsert MarketDataset by unique(workspaceId, exchange, symbol, interval, fromTsMs, toTsMs)
+      return tx.marketDataset.upsert({
+        where: {
+          workspaceId_exchange_symbol_interval_fromTsMs_toTsMs: {
+            workspaceId: workspace.id,
+            exchange:    exchangeUpper,
+            symbol,
+            interval:    interval as CandleInterval,
+            fromTsMs:    BigInt(fromMs),
+            toTsMs:      BigInt(toMs),
+          },
+        },
+        create: {
+          workspaceId:   workspace.id,
+          exchange:      exchangeUpper,
+          symbol,
+          interval:      interval as CandleInterval,
+          fromTsMs:      BigInt(fromMs),
+          toTsMs:        BigInt(toMs),
+          fetchedAt:     new Date(),
+          datasetHash,
+          candleCount:   dbCandles.length,
+          qualityJson:   qualityJson as unknown as object,
+          engineVersion,
+          status,
+        },
+        update: {
+          fetchedAt:     new Date(),
+          datasetHash,
+          candleCount:   dbCandles.length,
+          qualityJson:   qualityJson as unknown as object,
+          engineVersion,
+          status,
+        },
+      });
+    }, { timeout: 30_000 });
+
+    return reply.status(201).send({
+      datasetId:     dataset.id,
+      datasetHash:   dataset.datasetHash,
+      status:        dataset.status,
+      qualityJson:   dataset.qualityJson,
+      candleCount:   dataset.candleCount,
+      fetchedAt:     dataset.fetchedAt,
+      engineVersion: dataset.engineVersion,
+    });
+  });
+
+  // ── GET /lab/datasets/:id ──────────────────────────────────────────────────
+  app.get<{ Params: { id: string } }>("/lab/datasets/:id", {
+    config: { rateLimit: { max: 60, timeWindow: "1 minute" } },
+    onRequest: [app.authenticate],
+  }, async (request, reply) => {
+    const workspace = await resolveWorkspace(request, reply);
+    if (!workspace) return;
+
+    const ds = await prisma.marketDataset.findUnique({ where: { id: request.params.id } });
+    if (!ds) {
+      return problem(reply, 404, "Not Found", "Dataset not found");
+    }
+    if (ds.workspaceId !== workspace.id) {
+      return problem(reply, 403, "Forbidden", "Dataset belongs to another workspace");
+    }
+
+    return reply.send({
+      datasetId:     ds.id,
+      workspaceId:   ds.workspaceId,
+      exchange:      ds.exchange,
+      symbol:        ds.symbol,
+      interval:      ds.interval,
+      fromTsMs:      ds.fromTsMs.toString(),
+      toTsMs:        ds.toTsMs.toString(),
+      fetchedAt:     ds.fetchedAt,
+      datasetHash:   ds.datasetHash,
+      candleCount:   ds.candleCount,
+      qualityJson:   ds.qualityJson,
+      engineVersion: ds.engineVersion,
+      status:        ds.status,
+      createdAt:     ds.createdAt,
+    });
+  });
+}


### PR DESCRIPTION
## Stage 19a — Dataset Layer

**Deployment Report: GO ✓** (2026-03-04)

### Summary
- New Prisma models: `MarketCandle` (shared) + `MarketDataset` (workspace-scoped)
- Migration: `20260304a_stage19a_market_candles`
- POST/GET `/api/v1/lab/datasets` with auth + workspace isolation
- Deterministic `datasetHash` via SHA256 (Decimal.toFixed(8))
- Data quality: READY/PARTIAL/FAILED + `qualityJson` (7 fields)
- Hard limits: 365d range, 100k candles
- `engineVersion` from `COMMIT_SHA` env

### Test Results
| # | Test | Status |
|---|------|--------|
| 19.1 | POST /lab/datasets → 201 + all fields | ✅ PASS |
| 19.2 | Repeat POST → upsert (same id+hash) | ✅ PASS |
| 19.3 | GET qualityJson → all 7 fields | ✅ PASS |
| 19.4 | Range >365d → 400 | ✅ PASS |
| 19.5 | >100k candles → 400 | ✅ PASS |
| 19.6–19.7 | Backtest binding | Stage 19b scope |

### Smoke Suite
Sections 1–10: ALL PASSED (no regressions)