### PR TITLE
Phase 11.2: Funding API routes (scanner + history)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -19,6 +19,7 @@ import { aiRoutes } from "./routes/ai.js";
 import { preferencesRoutes } from "./routes/preferences.js";
 import { usersRoutes } from "./routes/users.js";
 import { demoRoutes } from "./routes/demo.js";
+import { fundingRoutes } from "./routes/funding.js";
 
 /** Wrap a route plugin with a per-route rate-limit override. */
 function withRateLimit(
@@ -51,6 +52,7 @@ async function registerRoutes(scope: import("fastify").FastifyInstance) {
   await scope.register(datasetRoutes);
   await scope.register(exchangeRoutes);
   await scope.register(withRateLimit(terminalRoutes, 30, "1 minute")); // /terminal/*: 30 req/min
+  await scope.register(withRateLimit(fundingRoutes, 30, "1 minute"));  // /terminal/funding/*: 30 req/min
   await scope.register(aiRoutes);
   await scope.register(preferencesRoutes);
   await scope.register(usersRoutes);

--- a/apps/api/src/routes/funding.ts
+++ b/apps/api/src/routes/funding.ts
@@ -1,0 +1,182 @@
+/**
+ * Funding Scanner API routes (Phase 11.2)
+ *
+ * GET /terminal/funding/scanner — ranked funding arbitrage candidates
+ * GET /terminal/funding/:symbol/history — historical funding snapshots
+ */
+
+import type { FastifyInstance } from "fastify";
+import { prisma } from "../lib/prisma.js";
+import { problem } from "../lib/problem.js";
+import { scanFundingCandidates } from "../lib/funding/scanner.js";
+import type { FundingSnapshot, SpreadSnapshot } from "../lib/funding/types.js";
+
+// ---------------------------------------------------------------------------
+// GET /terminal/funding/scanner
+// ---------------------------------------------------------------------------
+
+interface ScannerQuery {
+  minYield?: string;
+  maxBasis?: string;
+  minStreak?: string;
+  limit?: string;
+}
+
+// ---------------------------------------------------------------------------
+// GET /terminal/funding/:symbol/history
+// ---------------------------------------------------------------------------
+
+interface HistoryParams {
+  symbol: string;
+}
+
+interface HistoryQuery {
+  from?: string;
+  to?: string;
+  limit?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Route plugin
+// ---------------------------------------------------------------------------
+
+export async function fundingRoutes(app: FastifyInstance) {
+  /**
+   * GET /terminal/funding/scanner
+   *
+   * Scans FundingSnapshot records from the last 7 days, groups by symbol,
+   * fetches latest SpreadSnapshot per symbol, and runs scanFundingCandidates.
+   */
+  app.get<{ Querystring: ScannerQuery }>(
+    "/terminal/funding/scanner",
+    { onRequest: [app.authenticate] },
+    async (request, reply) => {
+      const minYield = parseFloat(request.query.minYield ?? "5");
+      const maxBasis = parseFloat(request.query.maxBasis ?? "50");
+      const minStreak = parseInt(request.query.minStreak ?? "3", 10);
+      const topN = parseInt(request.query.limit ?? "10", 10);
+
+      if ([minYield, maxBasis, minStreak, topN].some((v) => isNaN(v) || v < 0)) {
+        return problem(reply, 400, "Bad Request", "Invalid query parameters");
+      }
+
+      const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+
+      // Fetch funding snapshots from last 7 days
+      const fundingRows = await prisma.fundingSnapshot.findMany({
+        where: { timestamp: { gte: sevenDaysAgo } },
+        orderBy: { timestamp: "asc" },
+      });
+
+      // Group by symbol
+      const symbolMap = new Map<string, {
+        snapshots: FundingSnapshot[];
+        spread: SpreadSnapshot | null;
+      }>();
+
+      for (const row of fundingRows) {
+        const symbol = row.symbol;
+        if (!symbolMap.has(symbol)) {
+          symbolMap.set(symbol, { snapshots: [], spread: null });
+        }
+        symbolMap.get(symbol)!.snapshots.push({
+          symbol: row.symbol,
+          fundingRate: row.fundingRate,
+          nextFundingAt: row.nextFundingAt.getTime(),
+          timestamp: row.timestamp.getTime(),
+        });
+      }
+
+      // Fetch latest SpreadSnapshot per symbol
+      const symbols = [...symbolMap.keys()];
+      if (symbols.length > 0) {
+        const spreadRows = await prisma.spreadSnapshot.findMany({
+          where: { symbol: { in: symbols } },
+          orderBy: { timestamp: "desc" },
+          distinct: ["symbol"],
+        });
+
+        for (const row of spreadRows) {
+          const entry = symbolMap.get(row.symbol);
+          if (entry) {
+            entry.spread = {
+              symbol: row.symbol,
+              spotPrice: row.spotPrice,
+              perpPrice: row.perpPrice,
+              basisBps: row.basisBps,
+              timestamp: row.timestamp.getTime(),
+            };
+          }
+        }
+      }
+
+      const candidates = scanFundingCandidates(symbolMap, {
+        minAnnualizedYieldPct: minYield,
+        maxBasisBps: maxBasis,
+        minStreak,
+        topN,
+      });
+
+      return reply.send({
+        candidates,
+        updatedAt: new Date().toISOString(),
+      });
+    },
+  );
+
+  /**
+   * GET /terminal/funding/:symbol/history
+   *
+   * Returns funding snapshots for a specific symbol within a date range.
+   */
+  app.get<{ Params: HistoryParams; Querystring: HistoryQuery }>(
+    "/terminal/funding/:symbol/history",
+    { onRequest: [app.authenticate] },
+    async (request, reply) => {
+      const { symbol } = request.params;
+      const limit = Math.min(parseInt(request.query.limit ?? "100", 10), 1000);
+
+      if (isNaN(limit) || limit < 1) {
+        return problem(reply, 400, "Bad Request", "Invalid limit parameter");
+      }
+
+      const where: Record<string, unknown> = { symbol };
+      const timestampFilter: Record<string, Date> = {};
+
+      if (request.query.from) {
+        const from = new Date(request.query.from);
+        if (isNaN(from.getTime())) {
+          return problem(reply, 400, "Bad Request", "Invalid 'from' date");
+        }
+        timestampFilter.gte = from;
+      }
+
+      if (request.query.to) {
+        const to = new Date(request.query.to);
+        if (isNaN(to.getTime())) {
+          return problem(reply, 400, "Bad Request", "Invalid 'to' date");
+        }
+        timestampFilter.lte = to;
+      }
+
+      if (Object.keys(timestampFilter).length > 0) {
+        where.timestamp = timestampFilter;
+      }
+
+      const snapshots = await prisma.fundingSnapshot.findMany({
+        where,
+        orderBy: { timestamp: "asc" },
+        take: limit,
+      });
+
+      return reply.send({
+        snapshots: snapshots.map((row) => ({
+          symbol: row.symbol,
+          fundingRate: row.fundingRate,
+          nextFundingAt: row.nextFundingAt.toISOString(),
+          timestamp: row.timestamp.toISOString(),
+        })),
+      });
+    },
+  );
+}

--- a/apps/api/tests/routes/funding.test.ts
+++ b/apps/api/tests/routes/funding.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+
+// ── Mock Prisma ───────────────────────────────────────────────────────────────
+
+const mockFundingSnapshots: unknown[] = [];
+const mockSpreadSnapshots: unknown[] = [];
+
+vi.mock("@prisma/client", () => ({
+  PrismaClient: vi.fn().mockImplementation(() => ({})),
+  Prisma: { sql: vi.fn(), join: vi.fn() },
+}));
+
+vi.mock("../../src/lib/prisma.js", () => ({
+  prisma: {
+    fundingSnapshot: {
+      findMany: vi.fn().mockImplementation(() => Promise.resolve(mockFundingSnapshots)),
+    },
+    spreadSnapshot: {
+      findMany: vi.fn().mockImplementation(() => Promise.resolve(mockSpreadSnapshots)),
+    },
+    $queryRaw: vi.fn().mockResolvedValue([]),
+    $connect: vi.fn(),
+    $disconnect: vi.fn(),
+  },
+}));
+
+import { buildApp } from "../../src/app.js";
+import type { FastifyInstance } from "fastify";
+
+// ── Test setup ────────────────────────────────────────────────────────────────
+
+let app: FastifyInstance;
+let token: string;
+
+beforeAll(async () => {
+  app = await buildApp();
+  // Generate a JWT for authenticated requests
+  token = app.jwt.sign({ sub: "test-user-id", email: "test@test.com" });
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+// ── Helper ────────────────────────────────────────────────────────────────────
+
+function makeSnapshot(symbol: string, rate: number, daysAgo: number) {
+  const ts = new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000);
+  return {
+    id: `snap-${symbol}-${daysAgo}`,
+    symbol,
+    fundingRate: rate,
+    nextFundingAt: new Date(ts.getTime() + 8 * 3600 * 1000),
+    timestamp: ts,
+  };
+}
+
+function makeSpread(symbol: string, spotPrice: number, perpPrice: number) {
+  return {
+    id: `spread-${symbol}`,
+    symbol,
+    spotPrice,
+    perpPrice,
+    basisBps: ((perpPrice - spotPrice) / spotPrice) * 10000,
+    timestamp: new Date(),
+  };
+}
+
+// ── Scanner endpoint ──────────────────────────────────────────────────────────
+
+describe("GET /api/v1/terminal/funding/scanner", () => {
+  it("returns 401 without auth", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/terminal/funding/scanner",
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns ranked candidates from DB data", async () => {
+    // Setup mock data: BTCUSDT with high positive rate, 5 consecutive snapshots
+    mockFundingSnapshots.length = 0;
+    for (let i = 5; i >= 1; i--) {
+      mockFundingSnapshots.push(makeSnapshot("BTCUSDT", 0.001, i));
+    }
+    mockSpreadSnapshots.length = 0;
+    mockSpreadSnapshots.push(makeSpread("BTCUSDT", 42000, 42010));
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/terminal/funding/scanner?minYield=5&maxBasis=50&minStreak=3&limit=10",
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.payload);
+    expect(body).toHaveProperty("candidates");
+    expect(body).toHaveProperty("updatedAt");
+    expect(Array.isArray(body.candidates)).toBe(true);
+
+    if (body.candidates.length > 0) {
+      const c = body.candidates[0];
+      expect(c.symbol).toBe("BTCUSDT");
+      expect(typeof c.annualizedYieldPct).toBe("number");
+      expect(typeof c.basisBps).toBe("number");
+      expect(typeof c.streak).toBe("number");
+    }
+  });
+
+  it("returns empty candidates when no data", async () => {
+    mockFundingSnapshots.length = 0;
+    mockSpreadSnapshots.length = 0;
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/terminal/funding/scanner",
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.payload);
+    expect(body.candidates).toEqual([]);
+  });
+
+  it("returns 400 for invalid query params", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/terminal/funding/scanner?minYield=abc",
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+// ── History endpoint ──────────────────────────────────────────────────────────
+
+describe("GET /api/v1/terminal/funding/:symbol/history", () => {
+  it("returns 401 without auth", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/terminal/funding/BTCUSDT/history",
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns snapshots for a symbol", async () => {
+    // The findMany mock returns mockFundingSnapshots - set up data
+    mockFundingSnapshots.length = 0;
+    mockFundingSnapshots.push(makeSnapshot("BTCUSDT", 0.0001, 1));
+    mockFundingSnapshots.push(makeSnapshot("BTCUSDT", 0.0002, 0));
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/terminal/funding/BTCUSDT/history?limit=50",
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.payload);
+    expect(body).toHaveProperty("snapshots");
+    expect(Array.isArray(body.snapshots)).toBe(true);
+
+    if (body.snapshots.length > 0) {
+      const s = body.snapshots[0];
+      expect(s).toHaveProperty("symbol");
+      expect(s).toHaveProperty("fundingRate");
+      expect(s).toHaveProperty("timestamp");
+    }
+  });
+
+  it("returns 400 for invalid from date", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/terminal/funding/BTCUSDT/history?from=not-a-date",
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary

- **GET /terminal/funding/scanner** — scans FundingSnapshot records from last 7 days, groups by symbol, fetches latest SpreadSnapshot per symbol, runs `scanFundingCandidates` with configurable thresholds via query params (`minYield`, `maxBasis`, `minStreak`, `limit`)
- **GET /terminal/funding/:symbol/history** — returns funding snapshots for a specific symbol with optional `from`/`to` date range and `limit` (max 1000)
- Both endpoints require JWT auth, rate-limited at 30 req/min (same as terminal routes)

## New files

| File | Purpose |
|------|---------|
| `apps/api/src/routes/funding.ts` | Scanner + history route handlers |
| `apps/api/tests/routes/funding.test.ts` | 7 tests with mocked Prisma |

## Modified files

| File | Change |
|------|--------|
| `apps/api/src/app.ts` | Import + register `fundingRoutes` with 30 req/min rate limit |

## Test plan

- [x] `npx vitest run` — 990 pass (baseline 983, +7 new)
- [ ] Verify on VPS: `curl -H "Authorization: Bearer ..." localhost:4000/api/v1/terminal/funding/scanner`
- [ ] Verify after first cron cycle: scanner returns ranked candidates from DB

https://claude.ai/code/session_01MnxTfRCtKybYk2dGRitN2o