### PR TITLE
Phase 12.2 + 12.1: Unknown indicator warning + direct sideCondition

### DIFF
--- a/apps/api/src/lib/dslEvaluator.ts
+++ b/apps/api/src/lib/dslEvaluator.ts
@@ -30,6 +30,7 @@ import { calcMACD } from "./indicators/macd.js";
 import type { MACDResult } from "./indicators/macd.js";
 import { resolveMtfIndicator, createMtfCache } from "./mtf/mtfIndicatorResolver.js";
 import { fvgSeries, sweepSeries, orderBlockSeries, mssSeries } from "./runtime/patternEngine.js";
+import { logger } from "./logger.js";
 import type { DcaConfig, SafetyOrderLevel, DcaPositionState } from "./dcaPlanning.js";
 import {
   generateSafetyOrderSchedule,
@@ -142,6 +143,7 @@ export interface DslTimeExit {
 export interface DslSideCondition {
   indicator: DslIndicatorRef;
   source?: string;
+  mode?: "price_vs_indicator" | "indicator_sign";
   long: { op: string };
   short: { op: string };
 }
@@ -478,6 +480,7 @@ export function getIndicatorValues(
   }
 
   // Unknown indicator — return all nulls
+  logger.warn({ blockType: type }, "Unknown indicator type — returning nulls");
   return new Array(candles.length).fill(null);
 }
 
@@ -629,7 +632,14 @@ export function determineSide(
     const val = indValues[i];
     if (val === null) return null;
 
-    // For sideCondition, the source defaults to "close"
+    // Discrete signal mode: sign of indicator value determines side
+    if (sc.mode === "indicator_sign") {
+      if (val > 0) return "long";
+      if (val < 0) return "short";
+      return null;
+    }
+
+    // Default mode (price_vs_indicator): compare price to indicator value
     const source = sc.source ?? "close";
     const price = candles[i][source as keyof Candle] as number;
 

--- a/apps/api/tests/lib/dslEvaluator.test.ts
+++ b/apps/api/tests/lib/dslEvaluator.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { runDslBacktest, parseDsl, evaluateSignal } from "../../src/lib/dslEvaluator.js";
-import type { DslSignal } from "../../src/lib/dslEvaluator.js";
+import { runDslBacktest, parseDsl, evaluateSignal, getIndicatorValues, createIndicatorCache, determineSide } from "../../src/lib/dslEvaluator.js";
+import type { DslSignal, DslEntry } from "../../src/lib/dslEvaluator.js";
 import { makeUptrend, makeDowntrend, makeFlat, makeFlatThenUp, makeFlatThenDown } from "../fixtures/candles.js";
 
 // ---------------------------------------------------------------------------
@@ -586,5 +586,66 @@ describe("evaluateSignal – composed and/or gates", () => {
   it("undefined conditions → false", () => {
     expect(evaluateSignal({ type: "and" }, 10, candles, cache)).toBe(false);
     expect(evaluateSignal({ type: "or" }, 10, candles, cache)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 12.2 — Unknown indicator type returns nulls
+// ---------------------------------------------------------------------------
+
+describe("dslEvaluator – unknown indicator type", () => {
+  it("returns array of nulls with correct length for unknown indicator type", () => {
+    const candles = makeFlat(30, 100);
+    const cache = createIndicatorCache();
+    const result = getIndicatorValues("nonexistent_typo", {}, candles, cache);
+
+    expect(result.length).toBe(candles.length);
+    expect(result.every(v => v === null)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 12.1 — determineSide with indicator_sign mode
+// ---------------------------------------------------------------------------
+
+describe("dslEvaluator – sideCondition indicator_sign mode", () => {
+  const candles = makeFlat(30, 100);
+  const cache = createIndicatorCache();
+
+  // Pre-fill cache with known constant values for testing
+  function makeEntry(mode: string | undefined, constantVal: number): DslEntry {
+    return {
+      sideCondition: {
+        indicator: { type: "constant", length: constantVal } as any,
+        long: { op: "gt" },
+        short: { op: "lt" },
+        ...(mode ? { mode: mode as any } : {}),
+      },
+    };
+  }
+
+  it("mode=indicator_sign, positive value → long", () => {
+    const entry = makeEntry("indicator_sign", 1);
+    const side = determineSide(entry, 15, candles, cache);
+    expect(side).toBe("long");
+  });
+
+  it("mode=indicator_sign, negative value → short", () => {
+    const entry = makeEntry("indicator_sign", -1);
+    const side = determineSide(entry, 15, candles, cache);
+    expect(side).toBe("short");
+  });
+
+  it("mode=indicator_sign, zero value → null", () => {
+    const entry = makeEntry("indicator_sign", 0);
+    const side = determineSide(entry, 15, candles, cache);
+    expect(side).toBeNull();
+  });
+
+  it("mode=undefined → current behavior (price_vs_indicator)", () => {
+    // constant=50, close=100, so close > 50 → long (op "gt")
+    const entry = makeEntry(undefined, 50);
+    const side = determineSide(entry, 15, candles, cache);
+    expect(side).toBe("long");
   });
 });


### PR DESCRIPTION
## Summary

- **Phase 12.2**: Added `logger.warn` in `getIndicatorValues()` for unknown indicator types before returning nulls array. Added test verifying `getIndicatorValues("nonexistent_typo", ...)` returns all nulls with correct length.
- **Phase 12.1**: Extended `DslSideCondition` interface with `mode?: "price_vs_indicator" | "indicator_sign"`. In `indicator_sign` mode, `determineSide()` uses indicator value sign directly: `>0 → long`, `<0 → short`, `0 → null`. Default (undefined) preserves existing `price_vs_indicator` behavior for backward compatibility.

## Changes

| File | Change |
|------|--------|
| `apps/api/src/lib/dslEvaluator.ts` | Import logger, add warn on unknown type, add `mode` to `DslSideCondition`, add `indicator_sign` branch in `determineSide()` |
| `apps/api/tests/lib/dslEvaluator.test.ts` | 5 new tests: unknown indicator nulls, indicator_sign +1→long, -1→short, 0→null, undefined→backward compat |

## Test plan

- [x] `npx vitest run` — 973 pass (baseline 968), 1 pre-existing Prisma fail
- [ ] Verify logger output visible in API logs for unknown indicator types
- [ ] Verify `indicator_sign` mode works with MACD histogram signal in live strategy

https://claude.ai/code/session_01MnxTfRCtKybYk2dGRitN2o