### PR TITLE
feat(api): wire MTF resolver into evaluator sideCondition + indicatorExit (#134 slice 4)

### DIFF
--- a/apps/api/src/lib/dslEvaluator.ts
+++ b/apps/api/src/lib/dslEvaluator.ts
@@ -906,7 +906,9 @@ export function runDslBacktest(
     } else {
       // --- Entry evaluation ---
 
-      // Determine side (MTF-aware: uses resolveIndicator for sideCondition)
+      // Determine side (MTF-aware: uses resolveIndicator for sideCondition).
+      // Note: this inlines the logic from determineSide() to use resolveIndicator.
+      // Keep in sync with determineSide() if sideCondition evaluation changes.
       let side: TradeSide | null = null;
       if (entry.side) {
         side = entry.side === "Buy" ? "long" : "short";


### PR DESCRIPTION
## Summary

Fourth slice of #134 — wires the MTF resolver into the backtest evaluator's indicator resolution paths. This makes `sourceTimeframe` on indicator refs **functionally active**.

### What changed

Two `DslIndicatorRef`-based indicator resolution paths now use `resolveIndicator()` (MTF-aware helper):

1. **sideCondition indicator** (entry side determination) — when `sourceTimeframe` is set, resolves from context-TF candles
2. **indicatorExit** (exit condition) — same MTF resolution

Signal-level indicators (SMA crossover, compare, etc.) remain on primary TF — correct, since signals fire on the primary timeframe.

### How it works

```
resolveIndicator(ref, candles, cache):
  if (mtfCache && mtfContext):
    → resolveMtfIndicator(ref, candles, mtfCache, bundle)  // MTF path
  else:
    → getIndicatorValues(ref.type, params, candles, cache)  // single-TF path
```

### Files changed

| File | Change |
|------|--------|
| `dslEvaluator.ts` | +39/-18 — import resolver, add helper, replace 2 call sites |

### 788 tests pass, 0 regressions

Existing single-TF tests produce identical results — confirming MTF wiring doesn't affect non-MTF behavior.

https://claude.ai/code/session_01Q1KeciEtrAt7SSwixRffNt