### PR TITLE
feat(api): strategy capability matrix & drift contract tests (#123)

### DIFF
--- a/apps/api/src/lib/compiler/index.ts
+++ b/apps/api/src/lib/compiler/index.ts
@@ -21,6 +21,8 @@ export type {
 export { BlockRegistry, createRegistry } from "./blockRegistry.js";
 export { defaultHandlers } from "./blockHandlers.js";
 export { compileGraph as compileGraphWithRegistry } from "./graphCompiler.js";
+export { BLOCK_SUPPORT_MAP } from "./supportMap.js";
+export type { BlockSupportStatus, BlockSupportEntry } from "./supportMap.js";
 
 import { createRegistry } from "./blockRegistry.js";
 import { defaultHandlers } from "./blockHandlers.js";

--- a/apps/api/src/lib/compiler/supportMap.ts
+++ b/apps/api/src/lib/compiler/supportMap.ts
@@ -1,0 +1,59 @@
+/**
+ * Block support map — explicit record of backend support status for every UI block type.
+ *
+ * This map is the single source of truth for contract tests that detect drift
+ * between the UI block library (blockDefs.ts) and the backend compiler.
+ *
+ * Support levels:
+ *   - "supported"   — compiler handler exists AND backtest runtime can execute it
+ *   - "compile-only" — compiler handler exists but runtime does not yet execute the compiled DSL for this block
+ *   - "unsupported" — no compiler handler, block cannot be compiled
+ *
+ * When adding a new block to blockDefs.ts:
+ *   1. Add a compiler handler in blockHandlers.ts
+ *   2. Register it in defaultHandlers()
+ *   3. Add an entry here with the correct status
+ *   4. Run `pnpm --filter @botmarketplace/api test` — the contract test will fail if you miss any step
+ */
+
+export type BlockSupportStatus = "supported" | "compile-only" | "unsupported";
+
+export interface BlockSupportEntry {
+  status: BlockSupportStatus;
+  /** Brief note on why this status, or what's needed to promote it. */
+  note: string;
+}
+
+/**
+ * Authoritative support map. Keys must match blockType from blockDefs.ts exactly.
+ *
+ * Maintained manually — contract tests enforce that this map covers every UI block.
+ */
+export const BLOCK_SUPPORT_MAP: Record<string, BlockSupportEntry> = {
+  // ── Input ───────────────────────────────────────────────────────────────────
+  candles:      { status: "supported",    note: "Core input block, fully supported since Phase 3" },
+  constant:     { status: "compile-only", note: "Compiler handler extracts value; runtime DSL execution pending (#124)" },
+
+  // ── Indicators ──────────────────────────────────────────────────────────────
+  SMA:          { status: "supported",    note: "Fully supported since Phase 3" },
+  EMA:          { status: "supported",    note: "Fully supported since Phase 3" },
+  RSI:          { status: "supported",    note: "Fully supported since Phase 3" },
+  macd:         { status: "compile-only", note: "Compiler handler added in #122; backtest runtime pending (#125)" },
+  bollinger:    { status: "compile-only", note: "Compiler handler added in #122; backtest runtime pending (#125)" },
+  atr:          { status: "compile-only", note: "Compiler handler added in #122; backtest runtime pending (#125)" },
+  volume:       { status: "compile-only", note: "Compiler handler added in #122; backtest runtime pending (#125)" },
+
+  // ── Logic ───────────────────────────────────────────────────────────────────
+  compare:      { status: "supported",    note: "Fully supported since Phase 4" },
+  cross:        { status: "supported",    note: "Fully supported since Phase 3" },
+  and_gate:     { status: "compile-only", note: "Compiler handler added in #122; runtime pending (#124)" },
+  or_gate:      { status: "compile-only", note: "Compiler handler added in #122; runtime pending (#124)" },
+
+  // ── Execution ───────────────────────────────────────────────────────────────
+  enter_long:   { status: "supported",    note: "Fully supported since Phase 3" },
+  enter_short:  { status: "supported",    note: "Fully supported since Phase 4" },
+
+  // ── Risk ────────────────────────────────────────────────────────────────────
+  stop_loss:    { status: "supported",    note: "Fully supported since Phase 3" },
+  take_profit:  { status: "supported",    note: "Fully supported since Phase 3" },
+};

--- a/apps/api/tests/compiler/blockDrift.test.ts
+++ b/apps/api/tests/compiler/blockDrift.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Contract tests — UI / Compiler drift detection.
+ *
+ * These tests ensure that:
+ *   1. Every block defined in the UI (blockDefs.ts) is accounted for in the backend
+ *   2. Every compiler handler has a corresponding UI block definition
+ *   3. The support map covers every UI block — no silent gaps
+ *   4. Block categories are consistent between UI and compiler
+ *
+ * If any of these tests fail, it means someone added/removed a block on one side
+ * without updating the other. This is the exact "drift" we want to catch.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createRegistry, defaultHandlers, BLOCK_SUPPORT_MAP } from "../../src/lib/compiler/index.js";
+
+// Import UI block definitions via relative path (cross-package, test-only)
+import { BLOCK_DEFS } from "../../../web/src/app/lab/build/blockDefs.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/** All block types defined in the UI */
+const uiBlockTypes = BLOCK_DEFS.map((b) => b.type).sort();
+
+/** All block types with compiler handlers */
+const registry = createRegistry(defaultHandlers());
+const compilerBlockTypes = registry.registeredTypes().sort();
+
+/** All block types in the support map */
+const supportMapTypes = Object.keys(BLOCK_SUPPORT_MAP).sort();
+
+/** UI blocks grouped by category */
+const uiBlocksByCategory = new Map<string, string[]>();
+for (const b of BLOCK_DEFS) {
+  const list = uiBlocksByCategory.get(b.category) ?? [];
+  list.push(b.type);
+  uiBlocksByCategory.set(b.category, list);
+}
+
+// ---------------------------------------------------------------------------
+// Contract: UI → Compiler coverage
+// ---------------------------------------------------------------------------
+
+describe("UI → Compiler contract", () => {
+  it("every UI block type has a compiler handler", () => {
+    const missing = uiBlockTypes.filter((t) => !registry.has(t));
+    expect(missing, `UI blocks missing compiler handlers: [${missing.join(", ")}]`).toEqual([]);
+  });
+
+  it("every UI block type is listed in BLOCK_SUPPORT_MAP", () => {
+    const missing = uiBlockTypes.filter((t) => !(t in BLOCK_SUPPORT_MAP));
+    expect(missing, `UI blocks missing from support map: [${missing.join(", ")}]`).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Contract: Compiler → UI coverage
+// ---------------------------------------------------------------------------
+
+describe("Compiler → UI contract", () => {
+  it("every compiler handler corresponds to a UI block", () => {
+    const uiSet = new Set(uiBlockTypes);
+    const orphans = compilerBlockTypes.filter((t) => !uiSet.has(t));
+    expect(orphans, `Compiler handlers without UI block: [${orphans.join(", ")}]`).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Contract: Support map completeness
+// ---------------------------------------------------------------------------
+
+describe("Support map completeness", () => {
+  it("support map has no entries for non-existent UI blocks", () => {
+    const uiSet = new Set(uiBlockTypes);
+    const stale = supportMapTypes.filter((t) => !uiSet.has(t));
+    expect(stale, `Support map entries for removed UI blocks: [${stale.join(", ")}]`).toEqual([]);
+  });
+
+  it("support map has exactly the same block types as UI", () => {
+    expect(supportMapTypes).toEqual(uiBlockTypes);
+  });
+
+  it("every support map entry has a valid status", () => {
+    const validStatuses = new Set(["supported", "compile-only", "unsupported"]);
+    for (const [type, entry] of Object.entries(BLOCK_SUPPORT_MAP)) {
+      expect(validStatuses.has(entry.status), `Invalid status "${entry.status}" for block "${type}"`).toBe(true);
+      expect(entry.note.length, `Empty note for block "${type}"`).toBeGreaterThan(0);
+    }
+  });
+
+  it("compile-only blocks all have compiler handlers (not truly unsupported)", () => {
+    const compileOnly = Object.entries(BLOCK_SUPPORT_MAP)
+      .filter(([, e]) => e.status === "compile-only")
+      .map(([t]) => t);
+
+    for (const t of compileOnly) {
+      expect(registry.has(t), `Block "${t}" is compile-only but has no compiler handler`).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Contract: Category consistency
+// ---------------------------------------------------------------------------
+
+describe("Category consistency", () => {
+  it("compiler handler category matches UI block category for all blocks", () => {
+    const mismatches: string[] = [];
+    for (const uiBlock of BLOCK_DEFS) {
+      const handler = registry.get(uiBlock.type);
+      if (handler && handler.category !== uiBlock.category) {
+        mismatches.push(
+          `${uiBlock.type}: UI="${uiBlock.category}" vs compiler="${handler.category}"`,
+        );
+      }
+    }
+    expect(mismatches, `Category mismatches:\n${mismatches.join("\n")}`).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Snapshot: current support status (catches accidental status changes)
+// ---------------------------------------------------------------------------
+
+describe("Support status snapshot", () => {
+  it("currently supported blocks", () => {
+    const supported = Object.entries(BLOCK_SUPPORT_MAP)
+      .filter(([, e]) => e.status === "supported")
+      .map(([t]) => t)
+      .sort();
+
+    expect(supported).toEqual([
+      "EMA",
+      "RSI",
+      "SMA",
+      "candles",
+      "compare",
+      "cross",
+      "enter_long",
+      "enter_short",
+      "stop_loss",
+      "take_profit",
+    ]);
+  });
+
+  it("currently compile-only blocks", () => {
+    const compileOnly = Object.entries(BLOCK_SUPPORT_MAP)
+      .filter(([, e]) => e.status === "compile-only")
+      .map(([t]) => t)
+      .sort();
+
+    expect(compileOnly).toEqual([
+      "and_gate",
+      "atr",
+      "bollinger",
+      "constant",
+      "macd",
+      "or_gate",
+      "volume",
+    ]);
+  });
+
+  it("block count matches expected total", () => {
+    expect(uiBlockTypes.length).toBe(17);
+    expect(compilerBlockTypes.length).toBe(17);
+    expect(supportMapTypes.length).toBe(17);
+  });
+});

--- a/docs/strategies/08-strategy-capability-matrix.md
+++ b/docs/strategies/08-strategy-capability-matrix.md
@@ -1,0 +1,109 @@
+# Strategy Capability Matrix
+
+> Source of truth: `apps/api/src/lib/compiler/supportMap.ts`
+> Contract tests: `apps/api/tests/compiler/blockDrift.test.ts`
+> Last updated: 2026-03-20 (Issue #123)
+
+## Overview
+
+This document tracks the support status of every block type available in the
+Strategy Graph UI (`blockDefs.ts`) across the backend pipeline:
+compiler (graph → DSL), and backtest runtime (DSL → execution).
+
+The **authoritative source** for support status is `BLOCK_SUPPORT_MAP` in the
+compiler module. This document is a human-readable companion. Contract tests
+enforce that the code and this matrix stay in sync.
+
+## Support Levels
+
+| Status | Meaning |
+|--------|---------|
+| **supported** | Compiler handler exists AND backtest runtime can execute strategies using this block |
+| **compile-only** | Compiler handler extracts DSL data, but the backtest runtime does not yet execute it |
+| **unsupported** | No compiler handler — block cannot be compiled at all |
+
+## Block Capability Matrix
+
+### Input Blocks
+
+| Block | UI | Compiler | Runtime | Status | Notes |
+|-------|:--:|:--------:|:-------:|--------|-------|
+| `candles` | ✅ | ✅ | ✅ | **supported** | Core input block, since Phase 3 |
+| `constant` | ✅ | ✅ | ❌ | compile-only | Compiler extracts value; runtime pending (#124) |
+
+### Indicator Blocks
+
+| Block | UI | Compiler | Runtime | Status | Notes |
+|-------|:--:|:--------:|:-------:|--------|-------|
+| `SMA` | ✅ | ✅ | ✅ | **supported** | Since Phase 3 |
+| `EMA` | ✅ | ✅ | ✅ | **supported** | Since Phase 3 |
+| `RSI` | ✅ | ✅ | ✅ | **supported** | Since Phase 3 |
+| `macd` | ✅ | ✅ | ❌ | compile-only | Handler added #122; runtime pending (#125) |
+| `bollinger` | ✅ | ✅ | ❌ | compile-only | Handler added #122; runtime pending (#125) |
+| `atr` | ✅ | ✅ | ❌ | compile-only | Handler added #122; runtime pending (#125) |
+| `volume` | ✅ | ✅ | ❌ | compile-only | Handler added #122; runtime pending (#125) |
+
+### Logic Blocks
+
+| Block | UI | Compiler | Runtime | Status | Notes |
+|-------|:--:|:--------:|:-------:|--------|-------|
+| `compare` | ✅ | ✅ | ✅ | **supported** | Since Phase 4 |
+| `cross` | ✅ | ✅ | ✅ | **supported** | Since Phase 3 |
+| `and_gate` | ✅ | ✅ | ❌ | compile-only | Handler added #122; runtime pending (#124) |
+| `or_gate` | ✅ | ✅ | ❌ | compile-only | Handler added #122; runtime pending (#124) |
+
+### Execution Blocks
+
+| Block | UI | Compiler | Runtime | Status | Notes |
+|-------|:--:|:--------:|:-------:|--------|-------|
+| `enter_long` | ✅ | ✅ | ✅ | **supported** | Since Phase 3 |
+| `enter_short` | ✅ | ✅ | ✅ | **supported** | Since Phase 4 |
+
+### Risk Blocks
+
+| Block | UI | Compiler | Runtime | Status | Notes |
+|-------|:--:|:--------:|:-------:|--------|-------|
+| `stop_loss` | ✅ | ✅ | ✅ | **supported** | Since Phase 3 |
+| `take_profit` | ✅ | ✅ | ✅ | **supported** | Since Phase 3 |
+
+## Summary
+
+| Status | Count | Blocks |
+|--------|------:|--------|
+| **supported** | 10 | candles, SMA, EMA, RSI, compare, cross, enter_long, enter_short, stop_loss, take_profit |
+| **compile-only** | 7 | constant, macd, bollinger, atr, volume, and_gate, or_gate |
+| **unsupported** | 0 | — |
+| **Total** | 17 | |
+
+## How Drift Detection Works
+
+1. **UI block added without backend support** → contract test fails:
+   - `"every UI block type has a compiler handler"` catches missing handler
+   - `"every UI block type is listed in BLOCK_SUPPORT_MAP"` catches missing support entry
+
+2. **Compiler handler added without UI block** → contract test fails:
+   - `"every compiler handler corresponds to a UI block"` catches orphaned handlers
+
+3. **Support map out of sync** → contract test fails:
+   - `"support map has exactly the same block types as UI"` catches any mismatch
+   - Snapshot tests catch accidental status changes
+
+4. **Category mismatch** → contract test fails:
+   - `"compiler handler category matches UI block category"` catches inconsistencies
+
+## Adding a New Block
+
+1. Add the block definition to `apps/web/src/app/lab/build/blockDefs.ts`
+2. Create a `BlockHandler` in `apps/api/src/lib/compiler/blockHandlers.ts`
+3. Register it in `defaultHandlers()`
+4. Add an entry to `BLOCK_SUPPORT_MAP` in `apps/api/src/lib/compiler/supportMap.ts`
+5. Update the snapshot test expectations in `blockDrift.test.ts`
+6. Update this document
+7. Run `pnpm --filter @botmarketplace/api test` to verify
+
+## Promoting a Block from compile-only → supported
+
+1. Implement runtime execution in the backtest engine
+2. Update the status in `BLOCK_SUPPORT_MAP`
+3. Update the snapshot test expectations
+4. Update this document


### PR DESCRIPTION
## Summary

- Add `BLOCK_SUPPORT_MAP` (`apps/api/src/lib/compiler/supportMap.ts`) as the single source of truth for block support status across the pipeline
- Add 11 contract tests (`apps/api/tests/compiler/blockDrift.test.ts`) that detect UI/compiler drift automatically
- Add capability matrix document (`docs/strategies/08-strategy-capability-matrix.md`) listing all 17 blocks with status

### How drift detection works

If someone adds a new block to `blockDefs.ts` without:
1. Adding a compiler handler → test fails
2. Adding a support map entry → test fails
3. Updating snapshot expectations → test fails

Conversely, orphaned compiler handlers without UI blocks are also caught.

### Support levels

| Status | Count | Description |
|--------|------:|-------------|
| **supported** | 10 | Full pipeline: UI → compiler → runtime |
| **compile-only** | 7 | Compiler handler exists, runtime pending |
| **unsupported** | 0 | — |

### Compile-only blocks (7)

`constant`, `macd`, `bollinger`, `atr`, `volume`, `and_gate`, `or_gate` — all have compiler handlers from #122 but backtest runtime does not execute their DSL yet.

## Test plan

- [x] All 65 API tests pass (54 existing + 11 new)
- [x] Contract tests verify UI ↔ compiler ↔ support map consistency
- [x] Category consistency verified across UI and compiler
- [x] Snapshot tests lock current supported/compile-only block sets

Closes #123

https://claude.ai/code/session_011Y6u297GtfJa9KL9C7Z9Ee