### PR TITLE
fix: CORS whitelist + PrismaClient singleton + trustProxy (#roadmap-v3-4,5,6)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -67,11 +67,16 @@ export async function buildApp() {
           ? { target: "pino-pretty" }
           : undefined,
     },
+    trustProxy: "127.0.0.1",
     genReqId: (req) =>
       (req.headers["x-request-id"] as string) || randomUUID(),
   });
 
-  await app.register(cors, { origin: true });
+  await app.register(cors, {
+    origin: process.env.NODE_ENV === "production"
+      ? ["https://botmarketplace.store"]
+      : true,
+  });
 
   // Global rate limit — 100 req/min baseline; lab & terminal routes override below
   await app.register(rateLimit, {

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -2,7 +2,7 @@ import { buildApp } from "./app.js";
 import { startBotWorker } from "./lib/botWorker.js";
 import cron from "node-cron";
 import { runIngestion } from "./lib/funding/ingestJob.js";
-import { PrismaClient } from "@prisma/client";
+import { prisma } from "./lib/prisma.js";
 import { logger } from "./lib/logger.js";
 
 const PORT = parseInt(process.env.API_PORT || "4000", 10);
@@ -19,7 +19,6 @@ async function main() {
     const stopWorker = startBotWorker();
 
     // Funding ingestion cron — every 8 hours (matches Bybit settlement schedule)
-    const prisma = new PrismaClient();
     const fundingCron = cron.schedule("0 */8 * * *", () => {
       logger.info("Funding cron triggered");
       runIngestion(prisma);


### PR DESCRIPTION
## Summary
- **#4 CORS**: `origin: true` → whitelist `botmarketplace.store` in production
- **#5 PrismaClient**: Remove duplicate `new PrismaClient()` in server.ts, use shared singleton
- **#6 trustProxy**: Add `trustProxy: "127.0.0.1"` so rate limiting sees real client IPs behind nginx

## Test plan
- [x] All 1015 tests pass
- [x] No new tsc errors