### PR TITLE
feat(api): MTF interval alignment primitives + session helpers (#134 slice 1)

### DIFF
--- a/apps/api/src/lib/mtf/intervalAlignment.ts
+++ b/apps/api/src/lib/mtf/intervalAlignment.ts
@@ -1,0 +1,286 @@
+/**
+ * Multi-Timeframe Interval Alignment (#134 — Slice 1)
+ *
+ * Pure functions for aligning candle data across multiple timeframes.
+ *
+ * Core problem: when evaluating a 1m candle, which 5m/15m/1h candle is
+ * "current"? This module provides deterministic alignment primitives.
+ *
+ * Concepts:
+ *   - Primary TF: the timeframe on which signals are evaluated (e.g., 1m)
+ *   - Context TFs: higher timeframes providing confluence (e.g., 5m, 15m, 1h)
+ *   - Alignment: mapping a primary-TF candle to the correct context-TF candle
+ *
+ * Design:
+ *   - Pure functions, no I/O
+ *   - All alignment is timestamp-based (candle openTime in epoch ms)
+ *   - No assumptions about candle source (works with any OHLCV data)
+ */
+
+/** Standard OHLCV candle (compatible with bybitCandles.Candle) */
+export interface MtfCandle {
+  openTime: number;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+// ---------------------------------------------------------------------------
+// Interval definitions
+// ---------------------------------------------------------------------------
+
+export type Interval = "1m" | "5m" | "15m" | "1h" | "4h" | "1d";
+
+/** Duration of each interval in milliseconds */
+export const INTERVAL_MS: Record<Interval, number> = {
+  "1m": 60_000,
+  "5m": 300_000,
+  "15m": 900_000,
+  "1h": 3_600_000,
+  "4h": 14_400_000,
+  "1d": 86_400_000,
+};
+
+/** Map from DSL timeframe names to interval */
+export const TIMEFRAME_TO_INTERVAL: Record<string, Interval> = {
+  M1: "1m",
+  M5: "5m",
+  M15: "15m",
+  H1: "1h",
+  H4: "4h",
+  D1: "1d",
+};
+
+/** Ordered from smallest to largest */
+export const INTERVAL_ORDER: Interval[] = ["1m", "5m", "15m", "1h", "4h", "1d"];
+
+// ---------------------------------------------------------------------------
+// Alignment primitives
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the open time of the higher-TF candle that contains a given timestamp.
+ *
+ * Example: for timestamp in the middle of a 5m candle,
+ *   alignToInterval(ts, "5m") → start of that 5m period
+ *
+ * Uses floor division on UTC epoch — deterministic, no timezone ambiguity.
+ */
+export function alignToInterval(timestampMs: number, interval: Interval): number {
+  const ms = INTERVAL_MS[interval];
+  return Math.floor(timestampMs / ms) * ms;
+}
+
+/**
+ * Find the index of the context-TF candle that corresponds to a primary-TF candle.
+ *
+ * Given a primary candle's openTime and a sorted array of context-TF candles,
+ * returns the index of the context candle whose period contains the primary candle.
+ *
+ * Uses binary search for O(log n) performance.
+ *
+ * @returns Index into contextCandles, or -1 if not found
+ */
+export function findContextCandleIndex(
+  primaryOpenTime: number,
+  contextCandles: MtfCandle[],
+  contextInterval: Interval,
+): number {
+  const alignedTime = alignToInterval(primaryOpenTime, contextInterval);
+
+  // Binary search for the context candle with openTime === alignedTime
+  let lo = 0;
+  let hi = contextCandles.length - 1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >>> 1;
+    const midTime = contextCandles[mid].openTime;
+    if (midTime === alignedTime) return mid;
+    if (midTime < alignedTime) lo = mid + 1;
+    else hi = mid - 1;
+  }
+
+  return -1;
+}
+
+/**
+ * Build a lookup table mapping each primary-TF candle index to the
+ * corresponding context-TF candle index.
+ *
+ * The result array has the same length as primaryCandles.
+ * result[i] = index into contextCandles, or -1 if no match.
+ *
+ * Optimized: walks both arrays in parallel (O(n+m) instead of O(n log m)).
+ */
+export function buildAlignmentMap(
+  primaryCandles: MtfCandle[],
+  contextCandles: MtfCandle[],
+  contextInterval: Interval,
+): number[] {
+  const map = new Array<number>(primaryCandles.length).fill(-1);
+  if (contextCandles.length === 0) return map;
+
+  let ctxIdx = 0;
+
+  for (let i = 0; i < primaryCandles.length; i++) {
+    const aligned = alignToInterval(primaryCandles[i].openTime, contextInterval);
+
+    // Advance context pointer to match or pass the aligned time
+    while (ctxIdx < contextCandles.length && contextCandles[ctxIdx].openTime < aligned) {
+      ctxIdx++;
+    }
+
+    // Check if we found an exact match
+    if (ctxIdx < contextCandles.length && contextCandles[ctxIdx].openTime === aligned) {
+      map[i] = ctxIdx;
+    }
+  }
+
+  return map;
+}
+
+// ---------------------------------------------------------------------------
+// Multi-TF candle bundle
+// ---------------------------------------------------------------------------
+
+/** A bundle of candle arrays, one per timeframe */
+export interface CandleBundle {
+  /** The primary evaluation timeframe */
+  primaryInterval: Interval;
+  /** Candle data keyed by interval */
+  candles: Record<string, MtfCandle[]>;
+  /** Pre-computed alignment maps: alignmentMaps[contextInterval][primaryIdx] = contextIdx */
+  alignmentMaps: Record<string, number[]>;
+}
+
+/**
+ * Create a CandleBundle from a set of candle arrays.
+ *
+ * Pre-computes alignment maps for all context intervals relative to the primary.
+ *
+ * @param primaryInterval  The primary evaluation interval
+ * @param candlesByInterval  Map of interval → candle array (must include primary)
+ */
+export function createCandleBundle(
+  primaryInterval: Interval,
+  candlesByInterval: Record<string, MtfCandle[]>,
+): CandleBundle {
+  const primary = candlesByInterval[primaryInterval];
+  if (!primary) {
+    throw new Error(`Primary interval "${primaryInterval}" not found in candle data`);
+  }
+
+  const alignmentMaps: Record<string, number[]> = {};
+  for (const [interval, candles] of Object.entries(candlesByInterval)) {
+    if (interval === primaryInterval) continue;
+    if (!INTERVAL_MS[interval as Interval]) continue;
+    alignmentMaps[interval] = buildAlignmentMap(primary, candles, interval as Interval);
+  }
+
+  return {
+    primaryInterval,
+    candles: candlesByInterval,
+    alignmentMaps,
+  };
+}
+
+/**
+ * Look up the context-TF candle value at a given primary-TF bar index.
+ *
+ * @returns The context candle, or null if not aligned (gap in data)
+ */
+export function getContextCandle(
+  bundle: CandleBundle,
+  contextInterval: string,
+  primaryBarIndex: number,
+): MtfCandle | null {
+  const map = bundle.alignmentMaps[contextInterval];
+  if (!map) return null;
+
+  const ctxIdx = map[primaryBarIndex];
+  if (ctxIdx < 0) return null;
+
+  return bundle.candles[contextInterval]?.[ctxIdx] ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Session boundaries
+// ---------------------------------------------------------------------------
+
+/** Known trading session definitions (UTC hours) */
+export interface SessionWindow {
+  name: string;
+  /** UTC hour when session opens (0-23) */
+  openHourUtc: number;
+  /** UTC hour when session closes (0-23) */
+  closeHourUtc: number;
+}
+
+export const SESSIONS: Record<string, SessionWindow> = {
+  london: { name: "London", openHourUtc: 8, closeHourUtc: 16 },
+  new_york: { name: "New York", openHourUtc: 13, closeHourUtc: 21 },
+  asia: { name: "Asia", openHourUtc: 0, closeHourUtc: 8 },
+  utc_day: { name: "UTC Day", openHourUtc: 0, closeHourUtc: 0 }, // 24h, resets at midnight
+};
+
+/**
+ * Check if a timestamp falls within a trading session.
+ *
+ * For utc_day, always returns true (full 24h session).
+ */
+export function isInSession(timestampMs: number, session: SessionWindow): boolean {
+  if (session.openHourUtc === session.closeHourUtc) return true; // 24h session
+
+  const date = new Date(timestampMs);
+  const hour = date.getUTCHours();
+
+  if (session.openHourUtc < session.closeHourUtc) {
+    return hour >= session.openHourUtc && hour < session.closeHourUtc;
+  }
+  // Wraps midnight (e.g., 22:00 → 06:00)
+  return hour >= session.openHourUtc || hour < session.closeHourUtc;
+}
+
+/**
+ * Compute the start of the current session period for a given timestamp.
+ *
+ * Used for session-anchored VWAP resets: when the session starts,
+ * VWAP accumulation restarts from zero.
+ */
+export function getSessionStart(timestampMs: number, session: SessionWindow): number {
+  const date = new Date(timestampMs);
+  const hour = date.getUTCHours();
+
+  const sessionDate = new Date(date);
+  sessionDate.setUTCMinutes(0, 0, 0);
+  sessionDate.setUTCHours(session.openHourUtc);
+
+  // If current hour is before session open, session started yesterday
+  if (session.openHourUtc <= session.closeHourUtc) {
+    if (hour < session.openHourUtc) {
+      sessionDate.setUTCDate(sessionDate.getUTCDate() - 1);
+    }
+  } else {
+    // Wrap case: if we're in the early-morning portion (after midnight)
+    if (hour < session.openHourUtc && hour < session.closeHourUtc) {
+      sessionDate.setUTCDate(sessionDate.getUTCDate() - 1);
+    }
+  }
+
+  return sessionDate.getTime();
+}
+
+/**
+ * Check if a candle is the first bar of a new session.
+ *
+ * Compares the session start of the current candle vs the previous candle.
+ * If they differ, it's a new session → triggers VWAP/profile reset.
+ */
+export function isSessionBoundary(
+  currentOpenTime: number,
+  previousOpenTime: number,
+  session: SessionWindow,
+): boolean {
+  return getSessionStart(currentOpenTime, session) !== getSessionStart(previousOpenTime, session);
+}

--- a/apps/api/tests/mtf/intervalAlignment.test.ts
+++ b/apps/api/tests/mtf/intervalAlignment.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Multi-Timeframe Interval Alignment Tests (#134 — Slice 1)
+ *
+ * Deterministic tests for interval alignment, candle bundle, and session primitives.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  type MtfCandle,
+  alignToInterval,
+  findContextCandleIndex,
+  buildAlignmentMap,
+  createCandleBundle,
+  getContextCandle,
+  isInSession,
+  getSessionStart,
+  isSessionBoundary,
+  INTERVAL_MS,
+  SESSIONS,
+  TIMEFRAME_TO_INTERVAL,
+  type Interval,
+} from "../../src/lib/mtf/intervalAlignment.js";
+
+// ---------------------------------------------------------------------------
+// Candle fixtures
+// ---------------------------------------------------------------------------
+
+// Use a start time aligned to all intervals (divisible by 86400000 = 1d)
+const ALIGNED_START = 1700006400000; // 2023-11-15 00:00:00 UTC (aligned to day boundary)
+
+function makeCandles(interval: Interval, count: number, startMs: number = ALIGNED_START): MtfCandle[] {
+  const ms = INTERVAL_MS[interval];
+  const candles: MtfCandle[] = [];
+  for (let i = 0; i < count; i++) {
+    const openTime = startMs + i * ms;
+    candles.push({
+      openTime,
+      open: 100 + i,
+      high: 101 + i,
+      low: 99 + i,
+      close: 100.5 + i,
+      volume: 1000,
+    });
+  }
+  return candles;
+}
+
+// ---------------------------------------------------------------------------
+// alignToInterval
+// ---------------------------------------------------------------------------
+
+describe("alignToInterval", () => {
+  it("aligns 1m timestamp to 5m boundary", () => {
+    const base = ALIGNED_START; // on 5m boundary
+    const ts = base + 3 * 60_000; // +3m
+    expect(alignToInterval(ts, "5m")).toBe(base);
+  });
+
+  it("aligns to 15m boundary", () => {
+    const base = ALIGNED_START;
+    expect(alignToInterval(base + 7 * 60_000, "15m")).toBe(base);
+    expect(alignToInterval(base + 16 * 60_000, "15m")).toBe(base + 15 * 60_000);
+  });
+
+  it("aligns to 1h boundary", () => {
+    const base = ALIGNED_START;
+    const aligned = alignToInterval(base + 30 * 60_000, "1h");
+    expect(aligned).toBe(base);
+  });
+
+  it("exact boundary returns itself", () => {
+    expect(alignToInterval(ALIGNED_START, "5m")).toBe(ALIGNED_START);
+    expect(alignToInterval(ALIGNED_START, "15m")).toBe(ALIGNED_START);
+    expect(alignToInterval(ALIGNED_START, "1h")).toBe(ALIGNED_START);
+  });
+
+  it("is deterministic", () => {
+    const ts = ALIGNED_START + 123456;
+    expect(alignToInterval(ts, "15m")).toBe(alignToInterval(ts, "15m"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findContextCandleIndex
+// ---------------------------------------------------------------------------
+
+describe("findContextCandleIndex", () => {
+  it("finds correct 5m candle for a 1m timestamp", () => {
+    const ctx5m = makeCandles("5m", 10);
+    // A 1m candle 2 minutes into the 3rd 5m period
+    const primaryTime = ctx5m[2].openTime + 2 * 60_000;
+    expect(findContextCandleIndex(primaryTime, ctx5m, "5m")).toBe(2);
+  });
+
+  it("returns -1 when context data doesn't cover the timestamp", () => {
+    const ctx5m = makeCandles("5m", 5);
+    // Way after the last candle
+    const farFuture = ctx5m[4].openTime + 100 * 300_000;
+    expect(findContextCandleIndex(farFuture, ctx5m, "5m")).toBe(-1);
+  });
+
+  it("returns 0 for timestamp within first context candle", () => {
+    const ctx5m = makeCandles("5m", 5);
+    expect(findContextCandleIndex(ctx5m[0].openTime + 60_000, ctx5m, "5m")).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildAlignmentMap
+// ---------------------------------------------------------------------------
+
+describe("buildAlignmentMap", () => {
+  it("maps every 1m candle to the correct 5m candle", () => {
+    const start = ALIGNED_START;
+    const primary1m = makeCandles("1m", 15, start);
+    const context5m = makeCandles("5m", 3, start);
+
+    const map = buildAlignmentMap(primary1m, context5m, "5m");
+    expect(map).toHaveLength(15);
+
+    // First 5 candles (0-4) should map to context[0]
+    for (let i = 0; i < 5; i++) expect(map[i]).toBe(0);
+    // Next 5 (5-9) should map to context[1]
+    for (let i = 5; i < 10; i++) expect(map[i]).toBe(1);
+    // Last 5 (10-14) should map to context[2]
+    for (let i = 10; i < 15; i++) expect(map[i]).toBe(2);
+  });
+
+  it("maps 1m to 15m correctly", () => {
+    const start = ALIGNED_START;
+    const primary1m = makeCandles("1m", 30, start);
+    const context15m = makeCandles("15m", 2, start);
+
+    const map = buildAlignmentMap(primary1m, context15m, "15m");
+    // First 15 candles → context[0], next 15 → context[1]
+    for (let i = 0; i < 15; i++) expect(map[i]).toBe(0);
+    for (let i = 15; i < 30; i++) expect(map[i]).toBe(1);
+  });
+
+  it("returns -1 for gaps in context data", () => {
+    const start = ALIGNED_START;
+    const primary1m = makeCandles("1m", 10, start);
+    // Context starts at 5m offset (skip first 5m candle)
+    const context5m = makeCandles("5m", 2, start + 300_000);
+
+    const map = buildAlignmentMap(primary1m, context5m, "5m");
+    // First 5 1m candles have no matching 5m candle
+    for (let i = 0; i < 5; i++) expect(map[i]).toBe(-1);
+    // Next 5 should map to context[0]
+    for (let i = 5; i < 10; i++) expect(map[i]).toBe(0);
+  });
+
+  it("handles empty context array", () => {
+    const primary = makeCandles("1m", 5);
+    const map = buildAlignmentMap(primary, [], "5m");
+    expect(map).toEqual([-1, -1, -1, -1, -1]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CandleBundle
+// ---------------------------------------------------------------------------
+
+describe("createCandleBundle + getContextCandle", () => {
+  it("creates bundle with alignment maps", () => {
+    const start = ALIGNED_START;
+    const bundle = createCandleBundle("1m", {
+      "1m": makeCandles("1m", 30, start),
+      "5m": makeCandles("5m", 6, start),
+      "15m": makeCandles("15m", 2, start),
+    });
+
+    expect(bundle.primaryInterval).toBe("1m");
+    expect(bundle.alignmentMaps["5m"]).toHaveLength(30);
+    expect(bundle.alignmentMaps["15m"]).toHaveLength(30);
+    expect(bundle.alignmentMaps["1m"]).toBeUndefined(); // primary not in maps
+  });
+
+  it("getContextCandle returns correct higher-TF candle", () => {
+    const start = ALIGNED_START;
+    const bundle = createCandleBundle("1m", {
+      "1m": makeCandles("1m", 15, start),
+      "5m": makeCandles("5m", 3, start),
+    });
+
+    // 1m bar 7 is in the 2nd 5m period
+    const ctx = getContextCandle(bundle, "5m", 7);
+    expect(ctx).not.toBeNull();
+    expect(ctx!.openTime).toBe(start + 300_000); // 2nd 5m candle
+  });
+
+  it("returns null for unaligned bars", () => {
+    const start = ALIGNED_START;
+    const bundle = createCandleBundle("1m", {
+      "1m": makeCandles("1m", 10, start),
+      "5m": makeCandles("5m", 1, start + 300_000), // starts late
+    });
+
+    expect(getContextCandle(bundle, "5m", 0)).toBeNull(); // no match
+    expect(getContextCandle(bundle, "5m", 5)).not.toBeNull(); // match
+  });
+
+  it("returns null for non-existent context interval", () => {
+    const bundle = createCandleBundle("1m", { "1m": makeCandles("1m", 5) });
+    expect(getContextCandle(bundle, "5m", 0)).toBeNull();
+  });
+
+  it("throws when primary interval is missing", () => {
+    expect(() => createCandleBundle("1m", { "5m": makeCandles("5m", 5) })).toThrow("Primary interval");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session helpers
+// ---------------------------------------------------------------------------
+
+describe("isInSession", () => {
+  it("London session: 08:00-16:00 UTC", () => {
+    const london = SESSIONS.london;
+    // 10:00 UTC → in session
+    const inSession = Date.UTC(2024, 0, 15, 10, 0, 0);
+    expect(isInSession(inSession, london)).toBe(true);
+
+    // 07:59 UTC → before session
+    const before = Date.UTC(2024, 0, 15, 7, 59, 0);
+    expect(isInSession(before, london)).toBe(false);
+
+    // 16:00 UTC → session closed (exclusive)
+    const atClose = Date.UTC(2024, 0, 15, 16, 0, 0);
+    expect(isInSession(atClose, london)).toBe(false);
+  });
+
+  it("New York session: 13:00-21:00 UTC", () => {
+    const ny = SESSIONS.new_york;
+    expect(isInSession(Date.UTC(2024, 0, 15, 14, 30, 0), ny)).toBe(true);
+    expect(isInSession(Date.UTC(2024, 0, 15, 12, 0, 0), ny)).toBe(false);
+  });
+
+  it("UTC day: always in session", () => {
+    const utc = SESSIONS.utc_day;
+    expect(isInSession(Date.UTC(2024, 0, 15, 3, 0, 0), utc)).toBe(true);
+    expect(isInSession(Date.UTC(2024, 0, 15, 23, 59, 0), utc)).toBe(true);
+  });
+});
+
+describe("getSessionStart", () => {
+  it("returns London session start for mid-session timestamp", () => {
+    const london = SESSIONS.london;
+    const midSession = Date.UTC(2024, 0, 15, 12, 30, 0); // 12:30 UTC
+    const start = getSessionStart(midSession, london);
+    expect(start).toBe(Date.UTC(2024, 0, 15, 8, 0, 0)); // 08:00 UTC
+  });
+
+  it("returns previous day's session start for pre-session timestamp", () => {
+    const london = SESSIONS.london;
+    const beforeSession = Date.UTC(2024, 0, 15, 6, 0, 0); // 06:00 UTC
+    const start = getSessionStart(beforeSession, london);
+    expect(start).toBe(Date.UTC(2024, 0, 14, 8, 0, 0)); // previous day 08:00
+  });
+});
+
+describe("isSessionBoundary", () => {
+  it("detects new London session", () => {
+    const london = SESSIONS.london;
+    const prevDay = Date.UTC(2024, 0, 14, 15, 59, 0); // end of prev session
+    const newDay = Date.UTC(2024, 0, 15, 8, 0, 0);   // start of new session
+    expect(isSessionBoundary(newDay, prevDay, london)).toBe(true);
+  });
+
+  it("same session → no boundary", () => {
+    const london = SESSIONS.london;
+    const t1 = Date.UTC(2024, 0, 15, 10, 0, 0);
+    const t2 = Date.UTC(2024, 0, 15, 10, 1, 0);
+    expect(isSessionBoundary(t2, t1, london)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+describe("constants", () => {
+  it("TIMEFRAME_TO_INTERVAL maps all DSL timeframes", () => {
+    expect(TIMEFRAME_TO_INTERVAL["M1"]).toBe("1m");
+    expect(TIMEFRAME_TO_INTERVAL["M5"]).toBe("5m");
+    expect(TIMEFRAME_TO_INTERVAL["M15"]).toBe("15m");
+    expect(TIMEFRAME_TO_INTERVAL["H1"]).toBe("1h");
+    expect(TIMEFRAME_TO_INTERVAL["D1"]).toBe("1d");
+  });
+
+  it("INTERVAL_MS has correct millisecond values", () => {
+    expect(INTERVAL_MS["1m"]).toBe(60_000);
+    expect(INTERVAL_MS["5m"]).toBe(5 * 60_000);
+    expect(INTERVAL_MS["15m"]).toBe(15 * 60_000);
+    expect(INTERVAL_MS["1h"]).toBe(60 * 60_000);
+    expect(INTERVAL_MS["1d"]).toBe(24 * 60 * 60_000);
+  });
+});


### PR DESCRIPTION
## Summary

First slice of #134 — pure foundational primitives for multi-timeframe candle alignment and session boundary detection.

### New module: `apps/api/src/lib/mtf/intervalAlignment.ts`

**Interval alignment:**
- `alignToInterval(timestamp, interval)` — floor to interval boundary (UTC epoch)
- `findContextCandleIndex(primaryTime, contextCandles, interval)` — O(log n) binary search
- `buildAlignmentMap(primaryCandles, contextCandles, interval)` — O(n+m) parallel scan
- `createCandleBundle(primaryInterval, candlesByInterval)` — pre-computed alignment maps
- `getContextCandle(bundle, contextInterval, primaryBarIndex)` — O(1) lookup

**Session boundaries:**
- `isInSession(timestamp, session)` — check if timestamp is in a trading session
- `getSessionStart(timestamp, session)` — compute session start for VWAP anchoring
- `isSessionBoundary(currentTime, previousTime, session)` — detect session resets
- Predefined sessions: London, New York, Asia, UTC Day

**Constants:** `INTERVAL_MS`, `TIMEFRAME_TO_INTERVAL`, `INTERVAL_ORDER`, `SESSIONS`

### Files

| File | Lines | Description |
|------|-------|-------------|
| `apps/api/src/lib/mtf/intervalAlignment.ts` | 278 | New — pure MTF domain module |
| `apps/api/tests/mtf/intervalAlignment.test.ts` | 306 | New — 26 deterministic tests |

### What remains for #134

- Wire CandleBundle into backtest evaluator (multi-TF indicator resolution)
- Extend DSL with `sourceTimeframe` on indicator refs
- Multi-interval candle fetch in bot worker
- Runtime multi-TF candle buffer maintenance

753 tests pass, 0 regressions.

https://claude.ai/code/session_01Q1KeciEtrAt7SSwixRffNt