### PR TITLE
fix: getEncryptionKeyRaw throws on missing key (#roadmap-v3-2)

### DIFF
--- a/apps/api/src/lib/botWorker.ts
+++ b/apps/api/src/lib/botWorker.ts
@@ -537,9 +537,6 @@ async function executeIntent(intent: {
     } else {
       // ── Live mode: place order on Bybit ──────────────────────────────────
       const encKey = getEncryptionKeyRaw();
-      if (!encKey) {
-        throw new Error("SECRET_ENCRYPTION_KEY not configured");
-      }
       const plainSecret = decrypt(bot.exchangeConnection.encryptedSecret, encKey);
 
       // Determine orderType from strategy DSL or default to Market
@@ -915,10 +912,6 @@ async function reconcilePlacedIntents(): Promise<void> {
     if (intents.length === 0) return;
 
     const encKey = getEncryptionKeyRaw();
-    if (!encKey) {
-      workerLog.warn("SECRET_ENCRYPTION_KEY not set, skipping reconciliation");
-      return;
-    }
 
     for (const intent of intents) {
       const { bot } = intent.botRun;

--- a/apps/api/src/lib/crypto.ts
+++ b/apps/api/src/lib/crypto.ts
@@ -39,11 +39,16 @@ export function encrypt(plaintext: string, key: Buffer): string {
 
 /**
  * Get the encryption key directly (no Fastify reply required).
- * Returns null if the key is missing or invalid — caller decides what to do.
+ * Throws if the key is missing or invalid — fail fast, never silently skip.
  */
-export function getEncryptionKeyRaw(): Buffer | null {
+export function getEncryptionKeyRaw(): Buffer {
   const raw = process.env.SECRET_ENCRYPTION_KEY;
-  if (!raw || raw.length !== 64) return null;
+  if (!raw) {
+    throw new Error("SECRET_ENCRYPTION_KEY is not set — cannot decrypt exchange credentials");
+  }
+  if (raw.length !== KEY_HEX_LENGTH) {
+    throw new Error(`SECRET_ENCRYPTION_KEY has wrong length: expected ${KEY_HEX_LENGTH} hex chars, got ${raw.length}`);
+  }
   return Buffer.from(raw, "hex");
 }
 

--- a/apps/api/tests/lib/encryptionKeyFix.test.ts
+++ b/apps/api/tests/lib/encryptionKeyFix.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Encryption key missing fix — Roadmap V3, Task #2
+ *
+ * Tests that getEncryptionKeyRaw() throws instead of silently returning null
+ * when SECRET_ENCRYPTION_KEY is missing or invalid.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { getEncryptionKeyRaw, encrypt, decrypt } from "../../src/lib/crypto.js";
+
+describe("getEncryptionKeyRaw", () => {
+  const VALID_KEY_HEX = "a".repeat(64); // 32 bytes in hex
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    originalEnv = process.env.SECRET_ENCRYPTION_KEY;
+  });
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.SECRET_ENCRYPTION_KEY = originalEnv;
+    } else {
+      delete process.env.SECRET_ENCRYPTION_KEY;
+    }
+  });
+
+  it("throws when SECRET_ENCRYPTION_KEY is not set", () => {
+    delete process.env.SECRET_ENCRYPTION_KEY;
+    expect(() => getEncryptionKeyRaw()).toThrow("SECRET_ENCRYPTION_KEY is not set");
+  });
+
+  it("throws when SECRET_ENCRYPTION_KEY is empty string", () => {
+    process.env.SECRET_ENCRYPTION_KEY = "";
+    expect(() => getEncryptionKeyRaw()).toThrow("SECRET_ENCRYPTION_KEY is not set");
+  });
+
+  it("throws when SECRET_ENCRYPTION_KEY has wrong length", () => {
+    process.env.SECRET_ENCRYPTION_KEY = "abcd1234"; // too short
+    expect(() => getEncryptionKeyRaw()).toThrow("wrong length");
+  });
+
+  it("throws with specific length info for wrong-length key", () => {
+    process.env.SECRET_ENCRYPTION_KEY = "ab".repeat(16); // 32 hex chars, need 64
+    expect(() => getEncryptionKeyRaw()).toThrow("expected 64 hex chars, got 32");
+  });
+
+  it("returns Buffer for valid 64-char hex key", () => {
+    process.env.SECRET_ENCRYPTION_KEY = VALID_KEY_HEX;
+    const key = getEncryptionKeyRaw();
+    expect(key).toBeInstanceOf(Buffer);
+    expect(key.length).toBe(32);
+  });
+
+  it("encrypt→decrypt roundtrip works with valid key", () => {
+    process.env.SECRET_ENCRYPTION_KEY = VALID_KEY_HEX;
+    const key = getEncryptionKeyRaw();
+    const plaintext = "my-bybit-api-secret-12345";
+    const ciphertext = encrypt(plaintext, key);
+    const decrypted = decrypt(ciphertext, key);
+    expect(decrypted).toBe(plaintext);
+  });
+
+  it("decrypt with wrong key throws (GCM auth tag failure)", () => {
+    process.env.SECRET_ENCRYPTION_KEY = VALID_KEY_HEX;
+    const key = getEncryptionKeyRaw();
+    const ciphertext = encrypt("secret", key);
+
+    const wrongKey = Buffer.from("b".repeat(64), "hex");
+    expect(() => decrypt(ciphertext, wrongKey)).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- `getEncryptionKeyRaw()` now throws with clear message instead of silently returning null
- Removed redundant null checks in botWorker.ts callers
- 7 new tests covering missing key, wrong length, roundtrip, wrong key rejection

## Test plan
- [x] 7 new tests pass
- [x] All 1015 existing tests pass
- [x] No new tsc errors