### PR TITLE
fix(api): document mtfContext TODO in evaluator (#134)

### DIFF
--- a/apps/api/src/lib/dslEvaluator.ts
+++ b/apps/api/src/lib/dslEvaluator.ts
@@ -630,6 +630,12 @@ export function runDslBacktest(
 ): DslBacktestReport {
   const { feeBps = 0, slippageBps = 0 } = opts;
 
+  // TODO(#134-slice4): use mtfContext with resolveMtfIndicator from
+  // mtf/mtfIndicatorResolver.ts for DslIndicatorRef entries that have
+  // sourceTimeframe set. Currently mtfContext is threaded through the
+  // signature but indicator resolution still uses single-TF getIndicatorValues.
+  void mtfContext; // suppress unused-param lint until wired
+
   const emptyReport: DslBacktestReport = {
     trades: 0, wins: 0, winrate: 0, totalPnlPct: 0, maxDrawdownPct: 0,
     candles: candles.length, tradeLog: [],


### PR DESCRIPTION
Documents the review finding from PR #175: `mtfContext` is parameter-threaded but not yet wired into indicator resolution. Adds explicit `TODO(#134-slice4)` + `void mtfContext` to suppress lint.

788 tests pass.

https://claude.ai/code/session_01Q1KeciEtrAt7SSwixRffNt