### PR TITLE
feat(stage-20d): terminal symbols directory + watchlist builder + pol…

### DIFF
--- a/apps/api/src/routes/terminal.ts
+++ b/apps/api/src/routes/terminal.ts
@@ -66,12 +66,190 @@ function bybitErrorToProblem(
 }
 
 // ---------------------------------------------------------------------------
+// Stage 20d — Symbols directory + batch tickers
+// ---------------------------------------------------------------------------
+
+const SUPPORTED_EXCHANGES = ["bybit"] as const;
+const SUPPORTED_MARKETS = ["linear", "spot"] as const;
+type SupportedMarket = (typeof SUPPORTED_MARKETS)[number];
+
+const BYBIT_PUBLIC_BASE = "https://api.bybit.com";
+const MAX_TICKER_SYMBOLS = 30;
+
+/** Map our "market" param to Bybit category */
+function marketToCategory(market: SupportedMarket): string {
+  if (market === "spot") return "spot";
+  return "linear"; // linear perpetuals
+}
+
+interface BybitInstrumentsResponse {
+  retCode: number;
+  retMsg: string;
+  result: {
+    list: Array<{
+      symbol: string;
+      baseCoin: string;
+      quoteCoin: string;
+      status: string;
+    }>;
+  };
+}
+
+interface BybitBatchTickerResponse {
+  retCode: number;
+  retMsg: string;
+  result: {
+    list: Array<{
+      symbol: string;
+      lastPrice: string;
+      price24hPcnt: string;
+    }>;
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Routes
 // ---------------------------------------------------------------------------
 
 export async function terminalRoutes(app: FastifyInstance) {
   // Register order routes (Stage 9b)
   registerOrderRoutes(app);
+
+  /**
+   * GET /terminal/symbols?exchange=bybit&market=linear
+   *
+   * Public endpoint — no auth required.
+   * Returns tradeable instruments for the given exchange+market.
+   */
+  app.get<{ Querystring: { exchange?: string; market?: string } }>(
+    "/terminal/symbols",
+    async (request, reply) => {
+      const { exchange, market } = request.query;
+
+      if (!exchange || !SUPPORTED_EXCHANGES.includes(exchange as "bybit")) {
+        return problem(
+          reply,
+          400,
+          "Bad Request",
+          `Query parameter 'exchange' is required. Supported: ${SUPPORTED_EXCHANGES.join(", ")}`,
+        );
+      }
+      if (!market || !SUPPORTED_MARKETS.includes(market as SupportedMarket)) {
+        return problem(
+          reply,
+          400,
+          "Bad Request",
+          `Query parameter 'market' is required. Supported: ${SUPPORTED_MARKETS.join(", ")}`,
+        );
+      }
+
+      const category = marketToCategory(market as SupportedMarket);
+      const url =
+        `${BYBIT_PUBLIC_BASE}/v5/market/instruments-info?category=${category}&status=Trading&limit=1000`;
+
+      try {
+        const res = await fetch(url, { headers: { "User-Agent": "botmarketplace-terminal/1" } });
+        if (!res.ok) {
+          throw new Error(`Bybit instruments request failed: ${res.status} ${res.statusText}`);
+        }
+        const json = (await res.json()) as BybitInstrumentsResponse;
+        if (json.retCode !== 0) {
+          throw new Error(`Bybit API error ${json.retCode}: ${json.retMsg}`);
+        }
+
+        const symbols = (json.result?.list ?? []).map((item) => ({
+          symbol: item.symbol,
+          base: item.baseCoin,
+          quote: item.quoteCoin,
+          status: item.status,
+        }));
+
+        return reply.send({ exchange, market, symbols });
+      } catch (err) {
+        request.log.warn({ exchange, market, err }, "terminal symbols fetch failed");
+        return bybitErrorToProblem(reply, err, "symbols");
+      }
+    },
+  );
+
+  /**
+   * GET /terminal/tickers?exchange=bybit&market=linear&symbols=BTCUSDT,ETHUSDT
+   *
+   * Public endpoint — no auth required.
+   * Returns lastPrice + price24hPcnt for a batch of symbols (max 30).
+   */
+  app.get<{ Querystring: { exchange?: string; market?: string; symbols?: string } }>(
+    "/terminal/tickers",
+    async (request, reply) => {
+      const { exchange, market, symbols: symbolsParam } = request.query;
+
+      if (!exchange || !SUPPORTED_EXCHANGES.includes(exchange as "bybit")) {
+        return problem(
+          reply,
+          400,
+          "Bad Request",
+          `Query parameter 'exchange' is required. Supported: ${SUPPORTED_EXCHANGES.join(", ")}`,
+        );
+      }
+      if (!market || !SUPPORTED_MARKETS.includes(market as SupportedMarket)) {
+        return problem(
+          reply,
+          400,
+          "Bad Request",
+          `Query parameter 'market' is required. Supported: ${SUPPORTED_MARKETS.join(", ")}`,
+        );
+      }
+      if (!symbolsParam || !symbolsParam.trim()) {
+        return problem(reply, 400, "Bad Request", "Query parameter 'symbols' is required (comma-separated)");
+      }
+
+      const symbolList = symbolsParam
+        .split(",")
+        .map((s) => s.trim().toUpperCase())
+        .filter(Boolean);
+
+      if (symbolList.length === 0) {
+        return problem(reply, 400, "Bad Request", "'symbols' must contain at least one symbol");
+      }
+      if (symbolList.length > MAX_TICKER_SYMBOLS) {
+        return problem(
+          reply,
+          400,
+          "Bad Request",
+          `Too many symbols. Maximum allowed: ${MAX_TICKER_SYMBOLS}`,
+        );
+      }
+
+      const category = marketToCategory(market as SupportedMarket);
+
+      // Fan out — Bybit tickers endpoint accepts a single symbol per call.
+      try {
+        const results = await Promise.all(
+          symbolList.map(async (sym) => {
+            const url =
+              `${BYBIT_PUBLIC_BASE}/v5/market/tickers?category=${category}&symbol=${encodeURIComponent(sym)}`;
+            const res = await fetch(url, { headers: { "User-Agent": "botmarketplace-terminal/1" } });
+            if (!res.ok) return null;
+            const json = (await res.json()) as BybitBatchTickerResponse;
+            if (json.retCode !== 0) return null;
+            const item = json.result?.list?.[0];
+            if (!item) return null;
+            return {
+              symbol: item.symbol,
+              lastPrice: item.lastPrice,
+              price24hPcnt: item.price24hPcnt,
+            };
+          }),
+        );
+
+        const tickers = results.filter(Boolean);
+        return reply.send({ exchange, market, tickers });
+      } catch (err) {
+        request.log.warn({ exchange, market, err }, "terminal tickers fetch failed");
+        return bybitErrorToProblem(reply, err, "tickers");
+      }
+    },
+  );
 
   /**
    * GET /terminal/ticker?symbol=BTCUSDT

--- a/apps/web/src/app/terminal/page.tsx
+++ b/apps/web/src/app/terminal/page.tsx
@@ -54,16 +54,40 @@ type LoadState = "idle" | "loading" | "success" | "error";
 type OrderState = "idle" | "loading" | "success" | "error";
 type BottomTab = "ticker" | "orders" | "candles";
 
+interface SymbolInfo {
+  symbol: string;
+  base: string;
+  quote: string;
+  status: string;
+}
+
+interface WatchlistQuote {
+  symbol: string;
+  lastPrice: string;
+  price24hPcnt: string;
+  prevLastPrice?: string; // for up/down hint
+}
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
-const WATCHLIST_SYMBOLS = ["BTCUSDT", "ETHUSDT", "SOLUSDT", "BNBUSDT", "XRPUSDT"] as const;
+const SUPPORTED_EXCHANGES = ["bybit"] as const;
+const SUPPORTED_MARKETS = ["linear", "spot"] as const;
+type SupportedExchange = (typeof SUPPORTED_EXCHANGES)[number];
+type SupportedMarket = (typeof SUPPORTED_MARKETS)[number];
+
+const DEFAULT_EXCHANGE: SupportedExchange = "bybit";
+const DEFAULT_MARKET: SupportedMarket = "linear";
 const DEFAULT_SYMBOL = "BTCUSDT";
 const DEFAULT_INTERVAL = "15";
 
+const DEFAULT_WATCHLIST = ["BTCUSDT", "ETHUSDT", "SOLUSDT", "BNBUSDT", "XRPUSDT"];
+const MAX_WATCHLIST = 30;
+const POLL_INTERVAL_MS = 2000;
+
 // ---------------------------------------------------------------------------
-// Preferences helpers (Stage 20c)
+// Preferences helpers (Stage 20c extended for 20d)
 // ---------------------------------------------------------------------------
 
 const PREFS_LS_KEY = "terminalPrefsV1";
@@ -79,17 +103,22 @@ interface MarketPrefs {
 
 interface TerminalJson {
   version: 1;
+  selectedExchange?: string;
+  selectedMarket?: string;
   terminal: Record<string, MarketPrefs>;
 }
 
-/** Exchange+market key for bybit linear (default) */
-const MARKET_KEY = "bybit:linear";
+function marketKey(exchange: string, market: string) {
+  return `${exchange}:${market}`;
+}
 
 const DEFAULT_PREFS: TerminalJson = {
   version: 1,
+  selectedExchange: DEFAULT_EXCHANGE,
+  selectedMarket: DEFAULT_MARKET,
   terminal: {
-    [MARKET_KEY]: {
-      watchlist: [...WATCHLIST_SYMBOLS],
+    [marketKey(DEFAULT_EXCHANGE, DEFAULT_MARKET)]: {
+      watchlist: [...DEFAULT_WATCHLIST],
       activeSymbol: DEFAULT_SYMBOL,
       interval: DEFAULT_INTERVAL,
       indicators: [],
@@ -140,6 +169,16 @@ export default function TerminalPage() {
     setHasToken(!!getToken());
   }, []);
 
+  // --- Exchange + Market selection ---
+  const [selectedExchange, setSelectedExchange] = useState<SupportedExchange>(DEFAULT_EXCHANGE);
+  const [selectedMarket, setSelectedMarket] = useState<SupportedMarket>(DEFAULT_MARKET);
+
+  // --- Symbols directory ---
+  const [allSymbols, setAllSymbols] = useState<SymbolInfo[]>([]);
+  const [symbolsLoading, setSymbolsLoading] = useState(false);
+  const [symbolSearch, setSymbolSearch] = useState("");
+  const [showPicker, setShowPicker] = useState(false);
+
   // --- Market Data state ---
   const [symbol, setSymbol] = useState(DEFAULT_SYMBOL);
   const [interval, setInterval] = useState(DEFAULT_INTERVAL);
@@ -168,6 +207,11 @@ export default function TerminalPage() {
   const [allOrders, setAllOrders] = useState<TerminalOrder[]>([]);
   const [markers, setMarkers] = useState<ChartMarker[]>([]);
 
+  // --- Watchlist + polling ---
+  const [watchlist, setWatchlist] = useState<string[]>([...DEFAULT_WATCHLIST]);
+  const [watchlistQuotes, setWatchlistQuotes] = useState<Record<string, WatchlistQuote>>({});
+  const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   // --- Layout state ---
   const [showWatchlist, setShowWatchlist] = useState(true);
   const [showOrderPanel, setShowOrderPanel] = useState(true);
@@ -181,30 +225,48 @@ export default function TerminalPage() {
     }
   }, []);
 
-  // --- Preferences sync (Stage 20c) ---
+  // --- Preferences sync (Stage 20c extended) ---
   const prefsSaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const prefsLoaded = useRef(false);
 
-  /** Build current prefs snapshot from local state */
+  const currentMktKey = marketKey(selectedExchange, selectedMarket);
+
+  /** Build current prefs snapshot */
   const buildPrefs = useCallback((): TerminalJson => ({
     version: 1,
+    selectedExchange,
+    selectedMarket,
     terminal: {
-      [MARKET_KEY]: {
-        watchlist: [...WATCHLIST_SYMBOLS],
+      [currentMktKey]: {
+        watchlist: [...watchlist],
         activeSymbol: symbol,
         interval,
         indicators: [],
         layout: { showWatchlist, showOrderPanel },
       },
     },
-  }), [symbol, interval, showWatchlist, showOrderPanel]);
+  }), [selectedExchange, selectedMarket, currentMktKey, watchlist, symbol, interval, showWatchlist, showOrderPanel]);
 
   /** Apply a loaded TerminalJson to local state */
   function applyPrefs(tj: TerminalJson) {
-    const mkt = tj.terminal?.[MARKET_KEY];
+    if (tj.selectedExchange && SUPPORTED_EXCHANGES.includes(tj.selectedExchange as SupportedExchange)) {
+      setSelectedExchange(tj.selectedExchange as SupportedExchange);
+    }
+    if (tj.selectedMarket && SUPPORTED_MARKETS.includes(tj.selectedMarket as SupportedMarket)) {
+      setSelectedMarket(tj.selectedMarket as SupportedMarket);
+    }
+    // Load prefs for the saved market key
+    const mktKey = marketKey(
+      tj.selectedExchange ?? DEFAULT_EXCHANGE,
+      tj.selectedMarket ?? DEFAULT_MARKET,
+    );
+    const mkt = tj.terminal?.[mktKey] ?? tj.terminal?.[marketKey(DEFAULT_EXCHANGE, DEFAULT_MARKET)];
     if (!mkt) return;
     if (mkt.activeSymbol) setSymbol(mkt.activeSymbol);
     if (mkt.interval) setInterval(mkt.interval);
+    if (Array.isArray(mkt.watchlist) && mkt.watchlist.length > 0) {
+      setWatchlist(mkt.watchlist.slice(0, MAX_WATCHLIST));
+    }
     if (mkt.layout) {
       if (typeof mkt.layout.showWatchlist === "boolean") setShowWatchlist(mkt.layout.showWatchlist);
       if (typeof mkt.layout.showOrderPanel === "boolean") setShowOrderPanel(mkt.layout.showOrderPanel);
@@ -264,15 +326,66 @@ export default function TerminalPage() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Save preferences whenever key state changes (after initial load)
+  // Save preferences when key state changes
   useEffect(() => {
     if (!prefsLoaded.current) return;
     schedulePrefsWrite(buildPrefs());
-  }, [symbol, interval, showWatchlist, showOrderPanel, buildPrefs, schedulePrefsWrite]);
+  }, [symbol, interval, showWatchlist, showOrderPanel, watchlist, selectedExchange, selectedMarket, buildPrefs, schedulePrefsWrite]);
 
-  // Load exchange connections on mount (auth only — guests must not call this)
+  // --- Load symbols directory when exchange/market changes ---
   useEffect(() => {
-    if (!hasToken) return;
+    setAllSymbols([]);
+    setSymbolsLoading(true);
+    apiFetchNoWorkspace<{ symbols: SymbolInfo[] }>(
+      `/terminal/symbols?exchange=${selectedExchange}&market=${selectedMarket}`,
+    ).then((res) => {
+      if (res.ok) setAllSymbols(res.data.symbols ?? []);
+    }).catch(() => undefined).finally(() => setSymbolsLoading(false));
+  }, [selectedExchange, selectedMarket]);
+
+  // --- Watchlist polling ---
+  const pollWatchlistQuotes = useCallback(async () => {
+    if (watchlist.length === 0) return;
+    const syms = watchlist.slice(0, MAX_WATCHLIST).join(",");
+    const res = await apiFetchNoWorkspace<{ tickers: Array<{ symbol: string; lastPrice: string; price24hPcnt: string }> }>(
+      `/terminal/tickers?exchange=${selectedExchange}&market=${selectedMarket}&symbols=${encodeURIComponent(syms)}`,
+    );
+    if (!res.ok) return;
+    setWatchlistQuotes((prev) => {
+      const next: Record<string, WatchlistQuote> = { ...prev };
+      for (const t of res.data.tickers ?? []) {
+        next[t.symbol] = {
+          symbol: t.symbol,
+          lastPrice: t.lastPrice,
+          price24hPcnt: t.price24hPcnt,
+          prevLastPrice: prev[t.symbol]?.lastPrice,
+        };
+      }
+      return next;
+    });
+  }, [watchlist, selectedExchange, selectedMarket]);
+
+  // Start/restart polling when watchlist or exchange/market changes
+  useEffect(() => {
+    if (pollTimerRef.current) clearTimeout(pollTimerRef.current);
+    let active = true;
+    function schedulePoll() {
+      void pollWatchlistQuotes().finally(() => {
+        if (active) {
+          pollTimerRef.current = setTimeout(schedulePoll, POLL_INTERVAL_MS);
+        }
+      });
+    }
+    schedulePoll();
+    return () => {
+      active = false;
+      if (pollTimerRef.current) clearTimeout(pollTimerRef.current);
+    };
+  }, [pollWatchlistQuotes]);
+
+  // Load exchange connections on mount (auth only)
+  useEffect(() => {
+    if (!getToken()) return;
     apiFetch<ExchangeConnection[]>("/exchanges").then((res) => {
       if (res.ok) {
         setConnections(res.data);
@@ -281,7 +394,7 @@ export default function TerminalPage() {
         setSessionExpired(true);
       }
     });
-  }, [hasToken]);
+  }, []);
 
   // Load orders for markers (workspace-scoped via apiFetch)
   useEffect(() => {
@@ -469,6 +582,28 @@ export default function TerminalPage() {
           {showWatchlist ? "◀ Watch" : "Watch ▶"}
         </button>
 
+        {/* Exchange selector */}
+        <select
+          style={{ ...input, width: 80 }}
+          value={selectedExchange}
+          onChange={(e) => setSelectedExchange(e.target.value as SupportedExchange)}
+        >
+          {SUPPORTED_EXCHANGES.map((ex) => (
+            <option key={ex} value={ex}>{ex}</option>
+          ))}
+        </select>
+
+        {/* Market selector */}
+        <select
+          style={{ ...input, width: 80 }}
+          value={selectedMarket}
+          onChange={(e) => setSelectedMarket(e.target.value as SupportedMarket)}
+        >
+          {SUPPORTED_MARKETS.map((m) => (
+            <option key={m} value={m}>{m}</option>
+          ))}
+        </select>
+
         <input
           style={{ ...input, width: 120 }}
           placeholder="Symbol"
@@ -476,6 +611,15 @@ export default function TerminalPage() {
           onChange={(e) => setSymbol(e.target.value.toUpperCase())}
           onKeyDown={(e) => e.key === "Enter" && loadAll()}
         />
+
+        {/* Symbols picker toggle */}
+        <button
+          style={togglePanelBtn}
+          onClick={() => setShowPicker((v) => !v)}
+          title="Browse symbols"
+        >
+          {symbolsLoading ? "..." : `+ Symbols`}
+        </button>
 
         <select
           style={{ ...input, width: 80 }}
@@ -512,6 +656,54 @@ export default function TerminalPage() {
         </button>
       </div>
 
+      {/* ── Symbols picker dropdown ── */}
+      {showPicker && (
+        <div style={pickerDropdown}>
+          <div style={{ display: "flex", gap: 6, marginBottom: 8 }}>
+            <input
+              style={{ ...input, flex: 1 }}
+              placeholder="Search symbols..."
+              value={symbolSearch}
+              onChange={(e) => setSymbolSearch(e.target.value.toUpperCase())}
+              autoFocus
+            />
+            <button style={togglePanelBtn} onClick={() => setShowPicker(false)}>✕</button>
+          </div>
+          <div style={{ maxHeight: 240, overflowY: "auto" }}>
+            {allSymbols
+              .filter((s) => !symbolSearch || s.symbol.includes(symbolSearch))
+              .slice(0, 100)
+              .map((s) => {
+                const inList = watchlist.includes(s.symbol);
+                return (
+                  <div key={s.symbol} style={pickerRow}>
+                    <span style={{ fontFamily: "monospace", fontSize: 13 }}>{s.symbol}</span>
+                    <span style={{ color: "var(--text-secondary)", fontSize: 11 }}>{s.base}/{s.quote}</span>
+                    <button
+                      style={{
+                        ...togglePanelBtn,
+                        padding: "2px 8px",
+                        fontSize: 11,
+                        marginLeft: "auto",
+                        color: inList ? "#f85149" : "#3fb950",
+                      }}
+                      onClick={() => {
+                        if (inList) {
+                          setWatchlist((prev) => prev.filter((x) => x !== s.symbol));
+                        } else if (watchlist.length < MAX_WATCHLIST) {
+                          setWatchlist((prev) => [...prev, s.symbol]);
+                        }
+                      }}
+                    >
+                      {inList ? "Remove" : "Add"}
+                    </button>
+                  </div>
+                );
+              })}
+          </div>
+        </div>
+      )}
+
       {/* ── Main row: Watchlist | Chart | Order Panel ── */}
       <div style={mainRow}>
 
@@ -519,20 +711,40 @@ export default function TerminalPage() {
         {showWatchlist && (
           <div style={watchlistPanel}>
             <div style={panelTitle}>Watchlist</div>
-            {WATCHLIST_SYMBOLS.map((sym) => (
-              <button
-                key={sym}
-                style={{
-                  ...watchlistItem,
-                  background: sym === symbol ? "var(--accent, #0969da)" : "transparent",
-                  color: sym === symbol ? "#fff" : "var(--text-primary)",
-                  fontWeight: sym === symbol ? 700 : 400,
-                }}
-                onClick={() => setSymbol(sym)}
-              >
-                {sym}
-              </button>
-            ))}
+            {watchlist.map((sym) => {
+              const q = watchlistQuotes[sym];
+              const pct = q ? parseFloat(q.price24hPcnt) : 0;
+              const priceUp = q && q.prevLastPrice ? parseFloat(q.lastPrice) > parseFloat(q.prevLastPrice) : null;
+              return (
+                <button
+                  key={sym}
+                  style={{
+                    ...watchlistItem,
+                    background: sym === symbol ? "var(--accent, #0969da)" : "transparent",
+                    color: sym === symbol ? "#fff" : "var(--text-primary)",
+                    fontWeight: sym === symbol ? 700 : 400,
+                  }}
+                  onClick={() => setSymbol(sym)}
+                >
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                    <span>{sym}</span>
+                    {q && (
+                      <span style={{
+                        fontSize: 11,
+                        color: priceUp === true ? "#3fb950" : priceUp === false ? "#f85149" : "inherit",
+                      }}>
+                        {priceUp === true ? "▲" : priceUp === false ? "▼" : ""}{q.lastPrice}
+                      </span>
+                    )}
+                  </div>
+                  {q && (
+                    <div style={{ fontSize: 10, color: pct > 0 ? "#3fb950" : pct < 0 ? "#f85149" : "var(--text-secondary)", textAlign: "right" }}>
+                      {pct > 0 ? "+" : ""}{(pct * 100).toFixed(2)}%
+                    </div>
+                  )}
+                </button>
+              );
+            })}
           </div>
         )}
 
@@ -1087,4 +1299,20 @@ const loginCtaBtn: React.CSSProperties = {
   cursor: "pointer",
   fontSize: 16,
   fontWeight: 600,
+};
+
+const pickerDropdown: React.CSSProperties = {
+  position: "relative",
+  background: "var(--bg-card)",
+  borderBottom: "1px solid var(--border)",
+  padding: "10px 12px",
+  zIndex: 10,
+};
+
+const pickerRow: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 8,
+  padding: "5px 4px",
+  borderBottom: "1px solid var(--border)",
 };

--- a/deploy/smoke-test.sh
+++ b/deploy/smoke-test.sh
@@ -1861,6 +1861,37 @@ S20B_CLEAR=$(curl -s -o /dev/null -w "%{http_code}" -X PATCH \
   "$BASE_URL/api/v1/users/me")
 check "20b.4 PATCH /users/me clear avatarUrl → 200" "200" "$S20B_CLEAR"
 
+# ─── 20d. Terminal Symbols Directory + Batch Tickers (public) ────────────────
+header "20d. Terminal Symbols Directory + Tickers (Stage 20d)"
+
+# 20d.1 GET /terminal/symbols?exchange=bybit&market=linear → 200 + non-empty symbols
+S20D_SYM=$(curl -s -w "\n%{http_code}" \
+  "$BASE_URL/api/v1/terminal/symbols?exchange=bybit&market=linear")
+S20D_SYM_CODE=$(echo "$S20D_SYM" | tail -1)
+S20D_SYM_BODY=$(echo "$S20D_SYM" | head -1)
+check "20d.1 GET /terminal/symbols linear → 200" "200" "$S20D_SYM_CODE"
+check_contains "20d.1 symbols response has symbols array" '"symbols"' "$S20D_SYM_BODY"
+check_contains "20d.1 symbols array non-empty (has BTCUSDT)" "BTCUSDT" "$S20D_SYM_BODY"
+
+# 20d.2 GET /terminal/tickers?exchange=bybit&market=linear&symbols=BTCUSDT,ETHUSDT → 200 + lastPrice
+S20D_TICK=$(curl -s -w "\n%{http_code}" \
+  "$BASE_URL/api/v1/terminal/tickers?exchange=bybit&market=linear&symbols=BTCUSDT,ETHUSDT")
+S20D_TICK_CODE=$(echo "$S20D_TICK" | tail -1)
+S20D_TICK_BODY=$(echo "$S20D_TICK" | head -1)
+check "20d.2 GET /terminal/tickers 2 symbols → 200" "200" "$S20D_TICK_CODE"
+check_contains "20d.2 tickers response has tickers array" '"tickers"' "$S20D_TICK_BODY"
+check_contains "20d.2 tickers response has lastPrice" '"lastPrice"' "$S20D_TICK_BODY"
+
+# 20d.3 GET /terminal/tickers with too many symbols (31) → 400
+S20D_TOO_MANY=$(curl -s -o /dev/null -w "%{http_code}" \
+  "$BASE_URL/api/v1/terminal/tickers?exchange=bybit&market=linear&symbols=$(python3 -c 'print(",".join([f"SYM{i}USDT" for i in range(31)]))')")
+check "20d.3 GET /terminal/tickers 31 symbols → 400" "400" "$S20D_TOO_MANY"
+
+# 20d.4 GET /terminal/symbols invalid market → 400
+S20D_BAD_MKT=$(curl -s -o /dev/null -w "%{http_code}" \
+  "$BASE_URL/api/v1/terminal/symbols?exchange=bybit&market=invalid")
+check "20d.4 GET /terminal/symbols invalid market → 400" "400" "$S20D_BAD_MKT"
+
 # ─── Summary ─────────────────────────────────────────────────────────────────
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
…ling quotes

- GET /terminal/symbols?exchange=bybit&market=linear|spot — public, returns tradeable instruments from Bybit Instruments API
- GET /terminal/tickers?exchange=bybit&market=…&symbols=A,B,C — public, fan-out batch tickers (max 30), returns lastPrice + price24hPcnt
- Validation: exchange (bybit only), market (linear/spot), symbols ≤30, non-empty → 400
- Frontend: Exchange + Market selectors in top bar
- Symbols picker: searchable list with checkboxes to add/remove from watchlist
- Watchlist with polling (recursive setTimeout, 2s): shows lastPrice + 24h% with up/down color
- Preferences extended: selectedExchange, selectedMarket persisted (20c)
- Guest mode: public symbols/tickers work without login; orders panel shows Sign in
- Smoke (deploy/smoke-test.sh, section 20d): 20d.1–20d.4 symbols/tickers 200, too-many 400, invalid market 400
- Build: API (tsc) ✓, Web (next build) ✓

https://claude.ai/code/session_01SCh9iBHg2KTKTg38X9B1iP