### PR TITLE
fix(api): preserve audit fields in DCA position OPEN event (#132)

### DIFF
--- a/apps/api/src/lib/botWorker.ts
+++ b/apps/api/src/lib/botWorker.ts
@@ -1042,7 +1042,11 @@ async function reconcileEntryFill(
         // Override SL/TP with DCA-computed values
         slPrice = dcaState.slPrice;
         tpPrice = dcaState.tpPrice;
-        positionMeta = { dcaState: serializeDcaState(dcaState) };
+        positionMeta = {
+          source: "reconciliation",
+          orderId: intent.id,
+          dcaState: serializeDcaState(dcaState),
+        };
 
         workerLog.info(
           {


### PR DESCRIPTION
## Summary

One-line fix from comprehensive #132 review: DCA base fill was setting `positionMeta` to `{ dcaState }` only, losing `source`/`orderId` audit fields that non-DCA positions include in their OPEN event metaJson. Now merges both.

## Change

```diff
- positionMeta = { dcaState: serializeDcaState(dcaState) };
+ positionMeta = {
+   source: "reconciliation",
+   orderId: intent.id,
+   dcaState: serializeDcaState(dcaState),
+ };
```

711 tests pass, 0 regressions.

https://claude.ai/code/session_01Q1KeciEtrAt7SSwixRffNt