### PR TITLE
feat(stage-20a): Guest onboarding + guest terminal market-only

### DIFF
--- a/apps/api/src/routes/terminal.ts
+++ b/apps/api/src/routes/terminal.ts
@@ -77,11 +77,11 @@ export async function terminalRoutes(app: FastifyInstance) {
    * GET /terminal/ticker?symbol=BTCUSDT
    *
    * Returns current ticker data for a linear perpetual symbol.
-   * Requires authentication (JWT). No workspace required — Bybit data is public.
+   * Public — no authentication required. Bybit data is public.
    */
   app.get<{ Querystring: { symbol?: string } }>(
     "/terminal/ticker",
-    { onRequest: [app.authenticate] },
+    {},
     async (request, reply) => {
       const { symbol } = request.query;
 
@@ -105,7 +105,7 @@ export async function terminalRoutes(app: FastifyInstance) {
    * GET /terminal/candles?symbol=BTCUSDT&interval=15&limit=200
    *
    * Returns recent OHLCV candles for a linear perpetual symbol.
-   * Requires authentication (JWT). No workspace required — Bybit data is public.
+   * Public — no authentication required. Bybit data is public.
    *
    * Parameters:
    *   symbol   — required; e.g. "BTCUSDT"
@@ -114,7 +114,7 @@ export async function terminalRoutes(app: FastifyInstance) {
    */
   app.get<{ Querystring: { symbol?: string; interval?: string; limit?: string } }>(
     "/terminal/candles",
-    { onRequest: [app.authenticate] },
+    {},
     async (request, reply) => {
       const { symbol, interval: intervalParam, limit: limitParam } = request.query;
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 import { Navbar } from "./navbar";
 import { ChatWidgetWrapper } from "@/components/chat/ChatWidgetWrapper";
+import { OnboardingModal } from "@/components/OnboardingModal";
 
 export const metadata: Metadata = {
   title: "BotMarketplace",
@@ -26,6 +27,7 @@ export default function RootLayout({
       </head>
       <body>
         <Navbar />
+        <OnboardingModal />
         <main style={{ paddingTop: "var(--nav-height)" }}>{children}</main>
         <ChatWidgetWrapper />
       </body>

--- a/apps/web/src/app/terminal/page.tsx
+++ b/apps/web/src/app/terminal/page.tsx
@@ -270,8 +270,9 @@ export default function TerminalPage() {
     schedulePrefsWrite(buildPrefs());
   }, [symbol, interval, showWatchlist, showOrderPanel, buildPrefs, schedulePrefsWrite]);
 
-  // Load exchange connections on mount
+  // Load exchange connections on mount (auth only — guests must not call this)
   useEffect(() => {
+    if (!hasToken) return;
     apiFetch<ExchangeConnection[]>("/exchanges").then((res) => {
       if (res.ok) {
         setConnections(res.data);
@@ -280,7 +281,7 @@ export default function TerminalPage() {
         setSessionExpired(true);
       }
     });
-  }, []);
+  }, [hasToken]);
 
   // Load orders for markers (workspace-scoped via apiFetch)
   useEffect(() => {
@@ -347,10 +348,6 @@ export default function TerminalPage() {
   }
 
   async function loadAll() {
-    if (!getToken()) {
-      router.push("/login");
-      return;
-    }
     await Promise.all([loadTicker(), loadCandles()]);
   }
 
@@ -438,22 +435,6 @@ export default function TerminalPage() {
     return (
       <div style={{ padding: "32px 24px" }}>
         <p style={hint}>Loading...</p>
-      </div>
-    );
-  }
-
-  if (hasToken === false) {
-    return (
-      <div style={loginCtaWrap}>
-        <div style={loginCtaBox}>
-          <h1 style={{ fontSize: 26, marginBottom: 12 }}>Terminal</h1>
-          <p style={{ color: "var(--text-secondary)", marginBottom: 24, fontSize: 15 }}>
-            Sign in to load market data, view charts, and place orders.
-          </p>
-          <button style={loginCtaBtn} onClick={() => router.push("/login")}>
-            Login to load market data
-          </button>
-        </div>
       </div>
     );
   }
@@ -569,7 +550,16 @@ export default function TerminalPage() {
           <div style={orderPanelCol}>
             <div style={panelTitle}>Place Order</div>
 
-            {connections.length === 0 ? (
+            {!hasToken ? (
+              <div style={{ padding: "16px 12px", display: "flex", flexDirection: "column", gap: 10 }}>
+                <p style={{ ...hint, fontSize: 13, lineHeight: 1.5 }}>
+                  Login to trade / connect exchange
+                </p>
+                <button style={loginCtaBtn} onClick={() => router.push("/login")}>
+                  Sign in
+                </button>
+              </div>
+            ) : connections.length === 0 ? (
               <p style={{ ...hint, padding: "10px 12px" }}>
                 No exchange connections. Create one first.
               </p>
@@ -745,7 +735,14 @@ export default function TerminalPage() {
           {/* Orders tab */}
           {bottomTab === "orders" && (
             <>
-              {allOrders.length === 0 ? (
+              {!hasToken ? (
+                <div style={{ display: "flex", flexDirection: "column", gap: 10, alignItems: "flex-start" }}>
+                  <p style={hint}>Login to view order history.</p>
+                  <button style={{ ...loginCtaBtn, fontSize: 13, padding: "8px 20px" }} onClick={() => router.push("/login")}>
+                    Sign in to trade
+                  </button>
+                </div>
+              ) : allOrders.length === 0 ? (
                 <p style={hint}>No orders yet.</p>
               ) : (
                 <div style={{ overflowX: "auto" }}>
@@ -1079,19 +1076,6 @@ const td: React.CSSProperties = {
   textAlign: "right",
   borderBottom: "1px solid var(--border)",
   fontFamily: "monospace",
-};
-
-const loginCtaWrap: React.CSSProperties = {
-  display: "flex",
-  justifyContent: "center",
-  alignItems: "center",
-  minHeight: "60vh",
-  padding: "32px 24px",
-};
-
-const loginCtaBox: React.CSSProperties = {
-  textAlign: "center",
-  maxWidth: 400,
 };
 
 const loginCtaBtn: React.CSSProperties = {

--- a/apps/web/src/components/OnboardingModal.tsx
+++ b/apps/web/src/components/OnboardingModal.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
+const ONBOARDING_KEY = "onboardingSeen";
+
+export function OnboardingModal() {
+  const router = useRouter();
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (localStorage.getItem(ONBOARDING_KEY) !== "1") {
+      setVisible(true);
+    }
+  }, []);
+
+  function dismiss() {
+    localStorage.setItem(ONBOARDING_KEY, "1");
+    setVisible(false);
+  }
+
+  function handleSignIn() {
+    dismiss();
+    router.push("/login");
+  }
+
+  function handleGuest() {
+    dismiss();
+  }
+
+  if (!visible) return null;
+
+  return (
+    <div style={overlay}>
+      <div style={modal}>
+        <h2 style={{ margin: "0 0 8px", fontSize: 22 }}>Welcome to BotMarketplace</h2>
+        <p style={{ color: "var(--text-secondary)", fontSize: 14, margin: "0 0 24px", lineHeight: 1.5 }}>
+          Explore live market data without registration, or sign in to trade and save your preferences.
+        </p>
+        <div style={{ display: "flex", gap: 10, justifyContent: "center" }}>
+          <button style={primaryBtn} onClick={handleSignIn}>
+            Sign in
+          </button>
+          <button style={secondaryBtn} onClick={handleGuest}>
+            Continue as guest
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const overlay: React.CSSProperties = {
+  position: "fixed",
+  inset: 0,
+  background: "rgba(0,0,0,0.55)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  zIndex: 9999,
+};
+
+const modal: React.CSSProperties = {
+  background: "var(--bg-card, #1c1c1e)",
+  border: "1px solid var(--border, #30363d)",
+  borderRadius: 12,
+  padding: "32px 28px",
+  maxWidth: 420,
+  width: "90%",
+  textAlign: "center",
+  boxShadow: "0 8px 32px rgba(0,0,0,0.5)",
+};
+
+const primaryBtn: React.CSSProperties = {
+  padding: "11px 28px",
+  background: "var(--accent, #0969da)",
+  color: "#fff",
+  border: "none",
+  borderRadius: 8,
+  cursor: "pointer",
+  fontSize: 15,
+  fontWeight: 600,
+};
+
+const secondaryBtn: React.CSSProperties = {
+  padding: "11px 28px",
+  background: "transparent",
+  color: "var(--text-primary)",
+  border: "1px solid var(--border, #30363d)",
+  borderRadius: 8,
+  cursor: "pointer",
+  fontSize: 15,
+  fontWeight: 500,
+};

--- a/deploy/smoke-test.sh
+++ b/deploy/smoke-test.sh
@@ -295,15 +295,15 @@ FAKE_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
   -H "Authorization: Bearer $TOKEN")
 check "GET /terminal/ticker FAKE → 422" "422" "$FAKE_CODE"
 
-# 9.8 ticker without auth → 401
+# 9.8 ticker without auth → 200 (public since stage 20a)
 NO_AUTH_TICKER=$(curl -s -o /dev/null -w "%{http_code}" \
   "$BASE_URL/api/v1/terminal/ticker?symbol=BTCUSDT")
-check "GET /terminal/ticker without auth → 401" "401" "$NO_AUTH_TICKER"
+check "GET /terminal/ticker without auth → 200" "200" "$NO_AUTH_TICKER"
 
-# 9.9 candles without auth → 401
+# 9.9 candles without auth → 200 (public since stage 20a)
 NO_AUTH_CANDLES=$(curl -s -o /dev/null -w "%{http_code}" \
   "$BASE_URL/api/v1/terminal/candles?symbol=BTCUSDT&interval=15&limit=10")
-check "GET /terminal/candles without auth → 401" "401" "$NO_AUTH_CANDLES"
+check "GET /terminal/candles without auth → 200" "200" "$NO_AUTH_CANDLES"
 
 # 9.10 candles daily interval D → 200
 DAILY=$(curl -s -o /dev/null -w "%{http_code}" \
@@ -1800,6 +1800,26 @@ S20C_BAD_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X PUT "$BASE_URL/api/v1/
   -H "Content-Type: application/json" \
   -d '{"terminalJson":{"version":999,"terminal":{}}}')
 check "20c.4 PUT /user/preferences invalid version → 400" "400" "$S20C_BAD_CODE"
+
+# ─── 20a. Guest mode — market data without auth ──────────────────────────────
+header "20a. Guest mode — market data without auth"
+
+# 20a.1 GET /terminal/ticker without auth → 200
+GUEST_TICKER=$(curl -s -o /dev/null -w "%{http_code}" \
+  "$BASE_URL/api/v1/terminal/ticker?symbol=BTCUSDT")
+check "20a.1 GET /terminal/ticker (no auth) → 200" "200" "$GUEST_TICKER"
+
+# 20a.2 GET /terminal/candles without auth → 200
+GUEST_CANDLES=$(curl -s -o /dev/null -w "%{http_code}" \
+  "$BASE_URL/api/v1/terminal/candles?symbol=BTCUSDT&interval=15&limit=50")
+check "20a.2 GET /terminal/candles (no auth) → 200" "200" "$GUEST_CANDLES"
+
+# 20a.3 POST /terminal/orders without auth → 401 (still protected)
+GUEST_ORDER=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"symbol":"BTCUSDT","side":"BUY","type":"MARKET","qty":0.001}' \
+  "$BASE_URL/api/v1/terminal/orders")
+check "20a.3 POST /terminal/orders (no auth) → 401" "401" "$GUEST_ORDER"
 
 # ─── Summary ─────────────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary

- Backend: GET /terminal/ticker + /terminal/candles — публичные (снят authenticate)
- Frontend: убран auth gate на терминале, loadAll() работает без токена, guard на /exchanges, CTA для гостя в Order Panel и Orders tab
- OnboardingModal: новый компонент, localStorage.onboardingSeen, Sign in / Continue as guest
- layout.tsx: OnboardingModal смонтирован после Navbar
- Smoke: 9.8/9.9 → 200, секция 20a.1-20a.3 добавлена

https://claude.ai/code/session_015xWq52yJESygpsMx5FCebz