### PR TITLE
Phase 10.2: Implement and_gate + or_gate in evaluator

### DIFF
--- a/apps/api/src/lib/compiler/supportMap.ts
+++ b/apps/api/src/lib/compiler/supportMap.ts
@@ -49,8 +49,8 @@ export const BLOCK_SUPPORT_MAP: Record<string, BlockSupportEntry> = {
   // ── Logic ───────────────────────────────────────────────────────────────────
   compare:      { status: "supported",    note: "Fully supported since Phase 4" },
   cross:        { status: "supported",    note: "Fully supported since Phase 3" },
-  and_gate:     { status: "compile-only", note: "Compiler handler added in #122; runtime pending (#124)" },
-  or_gate:      { status: "compile-only", note: "Compiler handler added in #122; runtime pending (#124)" },
+  and_gate:     { status: "supported",    note: "Recursive evaluateSignal with conditions.every(), maxDepth=5" },
+  or_gate:      { status: "supported",    note: "Recursive evaluateSignal with conditions.some(), maxDepth=5" },
 
   // ── Execution ───────────────────────────────────────────────────────────────
   enter_long:     { status: "supported",    note: "Fully supported since Phase 3" },

--- a/apps/api/src/lib/dslEvaluator.ts
+++ b/apps/api/src/lib/dslEvaluator.ts
@@ -103,12 +103,14 @@ export interface DslSignalRef {
 }
 
 export interface DslSignal {
-  type: string; // "crossover" | "crossunder" | "compare" | "direct" | "raw"
+  type: string; // "crossover" | "crossunder" | "compare" | "and" | "or" | "direct" | "raw"
   op?: string;
   fast?: DslSignalRef | null;
   slow?: DslSignalRef | null;
   left?: DslSignalRef | null;
   right?: DslSignalRef | null;
+  /** Sub-conditions for composed signals (type "and" / "or") */
+  conditions?: DslSignal[];
 }
 
 export interface DslExitLevel {
@@ -506,13 +508,27 @@ export function parseDsl(dslJson: unknown): ParsedDsl {
 // Entry signal evaluation
 // ---------------------------------------------------------------------------
 
+const MAX_SIGNAL_DEPTH = 5;
+
 export function evaluateSignal(
   signal: DslSignal | undefined,
   i: number,
   candles: Candle[],
   cache: IndicatorCache,
+  _depth = 0,
 ): boolean {
   if (!signal) return false;
+  if (_depth >= MAX_SIGNAL_DEPTH) return false;
+
+  // Composed conditions: and / or
+  if (signal.type === "and") {
+    if (!signal.conditions || signal.conditions.length === 0) return false;
+    return signal.conditions.every((sub) => evaluateSignal(sub, i, candles, cache, _depth + 1));
+  }
+  if (signal.type === "or") {
+    if (!signal.conditions || signal.conditions.length === 0) return false;
+    return signal.conditions.some((sub) => evaluateSignal(sub, i, candles, cache, _depth + 1));
+  }
 
   if (signal.type === "crossover" || signal.type === "crossunder") {
     // Cross signal: fast crosses over/under slow

--- a/apps/api/tests/compiler/blockDrift.test.ts
+++ b/apps/api/tests/compiler/blockDrift.test.ts
@@ -136,6 +136,7 @@ describe("Support status snapshot", () => {
       "RSI",
       "SMA",
       "adx",
+      "and_gate",
       "atr",
       "bollinger",
       "candles",
@@ -149,6 +150,7 @@ describe("Support status snapshot", () => {
       "fair_value_gap",
       "liquidity_sweep",
       "market_structure_shift",
+      "or_gate",
       "order_block",
       "stop_loss",
       "supertrend",
@@ -164,9 +166,7 @@ describe("Support status snapshot", () => {
       .sort();
 
     expect(compileOnly).toEqual([
-      "and_gate",
       "macd",
-      "or_gate",
       "proximity_filter",
       "volume",
       "volume_profile",

--- a/apps/api/tests/lib/dslEvaluator.test.ts
+++ b/apps/api/tests/lib/dslEvaluator.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { runDslBacktest, parseDsl } from "../../src/lib/dslEvaluator.js";
+import { runDslBacktest, parseDsl, evaluateSignal } from "../../src/lib/dslEvaluator.js";
+import type { DslSignal } from "../../src/lib/dslEvaluator.js";
 import { makeUptrend, makeDowntrend, makeFlat, makeFlatThenUp, makeFlatThenDown } from "../fixtures/candles.js";
 
 // ---------------------------------------------------------------------------
@@ -504,5 +505,86 @@ describe("dslEvaluator – golden backtest (regression fixture)", () => {
     // Save and re-run to verify determinism
     const report2 = runDslBacktest(candles, dsl);
     expect(report).toEqual(report2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Composed signals: and_gate / or_gate (Phase 10.2)
+// ---------------------------------------------------------------------------
+
+describe("evaluateSignal – composed and/or gates", () => {
+  // Helpers: minimal candles + cache for unit-level signal tests
+  const candles = makeUptrend(30, 100, 1);
+  const cache = {} as Parameters<typeof evaluateSignal>[3];
+
+  const compareTrue: DslSignal = {
+    type: "compare",
+    op: ">",
+    left: { blockType: "constant", value: 10 } as unknown as DslSignal["left"],
+    right: { blockType: "constant", value: 5 } as unknown as DslSignal["right"],
+  };
+
+  const compareFalse: DslSignal = {
+    type: "compare",
+    op: ">",
+    left: { blockType: "constant", value: 3 } as unknown as DslSignal["left"],
+    right: { blockType: "constant", value: 5 } as unknown as DslSignal["right"],
+  };
+
+  it("and(true, true) → true", () => {
+    const signal: DslSignal = { type: "and", conditions: [compareTrue, compareTrue] };
+    expect(evaluateSignal(signal, 10, candles, cache)).toBe(true);
+  });
+
+  it("and(true, false) → false", () => {
+    const signal: DslSignal = { type: "and", conditions: [compareTrue, compareFalse] };
+    expect(evaluateSignal(signal, 10, candles, cache)).toBe(false);
+  });
+
+  it("and(false, false) → false", () => {
+    const signal: DslSignal = { type: "and", conditions: [compareFalse, compareFalse] };
+    expect(evaluateSignal(signal, 10, candles, cache)).toBe(false);
+  });
+
+  it("or(false, true) → true", () => {
+    const signal: DslSignal = { type: "or", conditions: [compareFalse, compareTrue] };
+    expect(evaluateSignal(signal, 10, candles, cache)).toBe(true);
+  });
+
+  it("or(false, false) → false", () => {
+    const signal: DslSignal = { type: "or", conditions: [compareFalse, compareFalse] };
+    expect(evaluateSignal(signal, 10, candles, cache)).toBe(false);
+  });
+
+  it("nested: and(or(false, true), true) → true", () => {
+    const orSignal: DslSignal = { type: "or", conditions: [compareFalse, compareTrue] };
+    const signal: DslSignal = { type: "and", conditions: [orSignal, compareTrue] };
+    expect(evaluateSignal(signal, 10, candles, cache)).toBe(true);
+  });
+
+  it("nested: or(and(true, false), and(true, true)) → true", () => {
+    const andFalse: DslSignal = { type: "and", conditions: [compareTrue, compareFalse] };
+    const andTrue: DslSignal = { type: "and", conditions: [compareTrue, compareTrue] };
+    const signal: DslSignal = { type: "or", conditions: [andFalse, andTrue] };
+    expect(evaluateSignal(signal, 10, candles, cache)).toBe(true);
+  });
+
+  it("maxDepth exceeded → false", () => {
+    // Build 6-level deep nesting (exceeds MAX_SIGNAL_DEPTH=5)
+    let deep: DslSignal = compareTrue;
+    for (let d = 0; d < 6; d++) {
+      deep = { type: "and", conditions: [deep] };
+    }
+    expect(evaluateSignal(deep, 10, candles, cache)).toBe(false);
+  });
+
+  it("empty conditions → false", () => {
+    expect(evaluateSignal({ type: "and", conditions: [] }, 10, candles, cache)).toBe(false);
+    expect(evaluateSignal({ type: "or", conditions: [] }, 10, candles, cache)).toBe(false);
+  });
+
+  it("undefined conditions → false", () => {
+    expect(evaluateSignal({ type: "and" }, 10, candles, cache)).toBe(false);
+    expect(evaluateSignal({ type: "or" }, 10, candles, cache)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Add recursive composed signal evaluation in `dslEvaluator.ts`
  - `type: "and"` → `conditions.every(sub => evaluateSignal(sub))`
  - `type: "or"` → `conditions.some(sub => evaluateSignal(sub))`
  - `maxDepth=5` guard against infinite recursion
- Extend `DslSignal` interface with `conditions?: DslSignal[]`
- Promote `and_gate`, `or_gate` from compile-only to **supported** in `supportMap.ts`
- Supported: 24 (+2) | Compile-only: 4 (-2)

## Test plan
- [x] `npx vitest run` — 955 pass (+10 new), 0 regressions
- [x] and(true, true) → true
- [x] and(true, false) → false
- [x] or(false, true) → true
- [x] or(false, false) → false
- [x] nested: and(or(false, true), true) → true
- [x] nested: or(and(true, false), and(true, true)) → true
- [x] maxDepth exceeded (6 levels) → false
- [x] empty/undefined conditions → false
- [x] blockDrift snapshot updated

https://claude.ai/code/session_01JfG8nhTbNLRLRJK7CWPmqT