### PR TITLE
fix(api): exclude tests from tsconfig for production build

### DIFF
--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -4,5 +4,5 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src", "tests"]
+  "include": ["src"]
 }


### PR DESCRIPTION
Removes `tests` from `tsconfig.json` include array. Fixes recurring VPS deploy failure where `tsc` tries to compile test files that import `vitest`.

Vitest handles test compilation independently — 944 tests still pass.

https://claude.ai/code/session_01T4a4NeCbCbuV5EUz69kE6U