### PR TITLE
feat(stage-20b): navbar profile + avatar url + dropdown menu

### DIFF
--- a/apps/api/prisma/migrations/20260305b_stage20b_user_avatar_url/migration.sql
+++ b/apps/api/prisma/migrations/20260305b_stage20b_user_avatar_url/migration.sql
@@ -1,0 +1,2 @@
+-- Stage 20b: add avatarUrl column to User table
+ALTER TABLE "User" ADD COLUMN "avatarUrl" TEXT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -11,6 +11,7 @@ model User {
   id           String   @id @default(uuid())
   email        String   @unique
   passwordHash String
+  avatarUrl    String?
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -17,6 +17,7 @@ import { exchangeRoutes } from "./routes/exchanges.js";
 import { terminalRoutes } from "./routes/terminal.js";
 import { aiRoutes } from "./routes/ai.js";
 import { preferencesRoutes } from "./routes/preferences.js";
+import { usersRoutes } from "./routes/users.js";
 
 /** Registers all domain routes. */
 async function registerRoutes(scope: import("fastify").FastifyInstance) {
@@ -34,6 +35,7 @@ async function registerRoutes(scope: import("fastify").FastifyInstance) {
   await scope.register(terminalRoutes);
   await scope.register(aiRoutes);
   await scope.register(preferencesRoutes);
+  await scope.register(usersRoutes);
 }
 
 export async function buildApp() {

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -94,12 +94,16 @@ export async function authRoutes(app: FastifyInstance) {
   // ── GET /auth/me ───────────────────────────────────────────────────────────
   app.get("/auth/me", { onRequest: [app.authenticate] }, async (request, reply) => {
     const payload = request.user as { sub: string; email: string };
+    const user = await prisma.user.findUnique({ where: { id: payload.sub } });
+    if (!user) {
+      return reply.status(401).send({ type: "about:blank", title: "Unauthorized", status: 401, detail: "User not found" });
+    }
     const membership = await prisma.workspaceMember.findFirst({
       where: { userId: payload.sub },
       orderBy: { createdAt: "asc" },
     });
     return reply.send({
-      user: { id: payload.sub, email: payload.email },
+      user: { id: user.id, email: user.email, avatarUrl: user.avatarUrl ?? null },
       workspaceId: membership?.workspaceId ?? null,
     });
   });

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,0 +1,45 @@
+import type { FastifyInstance } from "fastify";
+import { prisma } from "../lib/prisma.js";
+
+interface PatchMeBody {
+  avatarUrl?: string | null;
+}
+
+export async function usersRoutes(app: FastifyInstance) {
+  // ── PATCH /users/me ────────────────────────────────────────────────────────
+  app.patch<{ Body: PatchMeBody }>("/users/me", { onRequest: [app.authenticate] }, async (request, reply) => {
+    const payload = request.user as { sub: string; email: string };
+    const { avatarUrl } = request.body ?? {};
+
+    // Normalize: null or empty string → clear
+    let normalized: string | null = null;
+    if (avatarUrl !== undefined && avatarUrl !== null && avatarUrl !== "") {
+      const trimmed = avatarUrl.trim();
+      if (trimmed.length > 2048) {
+        return reply.status(400).send({
+          type: "about:blank",
+          title: "Bad Request",
+          status: 400,
+          detail: "avatarUrl must not exceed 2048 characters",
+        });
+      }
+      if (!trimmed.startsWith("http://") && !trimmed.startsWith("https://")) {
+        return reply.status(400).send({
+          type: "about:blank",
+          title: "Bad Request",
+          status: 400,
+          detail: "avatarUrl must start with http:// or https://",
+        });
+      }
+      normalized = trimmed;
+    }
+
+    const user = await prisma.user.update({
+      where: { id: payload.sub },
+      data: { avatarUrl: normalized },
+      select: { id: true, email: true, avatarUrl: true },
+    });
+
+    return reply.send({ user: { id: user.id, email: user.email, avatarUrl: user.avatarUrl ?? null } });
+  });
+}

--- a/apps/web/src/app/navbar.tsx
+++ b/apps/web/src/app/navbar.tsx
@@ -2,8 +2,8 @@
 
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
-import { getToken, clearAuth } from "../lib/api";
+import { useEffect, useRef, useState } from "react";
+import { getToken, clearAuth, apiFetchNoWorkspace } from "../lib/api";
 
 const NAV_ITEMS = [
   { href: "/terminal", label: "Terminal" },
@@ -11,19 +11,54 @@ const NAV_ITEMS = [
   { href: "/factory", label: "Factory" },
 ] as const;
 
+interface MeResponse {
+  user: { id: string; email: string; avatarUrl?: string | null };
+  workspaceId: string | null;
+}
+
 export function Navbar() {
   const pathname = usePathname();
   const router = useRouter();
   const [isAuth, setIsAuth] = useState(false);
+  const [userInfo, setUserInfo] = useState<{ email: string; avatarUrl?: string | null } | null>(null);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    setIsAuth(!!getToken());
+    const token = getToken();
+    setIsAuth(!!token);
+    if (token) {
+      apiFetchNoWorkspace<MeResponse>("/auth/me").then((res) => {
+        if (res.ok) setUserInfo(res.data.user);
+        else setUserInfo(null);
+      });
+    } else {
+      setUserInfo(null);
+    }
+    setDropdownOpen(false);
   }, [pathname]);
+
+  useEffect(() => {
+    if (!dropdownOpen) return;
+    function handleClickOutside(e: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setDropdownOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [dropdownOpen]);
 
   function handleLogout() {
     clearAuth();
     setIsAuth(false);
+    setUserInfo(null);
+    setDropdownOpen(false);
     router.push("/login");
+  }
+
+  function getInitials(email: string): string {
+    return email.slice(0, 2).toUpperCase();
   }
 
   return (
@@ -77,34 +112,103 @@ export function Navbar() {
 
       <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: "8px" }}>
         {isAuth ? (
-          <>
-            <Link
-              href="/settings"
-              style={{
-                padding: "6px 14px",
-                borderRadius: "6px",
-                fontSize: "13px",
-                color: pathname.startsWith("/settings") ? "var(--accent)" : "var(--text-secondary)",
-                background: pathname.startsWith("/settings") ? "var(--bg-card)" : "transparent",
-              }}
-            >
-              ⚙ Settings
-            </Link>
+          <div ref={dropdownRef} style={{ position: "relative" }}>
+            {/* Profile trigger */}
             <button
-              onClick={handleLogout}
+              onClick={() => setDropdownOpen((o) => !o)}
               style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "8px",
                 background: "transparent",
                 border: "1px solid var(--border)",
                 borderRadius: "6px",
-                color: "var(--text-secondary)",
+                color: "var(--text-primary)",
                 cursor: "pointer",
                 fontSize: "13px",
-                padding: "6px 14px",
+                padding: "5px 10px",
               }}
             >
-              Sign out
+              {/* Avatar circle */}
+              <span style={{
+                width: 28,
+                height: 28,
+                borderRadius: "50%",
+                overflow: "hidden",
+                background: "var(--accent)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                flexShrink: 0,
+                fontSize: "11px",
+                fontWeight: 700,
+                color: "#fff",
+              }}>
+                {userInfo?.avatarUrl ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={userInfo.avatarUrl}
+                    alt="avatar"
+                    style={{ width: "100%", height: "100%", objectFit: "cover" }}
+                  />
+                ) : (
+                  <span>{userInfo ? getInitials(userInfo.email) : "…"}</span>
+                )}
+              </span>
+              {userInfo?.email && (
+                <span style={{ maxWidth: 160, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                  {userInfo.email}
+                </span>
+              )}
+              <span style={{ fontSize: "10px", opacity: 0.6 }}>▾</span>
             </button>
-          </>
+
+            {/* Dropdown */}
+            {dropdownOpen && (
+              <div style={{
+                position: "absolute",
+                top: "calc(100% + 6px)",
+                right: 0,
+                background: "var(--bg-secondary)",
+                border: "1px solid var(--border)",
+                borderRadius: "8px",
+                minWidth: 160,
+                zIndex: 200,
+                boxShadow: "0 4px 16px rgba(0,0,0,0.3)",
+                overflow: "hidden",
+              }}>
+                <Link
+                  href="/settings"
+                  onClick={() => setDropdownOpen(false)}
+                  style={{
+                    display: "block",
+                    padding: "10px 16px",
+                    fontSize: "13px",
+                    color: "var(--text-primary)",
+                    borderBottom: "1px solid var(--border)",
+                  }}
+                >
+                  ⚙ Settings
+                </Link>
+                <button
+                  onClick={handleLogout}
+                  style={{
+                    display: "block",
+                    width: "100%",
+                    textAlign: "left",
+                    padding: "10px 16px",
+                    fontSize: "13px",
+                    color: "var(--text-secondary)",
+                    background: "transparent",
+                    border: "none",
+                    cursor: "pointer",
+                  }}
+                >
+                  Sign out
+                </button>
+              </div>
+            )}
+          </div>
         ) : (
           <>
             <Link

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -11,6 +11,12 @@ import { apiFetch, apiFetchNoWorkspace, clearAuth, getToken } from "../../lib/ap
 interface Me {
   id: string;
   email: string;
+  avatarUrl?: string | null;
+}
+
+interface MeResponse {
+  user: Me;
+  workspaceId: string | null;
 }
 
 interface ExchangeConn {
@@ -45,6 +51,11 @@ export default function SettingsPage() {
   const [sessionExpired, setSessionExpired] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // avatar
+  const [avatarInput, setAvatarInput] = useState("");
+  const [avatarSaving, setAvatarSaving] = useState(false);
+  const [avatarError, setAvatarError] = useState<string | null>(null);
+
   // appearance
   const [theme, setTheme] = useState<Theme>("system");
 
@@ -69,14 +80,15 @@ export default function SettingsPage() {
     }
     setConnLoading(true);
     Promise.all([
-      apiFetchNoWorkspace<Me>("/auth/me"),
+      apiFetchNoWorkspace<MeResponse>("/auth/me"),
       apiFetch<ExchangeConn[]>("/exchanges"),
     ]).then(([meRes, connsRes]) => {
       setLoading(false);
       setConnLoading(false);
 
       if (meRes.ok) {
-        setMe(meRes.data);
+        setMe(meRes.data.user);
+        setAvatarInput(meRes.data.user.avatarUrl ?? "");
       } else if (meRes.problem.status === 401) {
         setSessionExpired(true);
         return;
@@ -97,6 +109,21 @@ export default function SettingsPage() {
   function handleLogout() {
     clearAuth();
     router.push("/login");
+  }
+
+  async function handleAvatarSave() {
+    setAvatarError(null);
+    setAvatarSaving(true);
+    const res = await apiFetchNoWorkspace<{ user: Me }>("/users/me", {
+      method: "PATCH",
+      body: JSON.stringify({ avatarUrl: avatarInput.trim() || null }),
+    });
+    setAvatarSaving(false);
+    if (res.ok) {
+      setMe((prev) => prev ? { ...prev, avatarUrl: res.data.user.avatarUrl } : prev);
+    } else {
+      setAvatarError(res.problem.detail ?? "Failed to save avatar");
+    }
   }
 
   function applyTheme(t: Theme) {
@@ -218,6 +245,34 @@ export default function SettingsPage() {
         </div>
         <div style={{ marginTop: 20 }}>
           <button onClick={handleLogout} style={logoutBtn}>Log out</button>
+        </div>
+      </section>
+
+      {/* Avatar block */}
+      <section style={card}>
+        <h2 style={sectionTitle}>Avatar</h2>
+        {avatarError && <p style={{ color: "#f85149", fontSize: 13, marginBottom: 12 }}>{avatarError}</p>}
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+          {me?.avatarUrl && (
+            <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={me.avatarUrl}
+                alt="avatar preview"
+                style={{ width: 56, height: 56, borderRadius: "50%", objectFit: "cover", border: "1px solid var(--border)" }}
+              />
+              <span style={{ color: "var(--text-secondary)", fontSize: 12 }}>Current avatar</span>
+            </div>
+          )}
+          <input
+            placeholder="Avatar URL (http:// or https://)"
+            value={avatarInput}
+            onChange={(e) => setAvatarInput(e.target.value)}
+            style={inputStyle}
+          />
+          <button onClick={handleAvatarSave} disabled={avatarSaving} style={{ ...primaryBtn, alignSelf: "flex-start" }}>
+            {avatarSaving ? "Saving…" : "Save Avatar"}
+          </button>
         </div>
       </section>
 

--- a/deploy/smoke-test.sh
+++ b/deploy/smoke-test.sh
@@ -1821,6 +1821,46 @@ GUEST_ORDER=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
   "$BASE_URL/api/v1/terminal/orders")
 check "20a.3 POST /terminal/orders (no auth) → 401" "401" "$GUEST_ORDER"
 
+# ─── 20b. Navbar profile — avatarUrl + PATCH /users/me ───────────────────────
+header "20b. Navbar profile — avatarUrl + PATCH /users/me"
+
+# 20b.1 GET /auth/me (authed) → 200 and contains "email"
+S20B_ME=$(curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE_URL/api/v1/auth/me")
+S20B_ME_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer $TOKEN" \
+  "$BASE_URL/api/v1/auth/me")
+if [[ "$S20B_ME_CODE" == "200" ]] && echo "$S20B_ME" | grep -q '"email"'; then
+  ((++PASS)); printf "  \033[32m✓\033[0m 20b.1 GET /auth/me (authed) → 200 with email\n"
+else
+  ((++FAIL)); printf "  \033[31m✗\033[0m 20b.1 GET /auth/me (authed) → 200 with email (got $S20B_ME_CODE)\n"
+fi
+
+# 20b.2 PATCH /users/me set avatarUrl → 200
+S20B_PATCH=$(curl -s -o /dev/null -w "%{http_code}" -X PATCH \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"avatarUrl":"https://example.com/avatar-stage20b.gif"}' \
+  "$BASE_URL/api/v1/users/me")
+check "20b.2 PATCH /users/me set avatarUrl → 200" "200" "$S20B_PATCH"
+
+# 20b.3 GET /auth/me now contains avatarUrl (DB lookup)
+S20B_ME2=$(curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE_URL/api/v1/auth/me")
+if echo "$S20B_ME2" | grep -q '"avatarUrl"'; then
+  ((++PASS)); printf "  \033[32m✓\033[0m 20b.3 GET /auth/me contains avatarUrl after PATCH\n"
+else
+  ((++FAIL)); printf "  \033[31m✗\033[0m 20b.3 GET /auth/me contains avatarUrl after PATCH\n"
+fi
+
+# 20b.4 PATCH /users/me clear avatarUrl → 200
+S20B_CLEAR=$(curl -s -o /dev/null -w "%{http_code}" -X PATCH \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"avatarUrl":null}' \
+  "$BASE_URL/api/v1/users/me")
+check "20b.4 PATCH /users/me clear avatarUrl → 200" "200" "$S20B_CLEAR"
+
 # ─── Summary ─────────────────────────────────────────────────────────────────
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
- Prisma: add User.avatarUrl String? column + migration
- GET /auth/me: DB lookup (prisma.user.findUnique) to include avatarUrl
- POST new route PATCH /users/me: set/clear avatarUrl with validation (http/https only, max 2048 chars, null/empty clears)
- app.ts: register usersRoutes so PATCH /users/me is not 404
- Navbar: fetch /auth/me on pathname change; show email + avatar circle with initials fallback; dropdown menu (Settings + Logout) replaces flat Settings/Sign-out buttons; click-outside closes dropdown
- Settings: extend Me type with avatarUrl; fix /auth/me response shape (extract .user); add Avatar block with URL input, preview <img>, Save button via PATCH /users/me (apiFetchNoWorkspace)
- Smoke tests: add section 20b (4 checks for /auth/me + PATCH /users/me)

Notes: <img> used intentionally (not next/image) for arbitrary domains; /auth/me now uses DB lookup so avatarUrl is always current.

https://claude.ai/code/session_015xWq52yJESygpsMx5FCebz