### PR TITLE
Phase 11.1: Funding ingestion scheduler

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -22,11 +22,13 @@
     "ajv-formats": "^3.0.1",
     "bcryptjs": "^3.0.3",
     "fastify": "^5.3.0",
+    "node-cron": "^4.2.1",
     "pino": "^9.6.0"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",
     "@types/node": "^22.0.0",
+    "@types/node-cron": "^3.0.11",
     "pino-pretty": "^13.1.3",
     "prisma": "^6.5.0",
     "tsx": "^4.19.0",

--- a/apps/api/src/lib/funding/fetcher.ts
+++ b/apps/api/src/lib/funding/fetcher.ts
@@ -1,0 +1,69 @@
+/**
+ * HTTP fetch layer for Bybit funding/ticker data.
+ *
+ * Uses native fetch (Node 18+). Each function retries once on failure.
+ */
+
+import type { BybitFundingHistoryItem, BybitLinearTicker, BybitSpotTicker } from "./ingestion.js";
+import { logger } from "../logger.js";
+
+const BYBIT_BASE = "https://api.bybit.com";
+
+// ── Generic helper ────────────────────────────────────────────────────────────
+
+async function fetchWithRetry<T>(url: string, label: string): Promise<T> {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const res = await fetch(url);
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status} ${res.statusText}`);
+      }
+      const json = (await res.json()) as { retCode: number; retMsg: string; result: T };
+      if (json.retCode !== 0) {
+        throw new Error(`Bybit API error: ${json.retMsg} (code ${json.retCode})`);
+      }
+      return json.result;
+    } catch (err) {
+      if (attempt === 0) {
+        logger.warn({ err, url, label }, "Fetch failed, retrying once");
+        continue;
+      }
+      throw err;
+    }
+  }
+  // Unreachable, but satisfies TS
+  throw new Error("fetchWithRetry: exhausted retries");
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Fetch funding rate history for a symbol.
+ * Returns up to `limit` most recent items (default 200).
+ */
+export async function fetchFundingHistory(
+  symbol: string,
+  limit = 200,
+): Promise<BybitFundingHistoryItem[]> {
+  const url = `${BYBIT_BASE}/v5/market/funding/history?category=linear&symbol=${encodeURIComponent(symbol)}&limit=${limit}`;
+  const result = await fetchWithRetry<{ list: BybitFundingHistoryItem[] }>(url, "fundingHistory");
+  return result.list;
+}
+
+/**
+ * Fetch all linear (perpetual) tickers.
+ */
+export async function fetchLinearTickers(): Promise<BybitLinearTicker[]> {
+  const url = `${BYBIT_BASE}/v5/market/tickers?category=linear`;
+  const result = await fetchWithRetry<{ list: BybitLinearTicker[] }>(url, "linearTickers");
+  return result.list;
+}
+
+/**
+ * Fetch all spot tickers.
+ */
+export async function fetchSpotTickers(): Promise<BybitSpotTicker[]> {
+  const url = `${BYBIT_BASE}/v5/market/tickers?category=spot`;
+  const result = await fetchWithRetry<{ list: BybitSpotTicker[] }>(url, "spotTickers");
+  return result.list;
+}

--- a/apps/api/src/lib/funding/index.ts
+++ b/apps/api/src/lib/funding/index.ts
@@ -49,3 +49,13 @@ export type {
   FundingCandidate,
   ScannerThresholds,
 } from "./types.js";
+export {
+  fetchFundingHistory,
+  fetchLinearTickers,
+  fetchSpotTickers,
+} from "./fetcher.js";
+export {
+  ingestFundingRates,
+  ingestSpreads,
+  runIngestion,
+} from "./ingestJob.js";

--- a/apps/api/src/lib/funding/ingestJob.ts
+++ b/apps/api/src/lib/funding/ingestJob.ts
@@ -1,0 +1,126 @@
+/**
+ * Funding ingestion job — fetches live data from Bybit and persists
+ * FundingSnapshot + SpreadSnapshot records to the database.
+ *
+ * Designed to be called from a cron scheduler (every 8 hours).
+ */
+
+import type { PrismaClient } from "@prisma/client";
+import { fetchFundingHistory, fetchLinearTickers, fetchSpotTickers } from "./fetcher.js";
+import { parseFundingHistory, parseLinearTicker, buildSpreadFromTickers } from "./ingestion.js";
+import { logger } from "../logger.js";
+
+/** Default symbols to ingest funding history for. */
+const DEFAULT_SYMBOLS = ["BTCUSDT", "ETHUSDT", "SOLUSDT", "XRPUSDT", "DOGEUSDT"];
+
+/**
+ * Ingest historical funding rates for a list of symbols.
+ * Fetches from Bybit, parses, and bulk-inserts into FundingSnapshot.
+ */
+export async function ingestFundingRates(
+  prisma: PrismaClient,
+  symbols: string[] = DEFAULT_SYMBOLS,
+): Promise<number> {
+  let totalInserted = 0;
+
+  for (const symbol of symbols) {
+    try {
+      const rawItems = await fetchFundingHistory(symbol);
+      const snapshots = parseFundingHistory(rawItems);
+
+      if (snapshots.length === 0) continue;
+
+      const result = await prisma.fundingSnapshot.createMany({
+        data: snapshots.map((s) => ({
+          symbol: s.symbol,
+          fundingRate: s.fundingRate,
+          nextFundingAt: new Date(s.nextFundingAt),
+          timestamp: new Date(s.timestamp),
+        })),
+        skipDuplicates: true,
+      });
+
+      totalInserted += result.count;
+      logger.info({ symbol, inserted: result.count }, "Funding rates ingested");
+    } catch (err) {
+      logger.error({ err, symbol }, "Failed to ingest funding rates");
+    }
+  }
+
+  return totalInserted;
+}
+
+/**
+ * Ingest current spread snapshots by matching linear and spot tickers.
+ * Fetches all linear + spot tickers, matches by symbol, and bulk-inserts SpreadSnapshots.
+ */
+export async function ingestSpreads(prisma: PrismaClient): Promise<number> {
+  const now = Date.now();
+
+  const [linearTickers, spotTickers] = await Promise.all([
+    fetchLinearTickers(),
+    fetchSpotTickers(),
+  ]);
+
+  // Build a spot lookup: "BTCUSDT" → BybitSpotTicker
+  const spotMap = new Map(spotTickers.map((t) => [t.symbol, t]));
+
+  const spreads: Array<{
+    symbol: string;
+    spotPrice: number;
+    perpPrice: number;
+    basisBps: number;
+    timestamp: Date;
+  }> = [];
+
+  for (const perpTicker of linearTickers) {
+    // Bybit perp symbols end with "USDT", spot symbols are the same
+    const spotTicker = spotMap.get(perpTicker.symbol);
+    if (!spotTicker) continue;
+
+    const spread = buildSpreadFromTickers(perpTicker, spotTicker, now);
+    if (!spread) continue;
+
+    spreads.push({
+      symbol: spread.symbol,
+      spotPrice: spread.spotPrice,
+      perpPrice: spread.perpPrice,
+      basisBps: spread.basisBps,
+      timestamp: new Date(spread.timestamp),
+    });
+  }
+
+  if (spreads.length === 0) return 0;
+
+  const result = await prisma.spreadSnapshot.createMany({
+    data: spreads,
+    skipDuplicates: true,
+  });
+
+  logger.info({ inserted: result.count, total: spreads.length }, "Spread snapshots ingested");
+  return result.count;
+}
+
+/**
+ * Run the full ingestion pipeline: funding rates + spreads.
+ * Call this from the cron scheduler.
+ */
+export async function runIngestion(prisma: PrismaClient): Promise<void> {
+  const start = Date.now();
+  logger.info("Starting funding ingestion job");
+
+  try {
+    const [fundingCount, spreadCount] = await Promise.all([
+      ingestFundingRates(prisma),
+      ingestSpreads(prisma),
+    ]);
+
+    const durationMs = Date.now() - start;
+    logger.info(
+      { fundingCount, spreadCount, durationMs },
+      "Funding ingestion job completed",
+    );
+  } catch (err) {
+    logger.error({ err }, "Funding ingestion job failed");
+  }
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,5 +1,9 @@
 import { buildApp } from "./app.js";
 import { startBotWorker } from "./lib/botWorker.js";
+import cron from "node-cron";
+import { runIngestion } from "./lib/funding/ingestJob.js";
+import { PrismaClient } from "@prisma/client";
+import { logger } from "./lib/logger.js";
 
 const PORT = parseInt(process.env.API_PORT || "4000", 10);
 const HOST = process.env.API_HOST || "0.0.0.0";
@@ -14,10 +18,19 @@ async function main() {
     // Start bot worker background loop
     const stopWorker = startBotWorker();
 
+    // Funding ingestion cron — every 8 hours (matches Bybit settlement schedule)
+    const prisma = new PrismaClient();
+    const fundingCron = cron.schedule("0 */8 * * *", () => {
+      logger.info("Funding cron triggered");
+      runIngestion(prisma);
+    });
+
     // Graceful shutdown
     for (const signal of ["SIGINT", "SIGTERM"]) {
       process.once(signal, async () => {
+        fundingCron.stop();
         stopWorker();
+        await prisma.$disconnect();
         await app.close();
         process.exit(0);
       });

--- a/apps/api/tests/funding/fetcher.test.ts
+++ b/apps/api/tests/funding/fetcher.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fetchFundingHistory, fetchLinearTickers, fetchSpotTickers } from "../../src/lib/funding/fetcher.js";
+
+// ── Mock global fetch ─────────────────────────────────────────────────────────
+
+function mockFetchOk(result: unknown) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ retCode: 0, retMsg: "OK", result }),
+  });
+}
+
+function mockFetchFail() {
+  return vi.fn().mockRejectedValue(new Error("network error"));
+}
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", mockFetchOk({ list: [] }));
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ── fetchFundingHistory ───────────────────────────────────────────────────────
+
+describe("fetchFundingHistory", () => {
+  it("returns parsed list from Bybit response", async () => {
+    const items = [
+      { symbol: "BTCUSDT", fundingRate: "0.0001", fundingRateTimestamp: "1700000000000" },
+    ];
+    vi.stubGlobal("fetch", mockFetchOk({ list: items }));
+
+    const result = await fetchFundingHistory("BTCUSDT");
+    expect(result).toEqual(items);
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+
+  it("retries once on network failure then throws", async () => {
+    vi.stubGlobal("fetch", mockFetchFail());
+
+    await expect(fetchFundingHistory("BTCUSDT")).rejects.toThrow("network error");
+    expect(fetch).toHaveBeenCalledTimes(2); // original + 1 retry
+  });
+
+  it("throws on non-zero retCode", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ retCode: 10001, retMsg: "Invalid symbol", result: null }),
+    }));
+
+    await expect(fetchFundingHistory("BAD")).rejects.toThrow("Bybit API error");
+  });
+});
+
+// ── fetchLinearTickers ────────────────────────────────────────────────────────
+
+describe("fetchLinearTickers", () => {
+  it("returns linear ticker list", async () => {
+    const tickers = [
+      { symbol: "BTCUSDT", fundingRate: "0.0001", nextFundingTime: "1700000000000", lastPrice: "42000" },
+    ];
+    vi.stubGlobal("fetch", mockFetchOk({ list: tickers }));
+
+    const result = await fetchLinearTickers();
+    expect(result).toEqual(tickers);
+  });
+});
+
+// ── fetchSpotTickers ──────────────────────────────────────────────────────────
+
+describe("fetchSpotTickers", () => {
+  it("returns spot ticker list", async () => {
+    const tickers = [{ symbol: "BTCUSDT", lastPrice: "41950" }];
+    vi.stubGlobal("fetch", mockFetchOk({ list: tickers }));
+
+    const result = await fetchSpotTickers();
+    expect(result).toEqual(tickers);
+  });
+});

--- a/apps/api/tests/funding/ingestJob.test.ts
+++ b/apps/api/tests/funding/ingestJob.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ingestFundingRates, ingestSpreads } from "../../src/lib/funding/ingestJob.js";
+
+// ── Mock fetcher module ───────────────────────────────────────────────────────
+
+vi.mock("../../src/lib/funding/fetcher.js", () => ({
+  fetchFundingHistory: vi.fn(),
+  fetchLinearTickers: vi.fn(),
+  fetchSpotTickers: vi.fn(),
+}));
+
+import { fetchFundingHistory, fetchLinearTickers, fetchSpotTickers } from "../../src/lib/funding/fetcher.js";
+
+const mockFetchFundingHistory = vi.mocked(fetchFundingHistory);
+const mockFetchLinearTickers = vi.mocked(fetchLinearTickers);
+const mockFetchSpotTickers = vi.mocked(fetchSpotTickers);
+
+// ── Mock Prisma client ────────────────────────────────────────────────────────
+
+function makeMockPrisma() {
+  return {
+    fundingSnapshot: {
+      createMany: vi.fn().mockResolvedValue({ count: 0 }),
+    },
+    spreadSnapshot: {
+      createMany: vi.fn().mockResolvedValue({ count: 0 }),
+    },
+  } as any;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ── ingestFundingRates ────────────────────────────────────────────────────────
+
+describe("ingestFundingRates", () => {
+  it("fetches, parses, and inserts funding snapshots", async () => {
+    const rawItems = [
+      { symbol: "BTCUSDT", fundingRate: "0.0001", fundingRateTimestamp: "1700000000000" },
+      { symbol: "BTCUSDT", fundingRate: "0.0002", fundingRateTimestamp: "1700028800000" },
+    ];
+    mockFetchFundingHistory.mockResolvedValue(rawItems);
+
+    const prisma = makeMockPrisma();
+    prisma.fundingSnapshot.createMany.mockResolvedValue({ count: 2 });
+
+    const count = await ingestFundingRates(prisma, ["BTCUSDT"]);
+
+    expect(count).toBe(2);
+    expect(mockFetchFundingHistory).toHaveBeenCalledWith("BTCUSDT");
+    expect(prisma.fundingSnapshot.createMany).toHaveBeenCalledOnce();
+
+    // Verify data shape passed to createMany
+    const callArgs = prisma.fundingSnapshot.createMany.mock.calls[0][0];
+    expect(callArgs.data).toHaveLength(2);
+    expect(callArgs.data[0].symbol).toBe("BTCUSDT");
+    expect(callArgs.data[0].fundingRate).toBe(0.0001);
+    expect(callArgs.data[0].timestamp).toBeInstanceOf(Date);
+    expect(callArgs.data[0].nextFundingAt).toBeInstanceOf(Date);
+    expect(callArgs.skipDuplicates).toBe(true);
+  });
+
+  it("skips symbol when fetch returns empty", async () => {
+    mockFetchFundingHistory.mockResolvedValue([]);
+
+    const prisma = makeMockPrisma();
+    const count = await ingestFundingRates(prisma, ["BTCUSDT"]);
+
+    expect(count).toBe(0);
+    expect(prisma.fundingSnapshot.createMany).not.toHaveBeenCalled();
+  });
+
+  it("continues other symbols when one fails", async () => {
+    mockFetchFundingHistory
+      .mockRejectedValueOnce(new Error("timeout"))
+      .mockResolvedValueOnce([
+        { symbol: "ETHUSDT", fundingRate: "0.0003", fundingRateTimestamp: "1700000000000" },
+      ]);
+
+    const prisma = makeMockPrisma();
+    prisma.fundingSnapshot.createMany.mockResolvedValue({ count: 1 });
+
+    const count = await ingestFundingRates(prisma, ["BTCUSDT", "ETHUSDT"]);
+
+    expect(count).toBe(1);
+    expect(prisma.fundingSnapshot.createMany).toHaveBeenCalledOnce();
+  });
+});
+
+// ── ingestSpreads ─────────────────────────────────────────────────────────────
+
+describe("ingestSpreads", () => {
+  it("matches linear and spot tickers to produce spread snapshots", async () => {
+    mockFetchLinearTickers.mockResolvedValue([
+      { symbol: "BTCUSDT", fundingRate: "0.0001", nextFundingTime: "1700028800000", lastPrice: "42100" },
+      { symbol: "ETHUSDT", fundingRate: "0.0002", nextFundingTime: "1700028800000", lastPrice: "2210" },
+    ]);
+    mockFetchSpotTickers.mockResolvedValue([
+      { symbol: "BTCUSDT", lastPrice: "42000" },
+      // ETHUSDT missing from spot → should be skipped
+    ]);
+
+    const prisma = makeMockPrisma();
+    prisma.spreadSnapshot.createMany.mockResolvedValue({ count: 1 });
+
+    const count = await ingestSpreads(prisma);
+
+    expect(count).toBe(1);
+    expect(prisma.spreadSnapshot.createMany).toHaveBeenCalledOnce();
+
+    const callArgs = prisma.spreadSnapshot.createMany.mock.calls[0][0];
+    expect(callArgs.data).toHaveLength(1);
+    expect(callArgs.data[0].symbol).toBe("BTCUSDT");
+    expect(callArgs.data[0].spotPrice).toBe(42000);
+    expect(callArgs.data[0].perpPrice).toBe(42100);
+    expect(typeof callArgs.data[0].basisBps).toBe("number");
+    expect(callArgs.data[0].timestamp).toBeInstanceOf(Date);
+  });
+
+  it("returns 0 when no tickers match", async () => {
+    mockFetchLinearTickers.mockResolvedValue([
+      { symbol: "XYZUSDT", fundingRate: "0.0001", nextFundingTime: "1700028800000", lastPrice: "10" },
+    ]);
+    mockFetchSpotTickers.mockResolvedValue([
+      { symbol: "ABCUSDT", lastPrice: "5" },
+    ]);
+
+    const prisma = makeMockPrisma();
+    const count = await ingestSpreads(prisma);
+
+    expect(count).toBe(0);
+    expect(prisma.spreadSnapshot.createMany).not.toHaveBeenCalled();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,9 @@ importers:
       fastify:
         specifier: ^5.3.0
         version: 5.7.4
+      node-cron:
+        specifier: ^4.2.1
+        version: 4.2.1
       pino:
         specifier: ^9.6.0
         version: 9.14.0
@@ -44,6 +47,9 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.11
+      '@types/node-cron':
+        specifier: ^3.0.11
+        version: 3.0.11
       pino-pretty:
         specifier: ^13.1.3
         version: 13.1.3
@@ -713,6 +719,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/node-cron@3.0.11':
+    resolution: {integrity: sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==}
+
   '@types/node@22.19.11':
     resolution: {integrity: sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==}
 
@@ -1165,6 +1174,10 @@ packages:
         optional: true
       sass:
         optional: true
+
+  node-cron@4.2.1:
+    resolution: {integrity: sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==}
+    engines: {node: '>=6.0.0'}
 
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
@@ -1970,6 +1983,8 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/node-cron@3.0.11': {}
+
   '@types/node@22.19.11':
     dependencies:
       undici-types: 6.21.0
@@ -2446,6 +2461,8 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+
+  node-cron@4.2.1: {}
 
   node-fetch-native@1.6.7: {}
 


### PR DESCRIPTION
## Summary

- **fetcher.ts**: HTTP fetch layer for Bybit funding history, linear tickers, and spot tickers with retry-once on failure
- **ingestJob.ts**: Ingestion pipeline — fetches, parses via existing `ingestion.ts`, and bulk-inserts `FundingSnapshot` + `SpreadSnapshot` records via Prisma `createMany` with `skipDuplicates`
- **server.ts**: Registered `node-cron` job running every 8 hours (`0 */8 * * *`) matching Bybit settlement schedule, with graceful shutdown cleanup (`fundingCron.stop()` + `prisma.$disconnect()`)
- **index.ts**: Updated barrel exports for new modules

## New files

| File | Purpose |
|------|---------|
| `apps/api/src/lib/funding/fetcher.ts` | HTTP layer — `fetchFundingHistory`, `fetchLinearTickers`, `fetchSpotTickers` |
| `apps/api/src/lib/funding/ingestJob.ts` | `ingestFundingRates`, `ingestSpreads`, `runIngestion` |
| `apps/api/tests/funding/fetcher.test.ts` | 5 tests: success, retry, API error handling |
| `apps/api/tests/funding/ingestJob.test.ts` | 5 tests: parse→insert, empty skip, symbol failure isolation, spread matching |

## Architecture

```
cron (8h) → runIngestion(prisma)
  ├─ ingestFundingRates → fetchFundingHistory → parseFundingHistory → prisma.fundingSnapshot.createMany
  └─ ingestSpreads → fetchLinearTickers + fetchSpotTickers → buildSpreadFromTickers → prisma.spreadSnapshot.createMany
```

## Test plan

- [x] `npx vitest run` — 983 pass (baseline 973, +10 new), 1 pre-existing Prisma fail
- [ ] Verify cron fires on VPS: `journalctl -u botmarketplace-api | grep "Funding cron"`
- [ ] Verify FundingSnapshot records in DB after first 8h cycle

https://claude.ai/code/session_01MnxTfRCtKybYk2dGRitN2o