### PR TITLE
feat: add dca_config block to visual builder + compiler (#133 slice 2)

### DIFF
--- a/apps/api/src/lib/compiler/blockHandlers.ts
+++ b/apps/api/src/lib/compiler/blockHandlers.ts
@@ -449,6 +449,36 @@ export const takeProfitHandler: BlockHandler = {
 };
 
 // ---------------------------------------------------------------------------
+// DCA block (#133)
+// ---------------------------------------------------------------------------
+
+export const dcaConfigHandler: BlockHandler = {
+  blockType: "dca_config",
+  category: "risk",
+  validate(ctx) {
+    const nodes = nodesOf(ctx, "dca_config");
+    // Optional block — not required for non-DCA strategies
+    if (nodes.length > 1) {
+      ctx.issues.push({ severity: "error", message: "Only one DCA Config block is allowed." });
+    }
+  },
+  extract(ctx) {
+    const node = nodesOf(ctx, "dca_config")[0];
+    if (!node) return {};
+    return {
+      dca: {
+        baseOrderSizeUsd: Number(node.data.params["baseOrderSizeUsd"] ?? 100),
+        maxSafetyOrders: Number(node.data.params["maxSafetyOrders"] ?? 3),
+        priceStepPct: Number(node.data.params["priceStepPct"] ?? 1.0),
+        stepScale: Number(node.data.params["stepScale"] ?? 1.0),
+        volumeScale: Number(node.data.params["volumeScale"] ?? 1.5),
+        takeProfitPct: Number(node.data.params["takeProfitPct"] ?? 1.5),
+      },
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
 // Default handler set — all MVP block types
 // ---------------------------------------------------------------------------
 
@@ -480,5 +510,7 @@ export function defaultHandlers(): BlockHandler[] {
     // Risk
     stopLossHandler,
     takeProfitHandler,
+    // DCA
+    dcaConfigHandler,
   ];
 }

--- a/apps/api/src/lib/compiler/supportMap.ts
+++ b/apps/api/src/lib/compiler/supportMap.ts
@@ -60,4 +60,7 @@ export const BLOCK_SUPPORT_MAP: Record<string, BlockSupportEntry> = {
   // ── Risk ────────────────────────────────────────────────────────────────────
   stop_loss:    { status: "supported",    note: "Fully supported since Phase 3" },
   take_profit:  { status: "supported",    note: "Fully supported since Phase 3" },
+
+  // ── DCA ─────────────────────────────────────────────────────────────────────
+  dca_config:   { status: "supported",    note: "DCA ladder config block, #133. Compiles to DSL dca section, runtime engine #132" },
 };

--- a/apps/api/tests/compiler/blockDrift.test.ts
+++ b/apps/api/tests/compiler/blockDrift.test.ts
@@ -139,6 +139,7 @@ describe("Support status snapshot", () => {
       "candles",
       "compare",
       "cross",
+      "dca_config",
       "enter_adaptive",
       "enter_long",
       "enter_short",
@@ -167,8 +168,8 @@ describe("Support status snapshot", () => {
   });
 
   it("block count matches expected total", () => {
-    expect(uiBlockTypes.length).toBe(21);
-    expect(compilerBlockTypes.length).toBe(21);
-    expect(supportMapTypes.length).toBe(21);
+    expect(uiBlockTypes.length).toBe(22);
+    expect(compilerBlockTypes.length).toBe(22);
+    expect(supportMapTypes.length).toBe(22);
   });
 });

--- a/apps/web/src/app/lab/build/blockDefs.ts
+++ b/apps/web/src/app/lab/build/blockDefs.ts
@@ -448,6 +448,26 @@ export const BLOCK_DEFS: BlockDef[] = [
     ],
     description: "Computes take-profit risk parameters (fixed % or R-multiple).",
   },
+
+  // ── DCA ───────────────────────────────────────────────────────────────────
+  {
+    type: "dca_config",
+    label: "DCA Config",
+    category: "risk",
+    inputs: [],
+    outputs: [
+      { id: "risk", label: "dca", dataType: "RiskParams", required: false },
+    ],
+    params: [
+      { id: "baseOrderSizeUsd", label: "Base Order (USD)", type: "number", defaultValue: 100, min: 1, max: 100000 },
+      { id: "maxSafetyOrders", label: "Max Safety Orders", type: "number", defaultValue: 3, min: 1, max: 50 },
+      { id: "priceStepPct", label: "Price Step %", type: "number", defaultValue: 1.0, min: 0.1, max: 50 },
+      { id: "stepScale", label: "Step Scale", type: "number", defaultValue: 1.0, min: 1.0, max: 10 },
+      { id: "volumeScale", label: "Volume Scale", type: "number", defaultValue: 1.5, min: 1.0, max: 10 },
+      { id: "takeProfitPct", label: "TP from Avg %", type: "number", defaultValue: 1.5, min: 0.1, max: 100 },
+    ],
+    description: "Configures DCA ladder: base order, safety orders with step/volume scaling, and TP recalculation from averaged entry.",
+  },
 ];
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Second slice of #133 — adds the `dca_config` block to the visual builder and compiler pipeline, enabling DCA Momentum Bot authoring through the graph UI.

- **blockDefs.ts**: new `dca_config` block (risk category) with 6 params matching DCA config schema
- **blockHandlers.ts**: `dcaConfigHandler` extracts params into DSL `dca` section. Optional block — non-DCA strategies unaffected. Validates at most one per graph.
- **supportMap.ts**: `dca_config: supported`
- **blockDrift.test.ts**: snapshot updated 21→22 blocks

## Files changed

| File | Change |
|------|--------|
| `apps/web/src/app/lab/build/blockDefs.ts` | +20 — dca_config block definition |
| `apps/api/src/lib/compiler/blockHandlers.ts` | +32 — dcaConfigHandler |
| `apps/api/src/lib/compiler/supportMap.ts` | +3 — dca_config entry |
| `apps/api/tests/compiler/blockDrift.test.ts` | +4/-3 — snapshot update |

## What this completes

With slices 1-2, #133 now has:
- DSL fixtures + 16 e2e acceptance tests
- `dca_config` block in visual builder
- Compiler handler producing DSL `dca` section
- Block drift contract tests updated

## What remains for #133

- Graph fixture test: compile graph with dca_config → verify DSL output
- Documentation update

727 tests pass, 0 regressions.

https://claude.ai/code/session_01Q1KeciEtrAt7SSwixRffNt