### PR TITLE
fix(lab): Phase A1 — critical bug fixes and type hardening

### DIFF
--- a/apps/web/src/app/lab/LabShell.tsx
+++ b/apps/web/src/app/lab/LabShell.tsx
@@ -153,8 +153,19 @@ function LabContextBar({ activeTab }: { activeTab: TabId }) {
           value={activeDatasetId ?? "— not selected"}
           dimmed={activeDatasetId === null}
         />
-        <CtxBadge label="Validation" value={validationState} dimmed />
-        <CtxBadge label="Run"        value={runState}        dimmed />
+        {/* A1-5: dimmed only when idle; error/warning state surfaces with colour */}
+        <CtxBadge
+          label="Validation"
+          value={validationState}
+          dimmed={validationState === "idle"}
+          variant={validationState === "error" ? "error" : validationState === "warning" ? "warning" : undefined}
+        />
+        <CtxBadge
+          label="Run"
+          value={runState}
+          dimmed={runState === "idle"}
+          variant={runState === "failed" ? "error" : undefined}
+        />
         {/* Phase 3A: save state badge — independent of compile/validation */}
         {isOnBuildTab && activeGraphId && (
           <div style={{ ...ctxBadgeStyle, borderColor: saveState === "save_error" ? "rgba(212,76,76,0.5)" : undefined }}>
@@ -228,23 +239,43 @@ function LabContextBar({ activeTab }: { activeTab: TabId }) {
   );
 }
 
+// A1-5: variant prop drives badge colour for error/warning states
+const BADGE_VARIANT_COLOR: Record<string, string> = {
+  error: "#D44C4C",
+  warning: "#FBBF24",
+};
+
 function CtxBadge({
   label,
   value,
   dimmed,
+  variant,
 }: {
   label: string;
   value: string;
   dimmed?: boolean;
+  variant?: "error" | "warning";
 }) {
+  const valueColor = variant
+    ? BADGE_VARIANT_COLOR[variant]
+    : dimmed
+    ? "var(--text-secondary)"
+    : "var(--text-primary)";
+
   return (
-    <div style={ctxBadgeStyle}>
+    <div
+      style={{
+        ...ctxBadgeStyle,
+        borderColor: variant === "error" ? "rgba(212,76,76,0.4)" : variant === "warning" ? "rgba(251,191,36,0.3)" : undefined,
+      }}
+    >
       <span style={{ color: "var(--text-secondary)", fontSize: 11 }}>{label}:</span>
       <span
         style={{
           fontSize: 12,
           marginLeft: 4,
-          color: dimmed ? "var(--text-secondary)" : "var(--text-primary)",
+          color: valueColor,
+          fontWeight: variant ? 600 : 400,
         }}
       >
         {value}

--- a/apps/web/src/app/lab/build/InspectorPanel.tsx
+++ b/apps/web/src/app/lab/build/InspectorPanel.tsx
@@ -9,7 +9,7 @@
 // ---------------------------------------------------------------------------
 
 import { useCallback } from "react";
-import type { Node, Edge } from "@xyflow/react";
+import type { LabNode, LabEdge } from "../useLabGraphStore";
 import {
   BLOCK_DEF_MAP,
   CATEGORY_COLOR,
@@ -17,7 +17,6 @@ import {
   type LabNodeData,
   type PortDataType,
 } from "./blockDefs";
-import type { StrategyEdgeData } from "./edges/StrategyEdge";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -69,14 +68,14 @@ function SectionHeader({ title }: { title: string }) {
 // ---------------------------------------------------------------------------
 
 interface NodeInspectorProps {
-  node: Node;
-  allEdges: Edge[];
-  allNodes: Node[];
+  node: LabNode;
+  allEdges: LabEdge[];
+  allNodes: LabNode[];
   onParamChange: (nodeId: string, paramId: string, value: unknown) => void;
 }
 
 function NodeInspector({ node, allEdges, allNodes, onParamChange }: NodeInspectorProps) {
-  const data = node.data as LabNodeData;
+  const data = node.data;
   const blockDef = BLOCK_DEF_MAP[data.blockType];
 
   if (!blockDef) {
@@ -94,8 +93,7 @@ function NodeInspector({ node, allEdges, allNodes, onParamChange }: NodeInspecto
   for (const edge of allEdges) {
     if (edge.target === node.id && edge.targetHandle) {
       const sourceNode = allNodes.find((n) => n.id === edge.source);
-      const sourceNodeData = sourceNode?.data as LabNodeData | undefined;
-      const sourceLabel = sourceNodeData?.blockType ?? edge.source;
+      const sourceLabel = sourceNode?.data?.blockType ?? edge.source;
       incomingEdgeMap[edge.targetHandle] = {
         sourceNodeId: edge.source,
         sourceNodeLabel: sourceLabel,
@@ -311,19 +309,19 @@ function NodeInspector({ node, allEdges, allNodes, onParamChange }: NodeInspecto
 // ---------------------------------------------------------------------------
 
 interface EdgeInspectorProps {
-  edge: Edge;
-  allNodes: Node[];
+  edge: LabEdge;
+  allNodes: LabNode[];
 }
 
+// A1-4: edge.data is now typed as StrategyEdgeData — no cast needed
 function EdgeInspector({ edge, allNodes }: EdgeInspectorProps) {
-  const edgeData = edge.data as StrategyEdgeData | undefined;
-  const dataType = edgeData?.dataType;
+  const dataType = edge.data?.dataType;
 
   const sourceNode = allNodes.find((n) => n.id === edge.source);
   const targetNode = allNodes.find((n) => n.id === edge.target);
 
-  const sourceData = sourceNode?.data as LabNodeData | undefined;
-  const targetData = targetNode?.data as LabNodeData | undefined;
+  const sourceData = sourceNode?.data;
+  const targetData = targetNode?.data;
 
   return (
     <div style={{ padding: "10px 12px" }}>
@@ -353,7 +351,7 @@ function EdgeInspector({ edge, allNodes }: EdgeInspectorProps) {
       <div style={{ marginTop: 8, fontSize: 10, color: "rgba(255,255,255,0.3)" }}>
         id: {edge.id}
       </div>
-      {edgeData?.isStale && (
+      {edge.data?.isStale && (
         <div
           style={{
             marginTop: 8,
@@ -375,7 +373,7 @@ function EdgeInspector({ edge, allNodes }: EdgeInspectorProps) {
 // Multi-node summary view
 // ---------------------------------------------------------------------------
 
-function MultiSelectSummary({ nodes }: { nodes: Node[] }) {
+function MultiSelectSummary({ nodes }: { nodes: LabNode[] }) {
   return (
     <div style={{ padding: "10px 12px" }}>
       <div
@@ -384,7 +382,7 @@ function MultiSelectSummary({ nodes }: { nodes: Node[] }) {
         {nodes.length} nodes selected
       </div>
       {nodes.map((n) => {
-        const d = n.data as LabNodeData;
+        const d = n.data;
         const def = BLOCK_DEF_MAP[d.blockType];
         return (
           <div
@@ -431,10 +429,10 @@ function InspectorEmpty() {
 // ---------------------------------------------------------------------------
 
 interface InspectorPanelProps {
-  selectedNodes: Node[];
-  selectedEdges: Edge[];
-  allNodes: Node[];
-  allEdges: Edge[];
+  selectedNodes: LabNode[];
+  selectedEdges: LabEdge[];
+  allNodes: LabNode[];
+  allEdges: LabEdge[];
   onParamChange: (nodeId: string, paramId: string, value: unknown) => void;
 }
 

--- a/apps/web/src/app/lab/build/edges/StrategyEdge.tsx
+++ b/apps/web/src/app/lab/build/edges/StrategyEdge.tsx
@@ -35,6 +35,9 @@ function StrategyEdge({
   source,
   target,
 }: EdgeProps) {
+  // A1-4: LabEdge is now Edge<StrategyEdgeData> in the store.
+  // React Flow's EdgeProps component registration still passes untyped data,
+  // so we narrow it here at the component boundary.
   const edgeData = data as StrategyEdgeData | undefined;
   const dataType = edgeData?.dataType;
   const isStale = edgeData?.isStale ?? false;

--- a/apps/web/src/app/lab/build/page.tsx
+++ b/apps/web/src/app/lab/build/page.tsx
@@ -650,10 +650,25 @@ function LabBuildCanvas() {
     [markDownstreamStale]
   );
 
-  // ── Keyboard shortcuts ──────────────────────────────────────────────────
+  // ── Keyboard shortcuts (A1-3: scoped to canvas focus) ───────────────────
+  // Per docs/25 §A1-3: only fire when canvas container is focused or
+  // contains focus. Prevents undo/redo/select-all from firing when a modal,
+  // inspector input, or other non-canvas element is active.
+
+  const canvasContainerRef = useRef<HTMLDivElement>(null);
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
+      const canvasEl = canvasContainerRef.current;
+      if (!canvasEl) return;
+      // Only act when canvas container is focused or contains focus
+      if (
+        !canvasEl.contains(document.activeElement) &&
+        document.activeElement !== document.body
+      ) {
+        return;
+      }
+
       const meta = e.metaKey || e.ctrlKey;
       if (meta && e.key === "z" && !e.shiftKey) {
         e.preventDefault(); undo(); return;
@@ -842,9 +857,11 @@ function LabBuildCanvas() {
               overflow: "hidden",
             }}
           >
-            {/* Canvas area */}
+            {/* Canvas area — A1-3: ref + tabIndex for keyboard focus scoping */}
             <div
-              style={{ flex: 1, position: "relative", overflow: "hidden" }}
+              ref={canvasContainerRef}
+              tabIndex={0}
+              style={{ flex: 1, position: "relative", overflow: "hidden", outline: "none" }}
               onDragOver={onDragOver}
               onDrop={onDrop}
             >

--- a/apps/web/src/app/lab/useLabGraphStore.ts
+++ b/apps/web/src/app/lab/useLabGraphStore.ts
@@ -3,6 +3,7 @@ import { temporal } from "zundo";
 import type { Node, Edge, NodeChange, EdgeChange } from "@xyflow/react";
 import { applyNodeChanges, applyEdgeChanges } from "@xyflow/react";
 import { BLOCK_DEF_MAP, type LabNodeData } from "./build/blockDefs";
+import type { StrategyEdgeData } from "./build/edges/StrategyEdge";
 import { validateGraph, type ValidationIssue } from "./validationTypes";
 
 // ---------------------------------------------------------------------------
@@ -44,7 +45,9 @@ export interface CompileResult {
 }
 
 export type LabNode = Node<LabNodeData>;
-export type LabEdge = Edge;
+// A1-4 (docs/25): narrowed from `Edge` to `Edge<StrategyEdgeData>` —
+// eliminates `as StrategyEdgeData` casts throughout the codebase.
+export type LabEdge = Edge<StrategyEdgeData>;
 
 export interface LabGraphState {
   activeConnectionId: string | null;
@@ -139,50 +142,47 @@ const initialState: LabGraphState = {
 };
 
 // ---------------------------------------------------------------------------
-// ID generator
-// ---------------------------------------------------------------------------
-
-let _nodeSeq = 0;
-function nextNodeId(): string {
-  return `n${++_nodeSeq}_${Date.now()}`;
-}
-
-// ---------------------------------------------------------------------------
-// Debounce timers — module-level refs
-// ---------------------------------------------------------------------------
-
-/** 500ms validation debounce — per §13.3 */
-let _validationTimer: ReturnType<typeof setTimeout> | null = null;
-
-function scheduleValidation(runValidationFn: () => void) {
-  if (_validationTimer !== null) clearTimeout(_validationTimer);
-  _validationTimer = setTimeout(() => {
-    _validationTimer = null;
-    runValidationFn();
-  }, 500);
-}
-
-/** 1500ms auto-save debounce — Phase 3A */
-let _saveTimer: ReturnType<typeof setTimeout> | null = null;
-
-function scheduleAutoSave(saveNowFn: () => Promise<boolean>) {
-  if (_saveTimer !== null) clearTimeout(_saveTimer);
-  _saveTimer = setTimeout(() => {
-    _saveTimer = null;
-    saveNowFn().catch(() => {
-      // failure is reflected in saveState; no unhandled rejection
-    });
-  }, 1500);
-}
-
-// ---------------------------------------------------------------------------
 // Store — Phase 3A base + Phase 3B additions + Phase 3C validation + Phase 3A persistence
 // zundo provides undo/redo history.
+//
+// A1-2 (docs/25): All mutable timers and sequence counters are scoped inside
+// the create() closure, NOT at module level. This ensures:
+//   - SSR safety (no shared state between requests)
+//   - Test isolation (each create() call gets its own timers + counter)
 // ---------------------------------------------------------------------------
 
 export const useLabGraphStore = create<LabGraphState & LabGraphActions>()(
   temporal(
-    (set, get) => ({
+    (set, get) => {
+      // ── Closure-scoped mutable state (A1-2) ──────────────────────────────
+      let _nodeSeq = 0;
+      function nextNodeId(): string {
+        return `n${++_nodeSeq}_${Date.now()}`;
+      }
+
+      /** 500ms validation debounce — per §13.3 */
+      let _validationTimer: ReturnType<typeof setTimeout> | null = null;
+      function scheduleValidation(runValidationFn: () => void) {
+        if (_validationTimer !== null) clearTimeout(_validationTimer);
+        _validationTimer = setTimeout(() => {
+          _validationTimer = null;
+          runValidationFn();
+        }, 500);
+      }
+
+      /** 1500ms auto-save debounce — Phase 3A */
+      let _saveTimer: ReturnType<typeof setTimeout> | null = null;
+      function scheduleAutoSave(saveNowFn: () => Promise<boolean>) {
+        if (_saveTimer !== null) clearTimeout(_saveTimer);
+        _saveTimer = setTimeout(() => {
+          _saveTimer = null;
+          saveNowFn().catch(() => {
+            // failure is reflected in saveState; no unhandled rejection
+          });
+        }, 1500);
+      }
+
+      return {
       ...initialState,
 
       setActiveConnectionId: (id) => set({ activeConnectionId: id }),
@@ -329,7 +329,11 @@ export const useLabGraphStore = create<LabGraphState & LabGraphActions>()(
       },
 
       // Phase 3A — hydrate from persisted graph record
-      // Sets _hydrating = true to suppress autosave during restore
+      // Sets _hydrating = true to suppress autosave during restore.
+      // Two-call pattern (docs/25 §A1-1): first call sets the guard flag;
+      // second call is atomic — all fields land in a single Zustand update,
+      // eliminating the race-condition window between node/edge restore
+      // and the _hydrating flag clear.
       hydrateGraph: (graphId, nodes, edges) => {
         set({ _hydrating: true });
         set({
@@ -337,8 +341,8 @@ export const useLabGraphStore = create<LabGraphState & LabGraphActions>()(
           nodes,
           edges,
           saveState: "clean",
+          _hydrating: false,
         });
-        set({ _hydrating: false });
         // Run validation once after hydration (no autosave)
         scheduleValidation(get().runValidation);
       },
@@ -377,7 +381,7 @@ export const useLabGraphStore = create<LabGraphState & LabGraphActions>()(
           return false;
         }
       },
-    }),
+    }; },
     // zundo: only track graph state for undo/redo history.
     // saveState, _hydrating, validationIssues are excluded — derived or transient state.
     {


### PR DESCRIPTION
## Summary

Phase A1 из docs/25 — пять исправлений, повышающих надёжность Lab-модуля:

- **A1-1** Atomic `hydrateGraph` — устранена гонка между восстановлением nodes/edges и сбросом `_hydrating` (теперь одно атомарное обновление Zustand)
- **A1-2** Module-level timers → closure — `_nodeSeq`, `_validationTimer`, `_saveTimer` перенесены внутрь `create()` closure (SSR-безопасность, изоляция тестов)
- **A1-3** Scoped `handleKeyDown` — горячие клавиши (undo/redo/select-all) срабатывают только при фокусе на canvas, не конфликтуя с модалками и инпутами
- **A1-4** Narrowed `LabEdge` type — `Edge` → `Edge<StrategyEdgeData>`, убраны `as StrategyEdgeData` касты в InspectorPanel
- **A1-5** Context Bar badge dimming — бейджи Validation/Run теперь dim только в idle, а в error/warning подсвечиваются цветом

## Changed files

- `apps/web/src/app/lab/useLabGraphStore.ts` — A1-1, A1-2, A1-4
- `apps/web/src/app/lab/build/page.tsx` — A1-3 (canvasContainerRef + focus guard)
- `apps/web/src/app/lab/build/InspectorPanel.tsx` — A1-4 (LabNode/LabEdge types, removed casts)
- `apps/web/src/app/lab/build/edges/StrategyEdge.tsx` — A1-4 (narrowed edge data comment)
- `apps/web/src/app/lab/LabShell.tsx` — A1-5 (CtxBadge variant prop)

## Test plan

- [x] `tsc --noEmit` — zero errors
- [x] `next build` — all 16 pages generated successfully
- [ ] Manual: open Lab → Build, add nodes, undo/redo works only when canvas focused
- [ ] Manual: trigger validation error → Validation badge shows red, not dimmed
- [ ] Manual: hydrate graph → no flash of dirty/autosave during load

https://claude.ai/code/session_014zrq4k9XarrNvdPQnmy8dh