### PR TITLE
fix: login rate limit + poll isolation + env validation (#roadmap-v3-8,10,12)

### DIFF
--- a/apps/api/src/lib/botWorker.ts
+++ b/apps/api/src/lib/botWorker.ts
@@ -1647,10 +1647,18 @@ async function runMarketCandleRetention(): Promise<void> {
 // Main polling loop
 // ---------------------------------------------------------------------------
 
+/** Run a named poll step, catching and logging errors so subsequent steps still execute. */
+async function safeStep(name: string, fn: () => Promise<void>) {
+  try {
+    await fn();
+  } catch (err) {
+    workerLog.error({ err, step: name }, `poll step "${name}" failed (non-fatal)`);
+  }
+}
+
 /** Main polling loop. */
 async function poll() {
-  try {
-    // Pick up QUEUED runs (up to 5 at a time)
+  await safeStep("activateRuns", async () => {
     const queued = await prisma.botRun.findMany({
       where: { state: "QUEUED" },
       take: 5,
@@ -1660,8 +1668,9 @@ async function poll() {
     for (const { id } of queued) {
       await activateRun(id);
     }
+  });
 
-    // Complete STOPPING runs
+  await safeStep("stopRuns", async () => {
     const stopping = await prisma.botRun.findMany({
       where: { state: "STOPPING" },
       take: 10,
@@ -1670,32 +1679,27 @@ async function poll() {
     for (const { id } of stopping) {
       await stopRun(id);
     }
+  });
 
-    // Timeout runs that exceeded max duration
-    await timeoutExpiredRuns();
+  await safeStep("timeoutExpiredRuns", () => timeoutExpiredRuns());
+  await safeStep("renewLeases", () => renewLeases());
 
-    // Renew leases on our RUNNING runs
-    await renewLeases();
+  // Stage 8 (#141): enforce safety circuit breakers before evaluation
+  await safeStep("enforceDailyLossLimit", () => enforceDailyLossLimit());
+  await safeStep("enforceErrorPause", () => enforceErrorPause());
 
-    // Stage 8 (#141): enforce safety circuit breakers before evaluation
-    await enforceDailyLossLimit();
-    await enforceErrorPause();
+  // Stage 3 (#128): Evaluate DSL strategies for RUNNING runs
+  await safeStep("evaluateStrategies", () => evaluateStrategies());
 
-    // Stage 3 (#128): Evaluate DSL strategies for RUNNING runs
-    await evaluateStrategies();
+  // Process PENDING intents on RUNNING runs (Stage 11)
+  await safeStep("processIntents", () => processIntents());
 
-    // Process PENDING intents on RUNNING runs (Stage 11)
-    await processIntents();
+  // Reconcile PLACED/PARTIALLY_FILLED intents against exchange (Stage 3, #129 follow-up)
+  await safeStep("reconcilePlacedIntents", () => reconcilePlacedIntents());
 
-    // Reconcile PLACED/PARTIALLY_FILLED intents against exchange (Stage 3, #129 follow-up)
-    await reconcilePlacedIntents();
-
-    // Stage 19c: run retention at most once per hour
-    if (Date.now() - lastRetentionRunMs >= RETENTION_INTERVAL_MS) {
-      await runMarketCandleRetention();
-    }
-  } catch (err) {
-    workerLog.error({ err }, "poll error");
+  // Stage 19c: run retention at most once per hour
+  if (Date.now() - lastRetentionRunMs >= RETENTION_INTERVAL_MS) {
+    await safeStep("marketCandleRetention", () => runMarketCandleRetention());
   }
 }
 

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -59,7 +59,9 @@ export async function authRoutes(app: FastifyInstance) {
   });
 
   // ── POST /auth/login ───────────────────────────────────────────────────────
-  app.post<{ Body: LoginBody }>("/auth/login", async (request, reply) => {
+  app.post<{ Body: LoginBody }>("/auth/login", {
+    config: { rateLimit: { max: 5, timeWindow: "15 minutes" } },
+  }, async (request, reply) => {
     const { email, password } = request.body ?? {};
 
     if (!email || !password) {

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -8,7 +8,21 @@ import { logger } from "./lib/logger.js";
 const PORT = parseInt(process.env.API_PORT || "4000", 10);
 const HOST = process.env.API_HOST || "0.0.0.0";
 
+/** Fail fast if required env vars are missing. */
+function validateEnv() {
+  const required = ["DATABASE_URL", "JWT_SECRET"];
+  const requiredInProd = ["SECRET_ENCRYPTION_KEY"];
+  const missing = required.filter((k) => !process.env[k]);
+  if (process.env.NODE_ENV === "production") {
+    missing.push(...requiredInProd.filter((k) => !process.env[k]));
+  }
+  if (missing.length > 0) {
+    throw new Error(`Missing required env vars: ${missing.join(", ")}`);
+  }
+}
+
 async function main() {
+  validateEnv();
   const app = await buildApp();
 
   try {


### PR DESCRIPTION
## Summary
- **#8**: Login endpoint rate limit: 5 req / 15 min per IP (brute force protection)
- **#10**: Each poll() step wrapped in `safeStep()` — one step failure no longer kills the entire cycle
- **#12**: `validateEnv()` at startup — fail fast on missing DATABASE_URL, JWT_SECRET, SECRET_ENCRYPTION_KEY (prod)

## Test plan
- [x] All 1015 tests pass
- [x] No new tsc errors