### PR TITLE
feat(api): VolumeProfile + ProximityFilter indicators (#135)

### DIFF
--- a/apps/api/src/lib/indicators/proximityFilter.ts
+++ b/apps/api/src/lib/indicators/proximityFilter.ts
@@ -1,0 +1,95 @@
+/**
+ * Proximity Filter (#135)
+ *
+ * Signal gating based on distance to key price levels.
+ * Returns true when price is "near" a reference level (within threshold).
+ *
+ * Used by MTF Confluence Scalper to gate entries near volume profile
+ * levels (POC, VAH, VAL) or other support/resistance levels.
+ *
+ * Design:
+ *   - Pure function, deterministic
+ *   - Works with any pair of price series (e.g., close vs POC)
+ *   - Threshold can be absolute or percentage-based
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ProximityMode = "absolute" | "percentage";
+
+// ---------------------------------------------------------------------------
+// Computation
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute proximity filter: true when price is within threshold of a level.
+ *
+ * @param prices      The price series to check (e.g., candle closes)
+ * @param levels      The reference level series (e.g., POC from VolumeProfile)
+ * @param threshold   Distance threshold
+ * @param mode        "absolute" (fixed price distance) or "percentage" (% of level)
+ * @returns Boolean series: true = price is near level, false = not near, null = insufficient data
+ */
+export function calcProximityFilter(
+  prices: (number | null)[],
+  levels: (number | null)[],
+  threshold: number,
+  mode: ProximityMode = "percentage",
+): (boolean | null)[] {
+  const n = Math.min(prices.length, levels.length);
+  const result: (boolean | null)[] = new Array(n).fill(null);
+
+  for (let i = 0; i < n; i++) {
+    const price = prices[i];
+    const level = levels[i];
+    if (price === null || level === null || level === 0) {
+      result[i] = null;
+      continue;
+    }
+
+    const distance = Math.abs(price - level);
+    if (mode === "absolute") {
+      result[i] = distance <= threshold;
+    } else {
+      // percentage: threshold is % of the level price
+      result[i] = (distance / level) * 100 <= threshold;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Compute directional proximity: near level AND approaching from a specific side.
+ *
+ * @param side  "above" = price is above the level, "below" = price is below
+ * @returns Boolean series: true = near level from specified side
+ */
+export function calcDirectionalProximity(
+  prices: (number | null)[],
+  levels: (number | null)[],
+  threshold: number,
+  side: "above" | "below",
+  mode: ProximityMode = "percentage",
+): (boolean | null)[] {
+  const proximity = calcProximityFilter(prices, levels, threshold, mode);
+  const n = Math.min(prices.length, levels.length);
+  const result: (boolean | null)[] = new Array(n).fill(null);
+
+  for (let i = 0; i < n; i++) {
+    if (proximity[i] === null || prices[i] === null || levels[i] === null) {
+      result[i] = null;
+      continue;
+    }
+    if (!proximity[i]) {
+      result[i] = false;
+      continue;
+    }
+    // Price is near — check direction
+    result[i] = side === "above" ? prices[i]! >= levels[i]! : prices[i]! <= levels[i]!;
+  }
+
+  return result;
+}

--- a/apps/api/src/lib/indicators/volumeProfile.ts
+++ b/apps/api/src/lib/indicators/volumeProfile.ts
@@ -1,0 +1,147 @@
+/**
+ * Volume Profile Indicator (#135)
+ *
+ * Computes volume distribution across price levels to identify:
+ *   - POC (Point of Control): price level with highest volume
+ *   - VAH (Value Area High): upper bound of the value area (70% of volume)
+ *   - VAL (Value Area Low): lower bound of the value area
+ *
+ * Used by MTF Confluence Scalper to identify high-volume zones
+ * where price is likely to find support/resistance.
+ *
+ * Design:
+ *   - Pure function, deterministic
+ *   - Configurable lookback period and bin count
+ *   - Returns null arrays until enough data is available
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface VolumeProfileResult {
+  /** Point of Control — price with highest traded volume */
+  poc: (number | null)[];
+  /** Value Area High — upper bound of 70% volume zone */
+  vah: (number | null)[];
+  /** Value Area Low — lower bound of 70% volume zone */
+  val: (number | null)[];
+}
+
+export interface VolumeProfileCandle {
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+// ---------------------------------------------------------------------------
+// Computation
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute Volume Profile over a rolling window.
+ *
+ * For each bar, looks back `period` bars, distributes volume across
+ * `bins` evenly-spaced price levels between the lookback's low and high,
+ * then finds POC and value area.
+ *
+ * @param candles  OHLCV candle array
+ * @param period   Lookback window in bars (default: 20)
+ * @param bins     Number of price bins for volume distribution (default: 24)
+ * @param valueAreaPct  Volume percentage for value area (default: 0.70 = 70%)
+ */
+export function calcVolumeProfile(
+  candles: VolumeProfileCandle[],
+  period: number = 20,
+  bins: number = 24,
+  valueAreaPct: number = 0.70,
+): VolumeProfileResult {
+  const n = candles.length;
+  const poc: (number | null)[] = new Array(n).fill(null);
+  const vah: (number | null)[] = new Array(n).fill(null);
+  const val: (number | null)[] = new Array(n).fill(null);
+
+  if (n < period || bins < 2) return { poc, vah, val };
+
+  for (let i = period - 1; i < n; i++) {
+    // Find price range over lookback window
+    let rangeHigh = -Infinity;
+    let rangeLow = Infinity;
+    for (let j = i - period + 1; j <= i; j++) {
+      if (candles[j].high > rangeHigh) rangeHigh = candles[j].high;
+      if (candles[j].low < rangeLow) rangeLow = candles[j].low;
+    }
+
+    const rangeSpan = rangeHigh - rangeLow;
+    if (rangeSpan <= 0) {
+      // Flat market — POC = close, VAH = VAL = close
+      poc[i] = candles[i].close;
+      vah[i] = candles[i].close;
+      val[i] = candles[i].close;
+      continue;
+    }
+
+    // Distribute volume into bins
+    const binSize = rangeSpan / bins;
+    const volumeByBin = new Array<number>(bins).fill(0);
+
+    for (let j = i - period + 1; j <= i; j++) {
+      // Each candle's volume is distributed across the bins it covers
+      const cLow = candles[j].low;
+      const cHigh = candles[j].high;
+      const cVol = candles[j].volume;
+
+      const startBin = Math.max(0, Math.floor((cLow - rangeLow) / binSize));
+      const endBin = Math.min(bins - 1, Math.floor((cHigh - rangeLow) / binSize));
+      const coveredBins = endBin - startBin + 1;
+      const volPerBin = coveredBins > 0 ? cVol / coveredBins : 0;
+
+      for (let b = startBin; b <= endBin; b++) {
+        volumeByBin[b] += volPerBin;
+      }
+    }
+
+    // Find POC (bin with max volume)
+    let maxVol = 0;
+    let pocBin = 0;
+    for (let b = 0; b < bins; b++) {
+      if (volumeByBin[b] > maxVol) {
+        maxVol = volumeByBin[b];
+        pocBin = b;
+      }
+    }
+    poc[i] = rangeLow + (pocBin + 0.5) * binSize;
+
+    // Compute Value Area (70% of total volume, expanding from POC)
+    const totalVolume = volumeByBin.reduce((s, v) => s + v, 0);
+    const targetVolume = totalVolume * valueAreaPct;
+
+    let vaVolume = volumeByBin[pocBin];
+    let vaLow = pocBin;
+    let vaHigh = pocBin;
+
+    while (vaVolume < targetVolume && (vaLow > 0 || vaHigh < bins - 1)) {
+      const belowVol = vaLow > 0 ? volumeByBin[vaLow - 1] : 0;
+      const aboveVol = vaHigh < bins - 1 ? volumeByBin[vaHigh + 1] : 0;
+
+      if (belowVol >= aboveVol && vaLow > 0) {
+        vaLow--;
+        vaVolume += volumeByBin[vaLow];
+      } else if (vaHigh < bins - 1) {
+        vaHigh++;
+        vaVolume += volumeByBin[vaHigh];
+      } else if (vaLow > 0) {
+        vaLow--;
+        vaVolume += volumeByBin[vaLow];
+      } else {
+        break;
+      }
+    }
+
+    val[i] = rangeLow + vaLow * binSize;
+    vah[i] = rangeLow + (vaHigh + 1) * binSize;
+  }
+
+  return { poc, vah, val };
+}

--- a/apps/api/tests/indicators/proximityFilter.test.ts
+++ b/apps/api/tests/indicators/proximityFilter.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { calcProximityFilter, calcDirectionalProximity } from "../../src/lib/indicators/proximityFilter.js";
+
+describe("calcProximityFilter", () => {
+  it("returns true when price is within percentage threshold of level", () => {
+    const prices = [100, 101, 105, 110];
+    const levels = [100, 100, 100, 100];
+    // 2% threshold → within 2 of 100
+    const result = calcProximityFilter(prices, levels, 2, "percentage");
+    expect(result[0]).toBe(true);  // 0% away
+    expect(result[1]).toBe(true);  // 1% away
+    expect(result[2]).toBe(false); // 5% away
+    expect(result[3]).toBe(false); // 10% away
+  });
+
+  it("returns true when price is within absolute threshold", () => {
+    const prices = [100, 101, 105];
+    const levels = [100, 100, 100];
+    const result = calcProximityFilter(prices, levels, 2, "absolute");
+    expect(result[0]).toBe(true);  // 0 away
+    expect(result[1]).toBe(true);  // 1 away
+    expect(result[2]).toBe(false); // 5 away
+  });
+
+  it("handles null values in prices or levels", () => {
+    const prices = [100, null, 100];
+    const levels = [100, 100, null];
+    const result = calcProximityFilter(prices, levels, 2, "percentage");
+    expect(result[0]).toBe(true);
+    expect(result[1]).toBeNull();
+    expect(result[2]).toBeNull();
+  });
+
+  it("handles zero level (avoid division by zero)", () => {
+    const prices = [0];
+    const levels = [0];
+    const result = calcProximityFilter(prices, levels, 1, "percentage");
+    expect(result[0]).toBeNull();
+  });
+
+  it("works with mismatched array lengths", () => {
+    const prices = [100, 101, 102, 103];
+    const levels = [100, 100];
+    const result = calcProximityFilter(prices, levels, 2, "percentage");
+    expect(result).toHaveLength(2); // min of both
+  });
+
+  it("is deterministic", () => {
+    const prices = [100, 101, 105];
+    const levels = [100, 100, 100];
+    const a = calcProximityFilter(prices, levels, 2, "percentage");
+    const b = calcProximityFilter(prices, levels, 2, "percentage");
+    expect(a).toEqual(b);
+  });
+});
+
+describe("calcDirectionalProximity", () => {
+  it("filters for price above level", () => {
+    const prices = [101, 99, 100.5, 105];
+    const levels = [100, 100, 100, 100];
+    // 2% threshold, above
+    const result = calcDirectionalProximity(prices, levels, 2, "above", "percentage");
+    expect(result[0]).toBe(true);  // 101 >= 100 and within 2%
+    expect(result[1]).toBe(false); // 99 < 100 (below, not above)
+    expect(result[2]).toBe(true);  // 100.5 >= 100 and within 2%
+    expect(result[3]).toBe(false); // 105 > 100 but 5% away (not near)
+  });
+
+  it("filters for price below level", () => {
+    const prices = [99, 101, 99.5];
+    const levels = [100, 100, 100];
+    const result = calcDirectionalProximity(prices, levels, 2, "below", "percentage");
+    expect(result[0]).toBe(true);  // 99 <= 100 and within 2%
+    expect(result[1]).toBe(false); // 101 > 100 (above, not below)
+    expect(result[2]).toBe(true);  // 99.5 <= 100 and within 2%
+  });
+
+  it("returns null for null inputs", () => {
+    const result = calcDirectionalProximity([null], [100], 2, "above");
+    expect(result[0]).toBeNull();
+  });
+});

--- a/apps/api/tests/indicators/volumeProfile.test.ts
+++ b/apps/api/tests/indicators/volumeProfile.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { calcVolumeProfile, type VolumeProfileCandle } from "../../src/lib/indicators/volumeProfile.js";
+
+function makeCandles(n: number, basePrice = 100, spread = 2): VolumeProfileCandle[] {
+  return Array.from({ length: n }, (_, i) => ({
+    high: basePrice + spread / 2 + (i % 3) * 0.5,
+    low: basePrice - spread / 2 - (i % 3) * 0.5,
+    close: basePrice + (i % 2 === 0 ? 0.5 : -0.5),
+    volume: 1000 + i * 10,
+  }));
+}
+
+describe("calcVolumeProfile", () => {
+  it("returns null arrays for insufficient data", () => {
+    const candles = makeCandles(5);
+    const result = calcVolumeProfile(candles, 20);
+    expect(result.poc.every(v => v === null)).toBe(true);
+    expect(result.vah.every(v => v === null)).toBe(true);
+    expect(result.val.every(v => v === null)).toBe(true);
+  });
+
+  it("computes POC, VAH, VAL after warm-up period", () => {
+    const candles = makeCandles(30);
+    const result = calcVolumeProfile(candles, 20);
+
+    // First 19 bars are null (warm-up)
+    for (let i = 0; i < 19; i++) {
+      expect(result.poc[i]).toBeNull();
+    }
+    // Bar 19+ should have values
+    expect(result.poc[19]).not.toBeNull();
+    expect(result.vah[19]).not.toBeNull();
+    expect(result.val[19]).not.toBeNull();
+  });
+
+  it("POC is within the price range", () => {
+    const candles = makeCandles(30, 100, 4);
+    const result = calcVolumeProfile(candles, 20);
+
+    for (let i = 19; i < 30; i++) {
+      expect(result.poc[i]).toBeGreaterThanOrEqual(96);
+      expect(result.poc[i]).toBeLessThanOrEqual(104);
+    }
+  });
+
+  it("VAL <= POC <= VAH", () => {
+    const candles = makeCandles(30, 100, 4);
+    const result = calcVolumeProfile(candles, 20);
+
+    for (let i = 19; i < 30; i++) {
+      expect(result.val[i]!).toBeLessThanOrEqual(result.poc[i]!);
+      expect(result.poc[i]!).toBeLessThanOrEqual(result.vah[i]!);
+    }
+  });
+
+  it("VAH >= VAL (value area has positive width)", () => {
+    const candles = makeCandles(30, 100, 4);
+    const result = calcVolumeProfile(candles, 20);
+
+    for (let i = 19; i < 30; i++) {
+      expect(result.vah[i]!).toBeGreaterThanOrEqual(result.val[i]!);
+    }
+  });
+
+  it("handles flat market (all same price)", () => {
+    const candles: VolumeProfileCandle[] = Array.from({ length: 25 }, () => ({
+      high: 100, low: 100, close: 100, volume: 1000,
+    }));
+    const result = calcVolumeProfile(candles, 20);
+    // Flat → POC = VAH = VAL = close
+    expect(result.poc[19]).toBe(100);
+    expect(result.vah[19]).toBe(100);
+    expect(result.val[19]).toBe(100);
+  });
+
+  it("is deterministic", () => {
+    const candles = makeCandles(30);
+    const a = calcVolumeProfile(candles, 20);
+    const b = calcVolumeProfile(candles, 20);
+    expect(a.poc).toEqual(b.poc);
+    expect(a.vah).toEqual(b.vah);
+    expect(a.val).toEqual(b.val);
+  });
+
+  it("higher volume at specific price pushes POC there", () => {
+    // Create candles where most volume is at high prices
+    const candles: VolumeProfileCandle[] = Array.from({ length: 25 }, (_, i) => ({
+      high: i < 20 ? 105 : 110,
+      low: i < 20 ? 100 : 108,
+      close: i < 20 ? 102 : 109,
+      volume: i < 20 ? 100 : 10000, // huge volume at high prices for last 5 bars
+    }));
+    const result = calcVolumeProfile(candles, 25, 24);
+    // POC should be pulled toward the high-volume zone
+    expect(result.poc[24]).not.toBeNull();
+    expect(result.poc[24]!).toBeGreaterThan(105);
+  });
+});


### PR DESCRIPTION
## Summary

Pure indicator primitives for confluence-based strategies (#135).

### VolumeProfile (`indicators/volumeProfile.ts`)
- Rolling volume distribution across price bins
- POC (Point of Control): highest-volume price level
- VAH/VAL (Value Area High/Low): 70% volume zone bounds
- Configurable period, bins, value area percentage
- Handles flat markets gracefully

### ProximityFilter (`indicators/proximityFilter.ts`)
- Signal gating: is price "near" a reference level?
- Absolute (fixed distance) and percentage modes
- Directional variant: near + approaching from above/below
- Null-safe, length-mismatch safe

### Files

| File | Lines | Description |
|------|-------|-------------|
| `indicators/volumeProfile.ts` | 147 | VolumeProfile computation |
| `indicators/proximityFilter.ts` | 96 | ProximityFilter computation |
| `tests/indicators/volumeProfile.test.ts` | 97 | 8 tests |
| `tests/indicators/proximityFilter.test.ts` | 82 | 9 tests |

### What remains for #135
- Register both in compiler block registry + blockDefs.ts
- Wire into dslEvaluator indicator cache

773 tests pass, 0 regressions.

https://claude.ai/code/session_01Q1KeciEtrAt7SSwixRffNt