### PR TITLE
feat(lab): Phase A2 — save retry, labApi, inspector fix, new graph, DSL highlight, Constant block, port highlight

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@tanstack/react-virtual": "^3.13.21",
     "@xyflow/react": "^12.10.1",
+    "dompurify": "^3.3.3",
     "lightweight-charts": "^5.1.0",
     "next": "^15.3.0",
     "react": "^19.1.0",
@@ -19,6 +20,7 @@
     "zustand": "^5.0.11"
   },
   "devDependencies": {
+    "@types/dompurify": "^3.2.0",
     "@types/node": "^22.0.0",
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",

--- a/apps/web/src/app/lab/LabShell.tsx
+++ b/apps/web/src/app/lab/LabShell.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { Group, Panel, Separator } from "react-resizable-panels";
 import { useLabGraphStore } from "./useLabGraphStore";
+import { compileGraph } from "./labApi";
 
 // ---------------------------------------------------------------------------
 // Tab definitions — order matches spec
@@ -48,6 +49,8 @@ function LabContextBar({ activeTab }: { activeTab: TabId }) {
   const setServerIssues    = useLabGraphStore((s) => s.setServerIssues);
   // Phase 3A: persistence state (independent of compile/validation)
   const saveState          = useLabGraphStore((s) => s.saveState);
+  // A2-1: retry save action
+  const saveGraphNow       = useLabGraphStore((s) => s.saveGraphNow);
 
   // Phase 3A: show toast when save_error transitions in
   const [showSaveErrorToast, setShowSaveErrorToast] = useState(false);
@@ -80,29 +83,19 @@ function LabContextBar({ activeTab }: { activeTab: TabId }) {
         return;
       }
 
-      // Compile against the persisted graph record
-      const compileRes = await fetch(`/api/v1/lab/graphs/${graphId}/compile`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
-        body: JSON.stringify({ graphJson, symbol: "BTCUSDT", timeframe: "M15" }),
-      });
-
-      if (compileRes.status === 422) {
-        const body = await compileRes.json() as { validationIssues: import("./useLabGraphStore").ServerCompileIssue[] };
-        setServerIssues(body.validationIssues ?? []);
-        setCompileState("error");
-        return;
-      }
+      // A2-2: Compile via labApi instead of inline fetch
+      const compileRes = await compileGraph(graphId, graphJson, "BTCUSDT", "M15");
 
       if (!compileRes.ok) {
+        if (compileRes.status === 422 && compileRes.validationIssues) {
+          setServerIssues(compileRes.validationIssues);
+        }
         setCompileState("error");
         return;
       }
 
-      const result = await compileRes.json() as import("./useLabGraphStore").CompileResult;
-      setLastCompileResult(result);
-      setServerIssues(result.validationIssues ?? []);
+      setLastCompileResult(compileRes.data);
+      setServerIssues(compileRes.data.validationIssues ?? []);
       setCompileState("success");
     } catch {
       setCompileState("error");
@@ -173,6 +166,26 @@ function LabContextBar({ activeTab }: { activeTab: TabId }) {
             <span style={{ fontSize: 12, marginLeft: 4, color: saveLabelColor, fontWeight: saveState === "save_error" ? 600 : 400 }}>
               {saveLabel}
             </span>
+            {/* A2-1: Retry save button — visible only on save_error */}
+            {saveState === "save_error" && (
+              <button
+                onClick={() => { void saveGraphNow(); }}
+                style={{
+                  marginLeft: 4,
+                  padding: "1px 6px",
+                  fontSize: 11,
+                  fontWeight: 600,
+                  background: "rgba(212,76,76,0.15)",
+                  border: "1px solid rgba(212,76,76,0.4)",
+                  borderRadius: 3,
+                  color: "#D44C4C",
+                  cursor: "pointer",
+                  fontFamily: "inherit",
+                }}
+              >
+                Retry save
+              </button>
+            )}
           </div>
         )}
         {lastCompileResult && (
@@ -377,13 +390,8 @@ export function LabShell({ children }: LabShellProps) {
               </div>
             </Panel>
 
-            {/* Resize handle (horizontal) */}
-            <Separator style={resizeHandleH} />
-
-            {/* Right: Inspector placeholder */}
-            <Panel defaultSize={22} minSize={8} collapsible>
-              <InspectorPlaceholder />
-            </Panel>
+            {/* A2-3 (Option A): Inspector placeholder removed from LabShell.
+                Each tab owns its own right-side content (Build tab has InspectorPanel internally). */}
 
           </Group>
         </Panel>

--- a/apps/web/src/app/lab/build/JsonHighlight.tsx
+++ b/apps/web/src/app/lab/build/JsonHighlight.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+// ---------------------------------------------------------------------------
+// A2-5 — JSON syntax highlighting for DSL Preview
+// Token colours (dark theme, per docs/25 §A2-5):
+//   json-key    → #7EB8F7 (blue)
+//   json-string → #7EC48A (green)
+//   json-number → #D4934C (amber)
+//   json-bool   → #B57FE0 (violet)
+//   json-null   → #B57FE0 (violet)
+// Security: dangerouslySetInnerHTML wrapped in DOMPurify.sanitize() per docs/23 §15.1
+// ---------------------------------------------------------------------------
+
+import { useMemo } from "react";
+import DOMPurify from "dompurify";
+
+const COLORS = {
+  key: "#7EB8F7",
+  string: "#7EC48A",
+  number: "#D4934C",
+  bool: "#B57FE0",
+  null: "#B57FE0",
+} as const;
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function highlightJson(value: unknown): string {
+  const raw = JSON.stringify(value, null, 2);
+  if (!raw) return "";
+
+  // Tokenise JSON string and wrap tokens in coloured spans.
+  // Regex matches: strings (keys or values), numbers, booleans, null.
+  return raw.replace(
+    /("(?:\\.|[^"\\])*")\s*:/g,
+    (match, key: string) =>
+      `<span style="color:${COLORS.key}">${escapeHtml(key)}</span>:`,
+  ).replace(
+    // Match string values (not followed by colon — those are keys handled above)
+    /:\s*("(?:\\.|[^"\\])*")/g,
+    (match, val: string) =>
+      `: <span style="color:${COLORS.string}">${escapeHtml(val)}</span>`,
+  ).replace(
+    // Standalone strings in arrays
+    /(?<=[\[,\n]\s*)("(?:\\.|[^"\\])*")(?=\s*[,\]\n])/g,
+    (val: string) =>
+      `<span style="color:${COLORS.string}">${escapeHtml(val)}</span>`,
+  ).replace(
+    /\b(-?\d+\.?\d*(?:[eE][+-]?\d+)?)\b/g,
+    (num: string) =>
+      `<span style="color:${COLORS.number}">${num}</span>`,
+  ).replace(
+    /\b(true|false)\b/g,
+    (bool: string) =>
+      `<span style="color:${COLORS.bool}">${bool}</span>`,
+  ).replace(
+    /\bnull\b/g,
+    `<span style="color:${COLORS.null}">null</span>`,
+  );
+}
+
+interface JsonHighlightProps {
+  data: unknown;
+  style?: React.CSSProperties;
+}
+
+export default function JsonHighlight({ data, style }: JsonHighlightProps) {
+  const html = useMemo(() => {
+    const raw = highlightJson(data);
+    return DOMPurify.sanitize(raw);
+  }, [data]);
+
+  return (
+    <pre
+      style={{
+        margin: 0,
+        fontSize: 12,
+        lineHeight: 1.6,
+        color: "rgba(255,255,255,0.82)",
+        fontFamily: "monospace",
+        whiteSpace: "pre-wrap",
+        wordBreak: "break-word",
+        ...style,
+      }}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}

--- a/apps/web/src/app/lab/build/blockDefs.ts
+++ b/apps/web/src/app/lab/build/blockDefs.ts
@@ -101,6 +101,28 @@ export const BLOCK_DEFS: BlockDef[] = [
     description: "Raw market candle stream bound to the active MarketDataset.",
   },
 
+  // A2-6: Constant — emits a fixed numeric value
+  {
+    type: "constant",
+    label: "Constant",
+    category: "input",
+    inputs: [],
+    outputs: [
+      { id: "value", label: "value", dataType: "Series<number>", required: false },
+    ],
+    params: [
+      {
+        id: "value",
+        label: "Value",
+        type: "number",
+        defaultValue: 0,
+        min: -1_000_000,
+        max: 1_000_000,
+      },
+    ],
+    description: "Emits a fixed numeric value as a constant series.",
+  },
+
   // ── Indicators ────────────────────────────────────────────────────────────
   {
     type: "SMA",

--- a/apps/web/src/app/lab/build/nodes/StrategyNode.tsx
+++ b/apps/web/src/app/lab/build/nodes/StrategyNode.tsx
@@ -55,6 +55,7 @@ function PortHandle({
   const position = side === "input" ? Position.Left : Position.Right;
 
   // Build the handle style per §6.3.1 port state table
+  // A2-7: transition for smooth drag feedback
   const handleStyle: React.CSSProperties = {
     width: 10,
     height: 10,
@@ -62,13 +63,15 @@ function PortHandle({
     border: "none",
     cursor: "crosshair",
     position: "relative",
+    transition: "all 0.12s ease",
     // Hit area is handled by React Flow's default invisible wrapper
   };
 
   if (incompatibleTarget) {
-    // Incompatible: red ring, scale 0.85, opacity 25%
+    // A2-7: Incompatible: red ring, scale 0.85, opacity 25%, borderColor #D44C4C
     handleStyle.background = "transparent";
     handleStyle.boxShadow = `0 0 0 2px #D44C4C`;
+    handleStyle.borderColor = "#D44C4C";
     handleStyle.transform = "scale(0.85)";
     handleStyle.opacity = 0.25;
   } else if (compatibleTarget) {

--- a/apps/web/src/app/lab/build/page.tsx
+++ b/apps/web/src/app/lab/build/page.tsx
@@ -30,6 +30,7 @@ import "@xyflow/react/dist/style.css";
 import { useLabGraphStore } from "../useLabGraphStore";
 import type { LabNode, LabEdge, ValidationState, ServerCompileIssue } from "../useLabGraphStore";
 import type { ValidationIssue } from "../validationTypes";
+import { listGraphs, createGraph, fetchGraph, type PersistedGraph } from "../labApi";
 import {
   BLOCK_DEF_MAP,
   PORT_TYPE_COLOR,
@@ -43,6 +44,7 @@ import StrategyNode from "./nodes/StrategyNode";
 import StrategyEdge from "./edges/StrategyEdge";
 import BlockPalette from "./BlockPalette";
 import InspectorPanel from "./InspectorPanel";
+import JsonHighlight from "./JsonHighlight";
 
 // ---------------------------------------------------------------------------
 // React Flow node/edge type registrations
@@ -368,15 +370,7 @@ function ValidationDrawer({ issues, validationState, serverIssues = [] }: Valida
 // Canvas inner — must be inside ReactFlowProvider + ConnectionContextProvider
 // ---------------------------------------------------------------------------
 
-// ---------------------------------------------------------------------------
-// Graph persistence types (Phase 3A)
-// ---------------------------------------------------------------------------
-
-interface PersistedGraph {
-  id: string;
-  name: string;
-  graphJson: { nodes: LabNode[]; edges: LabEdge[] } | null;
-}
+// PersistedGraph type imported from labApi.ts (A2-2)
 
 function LabBuildCanvas() {
   const nodes = useLabGraphStore((s) => s.nodes);
@@ -427,12 +421,8 @@ function LabBuildCanvas() {
 
     (async () => {
       try {
-        // Step 1: list workspace graphs (most-recent first)
-        const listRes = await fetch("/api/v1/lab/graphs", {
-          credentials: "include",
-        });
-        if (!listRes.ok) throw new Error(`Failed to load graphs (${listRes.status})`);
-        const graphs = (await listRes.json()) as PersistedGraph[];
+        // Step 1: list workspace graphs (most-recent first) — A2-2: via labApi
+        const graphs = await listGraphs();
 
         let graph: PersistedGraph;
         let allGraphs: PersistedGraph[];
@@ -442,18 +432,8 @@ function LabBuildCanvas() {
           graph = graphs[0];
           allGraphs = graphs;
         } else {
-          // Step 2b: create first draft
-          const createRes = await fetch("/api/v1/lab/graphs", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            credentials: "include",
-            body: JSON.stringify({
-              name: "Untitled Graph",
-              graphJson: { nodes: [], edges: [] },
-            }),
-          });
-          if (!createRes.ok) throw new Error(`Failed to create graph (${createRes.status})`);
-          graph = (await createRes.json()) as PersistedGraph;
+          // Step 2b: create first draft — A2-2: via labApi
+          graph = await createGraph("Untitled Graph", { nodes: [], edges: [] });
           allGraphs = [graph];
         }
 
@@ -477,17 +457,33 @@ function LabBuildCanvas() {
   }, []);
 
   // Phase 3A corrective: minimal graph selector — flush + hydrate on switch
+  // A2-2: uses labApi.fetchGraph instead of inline fetch
   const handleSelectGraph = useCallback(async (targetId: string) => {
     if (!targetId || targetId === activeGraphId) return;
     // Flush current dirty state before switching
     await saveGraphNow();
     // Fetch fresh data from API to avoid stale-cache bug (A→B→A scenario)
-    const res = await fetch(`/api/v1/lab/graphs/${targetId}`, { credentials: "include" });
-    if (!res.ok) return;
-    const fresh = await res.json() as { id: string; graphJson?: { nodes?: LabNode[]; edges?: LabEdge[] } };
-    const gj = fresh.graphJson ?? { nodes: [], edges: [] };
-    hydrateGraph(fresh.id, gj.nodes ?? [], gj.edges ?? []);
+    try {
+      const fresh = await fetchGraph(targetId);
+      const gj = fresh.graphJson ?? { nodes: [], edges: [] };
+      hydrateGraph(fresh.id, gj.nodes ?? [], gj.edges ?? []);
+    } catch {
+      // fetch failed — stay on current graph
+    }
   }, [activeGraphId, saveGraphNow, hydrateGraph]);
+
+  // A2-4: create a new empty graph, add to selector, switch to it
+  const handleNewGraph = useCallback(async () => {
+    await saveGraphNow();
+    try {
+      const newGraph = await createGraph("Untitled Graph", { nodes: [], edges: [] });
+      setAvailableGraphs((prev) => [...prev, newGraph]);
+      const gj = newGraph.graphJson ?? { nodes: [], edges: [] };
+      hydrateGraph(newGraph.id, gj.nodes ?? [], gj.edges ?? []);
+    } catch {
+      // creation failed — stay on current graph
+    }
+  }, [saveGraphNow, hydrateGraph]);
 
   const [toasts, setToasts] = useState<ToastMessage[]>([]);
   const showToast = useCallback((text: string) => {
@@ -778,22 +774,38 @@ function LabBuildCanvas() {
 
   return (
     <div style={{ display: "flex", flexDirection: "column", width: "100%", height: "100%", overflow: "hidden" }}>
-      {/* Phase 3A corrective: Graph selector — shown only when workspace has multiple graphs */}
-      {availableGraphs.length > 1 && (
-        <div style={graphSelectorBarStyle}>
-          <span style={{ fontSize: 11, color: "rgba(255,255,255,0.35)", flexShrink: 0 }}>Graph:</span>
-          <select
-            value={activeGraphId ?? ""}
-            onChange={(e) => { void handleSelectGraph(e.target.value); }}
-            disabled={saveState === "saving" || isInitializing}
-            style={graphSelectorStyle}
-          >
-            {availableGraphs.map((g) => (
-              <option key={g.id} value={g.id}>{g.name}</option>
-            ))}
-          </select>
-        </div>
-      )}
+      {/* A2-4: Graph selector always visible (even with 1 graph) + New Graph button */}
+      <div style={graphSelectorBarStyle}>
+        <span style={{ fontSize: 11, color: "rgba(255,255,255,0.35)", flexShrink: 0 }}>Graph:</span>
+        <select
+          value={activeGraphId ?? ""}
+          onChange={(e) => { void handleSelectGraph(e.target.value); }}
+          disabled={saveState === "saving" || isInitializing}
+          style={graphSelectorStyle}
+        >
+          {availableGraphs.map((g) => (
+            <option key={g.id} value={g.id}>{g.name}</option>
+          ))}
+        </select>
+        <button
+          onClick={() => { void handleNewGraph(); }}
+          disabled={saveState === "saving" || isInitializing}
+          style={{
+            padding: "2px 8px",
+            fontSize: 11,
+            fontWeight: 600,
+            background: "rgba(59,130,246,0.15)",
+            border: "1px solid rgba(59,130,246,0.3)",
+            borderRadius: 4,
+            color: "#3B82F6",
+            cursor: "pointer",
+            fontFamily: "inherit",
+            flexShrink: 0,
+          }}
+        >
+          + New
+        </button>
+      </div>
       {/* Phase 4B: Build view tab switcher — Canvas | DSL Preview */}
       <div style={buildViewTabBarStyle}>
         <button
@@ -827,17 +839,8 @@ function LabBuildCanvas() {
           <div style={{ marginBottom: 10, fontSize: 11, color: "rgba(255,255,255,0.4)" }}>
             Strategy v{lastCompileResult.strategyVersion} — {lastCompileResult.strategyVersionId}
           </div>
-          <pre style={{
-            margin: 0,
-            fontSize: 12,
-            lineHeight: 1.6,
-            color: "rgba(255,255,255,0.82)",
-            fontFamily: "monospace",
-            whiteSpace: "pre-wrap",
-            wordBreak: "break-word",
-          }}>
-            {JSON.stringify(lastCompileResult.compiledDsl, null, 2)}
-          </pre>
+          {/* A2-5: syntax-highlighted JSON via JsonHighlight + DOMPurify */}
+          <JsonHighlight data={lastCompileResult.compiledDsl} />
         </div>
       ) : (
         /* Canvas view */

--- a/apps/web/src/app/lab/labApi.ts
+++ b/apps/web/src/app/lab/labApi.ts
@@ -1,0 +1,109 @@
+// ---------------------------------------------------------------------------
+// Phase A2-2 — Centralized lab graph API client
+// Replaces all inline fetch("/api/v1/lab/graphs") calls in components.
+// Uses apiFetch for automatic X-Workspace-Id injection + 401 handling.
+// ---------------------------------------------------------------------------
+
+import { apiFetch } from "@/lib/api";
+import type { LabNode, LabEdge } from "./useLabGraphStore";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface GraphJson {
+  nodes: LabNode[];
+  edges: LabEdge[];
+}
+
+export interface PersistedGraph {
+  id: string;
+  name: string;
+  graphJson: GraphJson | null;
+}
+
+// ---------------------------------------------------------------------------
+// API functions
+// ---------------------------------------------------------------------------
+
+/** List all workspace graphs (most-recent first). */
+export async function listGraphs(): Promise<PersistedGraph[]> {
+  const res = await apiFetch<PersistedGraph[]>("/lab/graphs");
+  if (!res.ok) throw new Error(res.problem.detail ?? "Failed to load graphs");
+  return res.data;
+}
+
+/** Create a new graph with given name and initial JSON. */
+export async function createGraph(
+  name: string,
+  graphJson: GraphJson,
+): Promise<PersistedGraph> {
+  const res = await apiFetch<PersistedGraph>("/lab/graphs", {
+    method: "POST",
+    body: JSON.stringify({ name, graphJson }),
+  });
+  if (!res.ok) throw new Error(res.problem.detail ?? "Failed to create graph");
+  return res.data;
+}
+
+/** Patch an existing graph (name and/or graphJson). */
+export async function patchGraph(
+  id: string,
+  payload: { name?: string; graphJson?: GraphJson },
+): Promise<void> {
+  const res = await apiFetch(`/lab/graphs/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) throw new Error(`${res.problem.status}: ${res.problem.detail ?? "Failed to save graph"}`);
+}
+
+/** Fetch a single graph by ID. */
+export async function fetchGraph(id: string): Promise<PersistedGraph> {
+  const res = await apiFetch<PersistedGraph>(`/lab/graphs/${id}`);
+  if (!res.ok) throw new Error(res.problem.detail ?? "Failed to fetch graph");
+  return res.data;
+}
+
+/** Compile response shape (for internal use by LabShell). */
+export type CompileResponse = {
+  ok: true;
+  data: {
+    strategyVersionId: string;
+    strategyVersion: number;
+    compiledDsl: Record<string, unknown>;
+    validationIssues: Array<{ severity: "error" | "warning"; message: string; nodeId?: string }>;
+  };
+} | {
+  ok: false;
+  status: number;
+  validationIssues?: Array<{ severity: "error" | "warning"; message: string; nodeId?: string }>;
+};
+
+/** Compile a graph against the backend. */
+export async function compileGraph(
+  graphId: string,
+  graphJson: GraphJson,
+  symbol: string,
+  timeframe: string,
+): Promise<CompileResponse> {
+  const res = await apiFetch<{
+    strategyVersionId: string;
+    strategyVersion: number;
+    compiledDsl: Record<string, unknown>;
+    validationIssues: Array<{ severity: "error" | "warning"; message: string; nodeId?: string }>;
+  }>(`/lab/graphs/${graphId}/compile`, {
+    method: "POST",
+    body: JSON.stringify({ graphJson, symbol, timeframe }),
+  });
+  if (!res.ok) {
+    // 422 means validation issues returned in problem body
+    if (res.problem.status === 422) {
+      const issues = (res.problem as unknown as Record<string, unknown>).validationIssues as
+        Array<{ severity: "error" | "warning"; message: string; nodeId?: string }> | undefined;
+      return { ok: false, status: 422, validationIssues: issues };
+    }
+    return { ok: false, status: res.problem.status };
+  }
+  return { ok: true, data: res.data };
+}

--- a/apps/web/src/app/lab/useLabGraphStore.ts
+++ b/apps/web/src/app/lab/useLabGraphStore.ts
@@ -5,6 +5,7 @@ import { applyNodeChanges, applyEdgeChanges } from "@xyflow/react";
 import { BLOCK_DEF_MAP, type LabNodeData } from "./build/blockDefs";
 import type { StrategyEdgeData } from "./build/edges/StrategyEdge";
 import { validateGraph, type ValidationIssue } from "./validationTypes";
+import { patchGraph } from "./labApi";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -348,6 +349,8 @@ export const useLabGraphStore = create<LabGraphState & LabGraphActions>()(
       },
 
       // Phase 3A — flush save immediately (called before graph switch or on demand)
+      // A2-1: retry with exponential backoff (max 3 attempts, 500/1000/2000ms)
+      // A2-2: uses labApi.patchGraph instead of inline fetch
       saveGraphNow: async () => {
         const { activeGraphId, nodes, edges, saveState } = get();
         if (!activeGraphId) return false;
@@ -355,31 +358,38 @@ export const useLabGraphStore = create<LabGraphState & LabGraphActions>()(
         if (saveState === "clean" || saveState === "stale_against_last_compile") return true;
 
         set({ saveState: "saving" });
-        try {
-          const res = await fetch(`/api/v1/lab/graphs/${activeGraphId}`, {
-            method: "PATCH",
-            headers: { "Content-Type": "application/json" },
-            credentials: "include",
-            body: JSON.stringify({ graphJson: { nodes, edges } }),
-          });
-          if (!res.ok) {
-            set({ saveState: "save_error" });
-            return false;
+
+        const RETRY_DELAYS = [500, 1000, 2000];
+        for (let attempt = 0; attempt < 3; attempt++) {
+          try {
+            await patchGraph(activeGraphId, { graphJson: { nodes, edges } });
+            // Success — determine final save state
+            const { lastCompileResult, _graphChangedSinceCompile } = get();
+            set({
+              saveState:
+                lastCompileResult !== null && _graphChangedSinceCompile
+                  ? "stale_against_last_compile"
+                  : "clean",
+            });
+            return true;
+          } catch (err: unknown) {
+            // 4xx errors: no retry (client error, won't fix itself)
+            const is4xx =
+              err instanceof Error &&
+              /\b4\d{2}\b/.test(err.message);
+            if (is4xx) {
+              set({ saveState: "save_error" });
+              return false;
+            }
+            // 5xx / network error: retry after delay (unless last attempt)
+            if (attempt < 2) {
+              await new Promise((r) => setTimeout(r, RETRY_DELAYS[attempt]));
+            }
           }
-          // If graph has been mutated since last compile → stale_against_last_compile;
-          // otherwise clean. This is how stale_against_last_compile is actually reached.
-          const { lastCompileResult, _graphChangedSinceCompile } = get();
-          set({
-            saveState:
-              lastCompileResult !== null && _graphChangedSinceCompile
-                ? "stale_against_last_compile"
-                : "clean",
-          });
-          return true;
-        } catch {
-          set({ saveState: "save_error" });
-          return false;
         }
+        // All 3 attempts failed
+        set({ saveState: "save_error" });
+        return false;
       },
     }; },
     // zundo: only track graph state for undo/redo history.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@xyflow/react':
         specifier: ^12.10.1
         version: 12.10.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      dompurify:
+        specifier: ^3.3.3
+        version: 3.3.3
       lightweight-charts:
         specifier: ^5.1.0
         version: 5.1.0
@@ -84,6 +87,9 @@ importers:
         specifier: ^5.0.11
         version: 5.0.11(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
     devDependencies:
+      '@types/dompurify':
+        specifier: ^3.2.0
+        version: 3.2.0
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.11
@@ -572,6 +578,10 @@ packages:
   '@types/d3-zoom@3.0.8':
     resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
 
+  '@types/dompurify@3.2.0':
+    resolution: {integrity: sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==}
+    deprecated: This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.
+
   '@types/node@22.19.11':
     resolution: {integrity: sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==}
 
@@ -582,6 +592,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@xyflow/react@12.10.1':
     resolution: {integrity: sha512-5eSWtIK/+rkldOuFbOOz44CRgQRjtS9v5nufk77DV+XBnfCGL9HAQ8PG00o2ZYKqkEU/Ak6wrKC95Tu+2zuK3Q==}
@@ -719,6 +732,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  dompurify@3.3.3:
+    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -1437,6 +1453,10 @@ snapshots:
       '@types/d3-interpolate': 3.0.4
       '@types/d3-selection': 3.0.11
 
+  '@types/dompurify@3.2.0':
+    dependencies:
+      dompurify: 3.3.3
+
   '@types/node@22.19.11':
     dependencies:
       undici-types: 6.21.0
@@ -1448,6 +1468,9 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@xyflow/react@12.10.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -1588,6 +1611,10 @@ snapshots:
 
   detect-libc@2.1.2:
     optional: true
+
+  dompurify@3.3.3:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dotenv@16.6.1: {}
 


### PR DESCRIPTION
## Summary

Phase A2 — 7 tasks in a single PR, no schema migrations, no new API endpoints.

- **A2-1 (#96):** Save retry with exponential backoff (3 attempts, 500ms/1s/2s). 4xx → immediate fail; 5xx/network → retry. "Retry save" button in context bar on `save_error`.
- **A2-2 (#97):** Extracted `labApi.ts` — centralized API client for graph CRUD + compile. All inline `fetch("/api/v1/lab/graphs")` calls replaced. Zero inline fetches remain.
- **A2-3 (#98):** Removed `InspectorPlaceholder` from LabShell right panel (Option A). Build tab owns its own InspectorPanel internally.
- **A2-4 (#99):** Graph selector always visible (even with 1 graph). Added "+ New" button → `labApi.createGraph` → appends to selector → switches.
- **A2-5 (#100):** DSL Preview syntax highlighting via `JsonHighlight` component. Keys blue (#7EB8F7), strings green (#7EC48A), numbers amber (#D4934C), booleans/null violet (#B57FE0). `DOMPurify.sanitize()` wraps `dangerouslySetInnerHTML`.
- **A2-6 (#101):** Added Constant block (input category, `Series<number>` output, value param -1M..1M). Client-side only.
- **A2-7 (#102):** Port highlight transition `all 0.12s ease` + `borderColor #D44C4C` on incompatible handles during drag.

Closes #96, #97, #98, #99, #100, #101, #102

## Files Changed

| Task | Files | Lines |
|------|-------|-------|
| A2-1 | `useLabGraphStore.ts`, `LabShell.tsx` | +45 −20 |
| A2-2 | `labApi.ts` (new), `page.tsx`, `LabShell.tsx`, `useLabGraphStore.ts` | +110 −35 |
| A2-3 | `LabShell.tsx` | +2 −8 |
| A2-4 | `page.tsx` | +30 −5 |
| A2-5 | `JsonHighlight.tsx` (new), `page.tsx`, `package.json` | +90 −8 |
| A2-6 | `blockDefs.ts` | +18 |
| A2-7 | `StrategyNode.tsx` | +3 −1 |

## Verification Results

- ✅ `tsc --noEmit`: 0 errors
- ✅ `next build`: 0 errors
- ✅ `grep -r "api/v1/lab/graphs" apps/web/src/`: only `labApi.ts` (comment line)

## Test plan

- [ ] **save_error state:** simulate network failure → badge shows "Save Error" + "Retry save" button appears → clicking retries
- [ ] **New graph:** click "+ New" → empty canvas appears, new graph in selector dropdown
- [ ] **Dual inspector:** open Build tab → only ONE inspector panel visible
- [ ] **DSL Preview:** add nodes → compile → DSL panel shows coloured JSON (keys blue, strings green)
- [ ] **Constant block:** drag "Constant" from palette → connect to Compare block second input → no type error
- [ ] **Port highlight:** drag from RSI output → Compare input glows, String input dims to 25%
- [ ] **labApi.ts:** `grep -r "api/v1/lab/graphs"` → returns ONLY labApi.ts (zero inline fetches elsewhere)

https://claude.ai/code/session_014zrq4k9XarrNvdPQnmy8dh