### PR TITLE
fix(api): DCA slice 3 hotfix — reason ReferenceError + soIndex validation (#132)

### DIFF
--- a/apps/api/src/lib/botWorker.ts
+++ b/apps/api/src/lib/botWorker.ts
@@ -1074,6 +1074,17 @@ async function reconcileEntryFill(
       });
       const dcaState = recoverDcaState(existingPos?.metaJson);
       if (dcaState && dcaState.nextSoIndex >= 0) {
+        // Validate soIndex from intent matches expected nextSoIndex from state.
+        // In normal sequential processing these always agree; a mismatch means
+        // a race or replay anomaly — log warning but proceed with state's index
+        // since the engine enforces sequential fill guards.
+        const intentSoIndex = typeof meta.soIndex === "number" ? meta.soIndex : undefined;
+        if (intentSoIndex !== undefined && intentSoIndex !== dcaState.nextSoIndex) {
+          workerLog.warn(
+            { intentSoIndex, stateNextSoIndex: dcaState.nextSoIndex, intentId: intent.intentId },
+            "DCA SO index mismatch: intent soIndex differs from state nextSoIndex",
+          );
+        }
         const soResult = handleDcaSoFill(dcaState, dcaState.nextSoIndex, fillPrice, fillDelta);
         if (soResult.exitLevelsChanged) {
           // Merge updated DCA state into existing metaJson (preserve other fields)
@@ -1177,7 +1188,7 @@ async function reconcileExitFill(
             },
           });
           workerLog.info(
-            { positionId: position.id, sosFilled: dcaState.safetyOrdersFilled, reason },
+            { positionId: position.id, sosFilled: dcaState.safetyOrdersFilled, reason: "position_closed" },
             "DCA ladder finalized on exit fill",
           );
         }
@@ -1450,6 +1461,8 @@ async function evaluateStrategies(): Promise<void> {
                         soIndex: so.index,
                         triggerPrice: so.triggerPrice,
                         positionId: position.id,
+                        slPrice: dcaState.slPrice,
+                        tpPrice: dcaState.tpPrice,
                       } as Prisma.InputJsonValue,
                     },
                   });


### PR DESCRIPTION
## Summary

Hotfix for 3 findings from post-merge review of PR #163.

**B2 (runtime bug):** `reason` variable referenced in finalization log was undefined after fix commit `4c870d6` removed the declaration. Causes ReferenceError on every DCA ladder finalization — caught by non-fatal handler but produces misleading logs. Fixed with string literal.

**B1 (contract hardening):** SO fill path uses `dcaState.nextSoIndex` from DB but ignores `meta.soIndex` from the intent. Added log-warn when these diverge, making the implicit sequential-fill contract explicit for diagnostics.

**M1 (diagnostics):** Added `slPrice`/`tpPrice` to SO intent metaJson for parity with base order intents.

## Files changed

| File | Change |
|------|--------|
| `apps/api/src/lib/botWorker.ts` | +14/-1 |

## Test plan

- [x] 705 total API tests pass, 0 regressions

https://claude.ai/code/session_01Q1KeciEtrAt7SSwixRffNt