### PR TITLE
feat: JWT hardening — 1h access + refresh token rotation (#roadmap-v3-3)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -76,6 +76,7 @@ export async function buildApp() {
     origin: process.env.NODE_ENV === "production"
       ? ["https://botmarketplace.store"]
       : true,
+    credentials: true,
   });
 
   // Global rate limit — 100 req/min baseline; lab & terminal routes override below
@@ -91,8 +92,12 @@ export async function buildApp() {
     }),
   });
 
-  // JWT plugin — secret from env or a fallback for dev
-  const jwtSecret = process.env.JWT_SECRET ?? "dev-secret-change-in-production-please";
+  // JWT plugin — secret from env; dev fallback only in non-production
+  const jwtSecret = process.env.JWT_SECRET ?? (
+    process.env.NODE_ENV === "production"
+      ? (() => { throw new Error("JWT_SECRET must be set in production"); })()
+      : "dev-secret-change-in-production-please"
+  );
   await app.register(jwt, { secret: jwtSecret });
 
   // Authenticate decorator used by protected routes

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,4 +1,4 @@
-import type { FastifyInstance, FastifyReply } from "fastify";
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import bcrypt from "bcryptjs";
 import { prisma } from "../lib/prisma.js";
 
@@ -12,9 +12,40 @@ interface LoginBody {
   password: string;
 }
 
+const ACCESS_TOKEN_EXPIRY = "1h";
+const REFRESH_TOKEN_EXPIRY = "7d";
+const REFRESH_COOKIE_NAME = "refreshToken";
+const REFRESH_COOKIE_MAX_AGE = 7 * 24 * 60 * 60; // 7 days in seconds
+
 function authProblem(reply: FastifyReply, status: number, detail: string) {
   const titles: Record<number, string> = { 400: "Bad Request", 401: "Unauthorized", 409: "Conflict" };
   return reply.status(status).send({ type: "about:blank", title: titles[status] ?? "Error", status, detail });
+}
+
+/** Set refresh token as httpOnly cookie. */
+function setRefreshCookie(reply: FastifyReply, token: string) {
+  const isProduction = process.env.NODE_ENV === "production";
+  reply.header(
+    "Set-Cookie",
+    `${REFRESH_COOKIE_NAME}=${token}; HttpOnly; Path=/api; Max-Age=${REFRESH_COOKIE_MAX_AGE}; SameSite=Strict${isProduction ? "; Secure" : ""}`,
+  );
+}
+
+/** Clear refresh token cookie. */
+function clearRefreshCookie(reply: FastifyReply) {
+  const isProduction = process.env.NODE_ENV === "production";
+  reply.header(
+    "Set-Cookie",
+    `${REFRESH_COOKIE_NAME}=; HttpOnly; Path=/api; Max-Age=0; SameSite=Strict${isProduction ? "; Secure" : ""}`,
+  );
+}
+
+/** Parse a specific cookie from the Cookie header. */
+function parseCookie(request: FastifyRequest, name: string): string | undefined {
+  const header = request.headers.cookie;
+  if (!header) return undefined;
+  const match = header.split(";").map((s) => s.trim()).find((s) => s.startsWith(`${name}=`));
+  return match ? match.slice(name.length + 1) : undefined;
 }
 
 export async function authRoutes(app: FastifyInstance) {
@@ -49,10 +80,12 @@ export async function authRoutes(app: FastifyInstance) {
       },
     });
 
-    const token = await reply.jwtSign({ sub: user.id, email: user.email }, { expiresIn: "30d" });
+    const accessToken = await reply.jwtSign({ sub: user.id, email: user.email }, { expiresIn: ACCESS_TOKEN_EXPIRY });
+    const refreshToken = await reply.jwtSign({ sub: user.id, type: "refresh" }, { expiresIn: REFRESH_TOKEN_EXPIRY });
+    setRefreshCookie(reply, refreshToken);
 
     return reply.status(201).send({
-      accessToken: token,
+      accessToken,
       workspaceId: workspace.id,
       user: { id: user.id, email: user.email },
     });
@@ -84,13 +117,67 @@ export async function authRoutes(app: FastifyInstance) {
       orderBy: { createdAt: "asc" },
     });
 
-    const token = await reply.jwtSign({ sub: user.id, email: user.email }, { expiresIn: "30d" });
+    const accessToken = await reply.jwtSign({ sub: user.id, email: user.email }, { expiresIn: ACCESS_TOKEN_EXPIRY });
+    const refreshToken = await reply.jwtSign({ sub: user.id, type: "refresh" }, { expiresIn: REFRESH_TOKEN_EXPIRY });
+    setRefreshCookie(reply, refreshToken);
 
     return reply.send({
-      accessToken: token,
+      accessToken,
       workspaceId: membership?.workspaceId ?? null,
       user: { id: user.id, email: user.email },
     });
+  });
+
+  // ── POST /auth/refresh ─────────────────────────────────────────────────────
+  app.post("/auth/refresh", {
+    config: { rateLimit: { max: 10, timeWindow: "1 minute" } },
+  }, async (request, reply) => {
+    const token = parseCookie(request, REFRESH_COOKIE_NAME);
+    if (!token) {
+      return authProblem(reply, 401, "refresh token missing");
+    }
+
+    let payload: { sub: string; type?: string };
+    try {
+      payload = app.jwt.verify<{ sub: string; type?: string }>(token);
+    } catch {
+      clearRefreshCookie(reply);
+      return authProblem(reply, 401, "refresh token expired or invalid");
+    }
+
+    if (payload.type !== "refresh") {
+      clearRefreshCookie(reply);
+      return authProblem(reply, 401, "invalid token type");
+    }
+
+    // Verify user still exists
+    const user = await prisma.user.findUnique({ where: { id: payload.sub } });
+    if (!user) {
+      clearRefreshCookie(reply);
+      return authProblem(reply, 401, "user not found");
+    }
+
+    const membership = await prisma.workspaceMember.findFirst({
+      where: { userId: user.id },
+      orderBy: { createdAt: "asc" },
+    });
+
+    // Rotate: issue new access + refresh tokens
+    const newAccessToken = await reply.jwtSign({ sub: user.id, email: user.email }, { expiresIn: ACCESS_TOKEN_EXPIRY });
+    const newRefreshToken = await reply.jwtSign({ sub: user.id, type: "refresh" }, { expiresIn: REFRESH_TOKEN_EXPIRY });
+    setRefreshCookie(reply, newRefreshToken);
+
+    return reply.send({
+      accessToken: newAccessToken,
+      workspaceId: membership?.workspaceId ?? null,
+      user: { id: user.id, email: user.email },
+    });
+  });
+
+  // ── POST /auth/logout ──────────────────────────────────────────────────────
+  app.post("/auth/logout", async (_request, reply) => {
+    clearRefreshCookie(reply);
+    return reply.send({ ok: true });
   });
 
   // ── GET /auth/me ───────────────────────────────────────────────────────────

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -52,6 +52,7 @@ export default function LoginPage() {
       const res = await fetch("/api/v1/auth/login", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
+        credentials: "include",
         body: JSON.stringify({ email, password }),
       });
       const data = await res.json();

--- a/apps/web/src/app/navbar.tsx
+++ b/apps/web/src/app/navbar.tsx
@@ -51,6 +51,8 @@ export function Navbar() {
   }, [dropdownOpen]);
 
   function handleLogout() {
+    // Clear server-side refresh token cookie
+    fetch("/api/v1/auth/logout", { method: "POST", credentials: "include" }).catch(() => {});
     clearAuth();
     setIsAuth(false);
     setUserInfo(null);

--- a/apps/web/src/app/register/page.tsx
+++ b/apps/web/src/app/register/page.tsx
@@ -56,6 +56,7 @@ export default function RegisterPage() {
       const res = await fetch("/api/v1/auth/register", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
+        credentials: "include",
         body: JSON.stringify({ email, password }),
       });
       const data = await res.json();

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -107,6 +107,7 @@ export default function SettingsPage() {
   }, [router]);
 
   function handleLogout() {
+    fetch("/api/v1/auth/logout", { method: "POST", credentials: "include" }).catch(() => {});
     clearAuth();
     router.push("/login");
   }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -31,25 +31,58 @@ export interface ProblemDetails {
   errors?: Array<{ field: string; message: string }>;
 }
 
+// ---------------------------------------------------------------------------
+// Token refresh — single in-flight request to avoid thundering herd
+// ---------------------------------------------------------------------------
+
+let refreshPromise: Promise<boolean> | null = null;
+
+/** Attempt to refresh the access token using the httpOnly refresh cookie. */
+async function tryRefreshToken(): Promise<boolean> {
+  if (refreshPromise) return refreshPromise;
+
+  refreshPromise = (async () => {
+    try {
+      const res = await fetch(`${API_PREFIX}/auth/refresh`, {
+        method: "POST",
+        credentials: "include",
+      });
+      if (!res.ok) return false;
+      const data = await res.json();
+      if (data.accessToken) {
+        setToken(data.accessToken);
+        return true;
+      }
+      return false;
+    } catch {
+      return false;
+    } finally {
+      refreshPromise = null;
+    }
+  })();
+
+  return refreshPromise;
+}
+
+// ---------------------------------------------------------------------------
+// Core fetch wrapper
+// ---------------------------------------------------------------------------
+
 async function doFetch<T>(
   path: string,
   options: RequestInit,
   injectWorkspace: boolean,
 ): Promise<{ ok: true; data: T } | { ok: false; problem: ProblemDetails }> {
-  const token = getToken();
-  const headers: Record<string, string> = {
-    ...(options.body != null ? { "Content-Type": "application/json" } : {}),
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    ...(options.headers as Record<string, string>),
-  };
-  if (injectWorkspace) {
-    const workspaceId = getWorkspaceId();
-    if (workspaceId) headers["X-Workspace-Id"] = workspaceId;
-  }
+  const res = await rawFetch(path, options, injectWorkspace);
 
-  const res = await fetch(`${API_PREFIX}${path}`, { ...options, headers });
-
+  // On 401, try to refresh the token and retry once
   if (res.status === 401) {
+    const refreshed = await tryRefreshToken();
+    if (refreshed) {
+      const retry = await rawFetch(path, options, injectWorkspace);
+      return parseResponse<T>(retry);
+    }
+    // Refresh failed — session is truly expired
     clearAuth();
     return {
       ok: false,
@@ -62,6 +95,37 @@ async function doFetch<T>(
     };
   }
 
+  return parseResponse<T>(res);
+}
+
+/** Execute a fetch with auth headers. */
+async function rawFetch(
+  path: string,
+  options: RequestInit,
+  injectWorkspace: boolean,
+): Promise<Response> {
+  const token = getToken();
+  const headers: Record<string, string> = {
+    ...(options.body != null ? { "Content-Type": "application/json" } : {}),
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    ...(options.headers as Record<string, string>),
+  };
+  if (injectWorkspace) {
+    const workspaceId = getWorkspaceId();
+    if (workspaceId) headers["X-Workspace-Id"] = workspaceId;
+  }
+
+  return fetch(`${API_PREFIX}${path}`, {
+    ...options,
+    headers,
+    credentials: "include",
+  });
+}
+
+/** Parse a non-401 response into our standard result type. */
+async function parseResponse<T>(
+  res: Response,
+): Promise<{ ok: true; data: T } | { ok: false; problem: ProblemDetails }> {
   if (!res.ok) {
     const contentType = res.headers.get("content-type") ?? "";
     if (contentType.includes("application/problem+json") || contentType.includes("application/json")) {


### PR DESCRIPTION
## Summary
- Access token expiry: 30d → 1h
- Refresh token (7d) via httpOnly/Secure/SameSite cookie with rotation
- New endpoints: POST /auth/refresh, POST /auth/logout
- Frontend auto-refresh on 401 (single in-flight, retry once)
- Production: throw if JWT_SECRET is default fallback
- CORS: credentials: true for cookie transport

## Changed files
- `apps/api/src/app.ts` — JWT secret prod check, CORS credentials
- `apps/api/src/routes/auth.ts` — refresh/logout endpoints, token expiry
- `apps/web/src/lib/api.ts` — auto-refresh interceptor
- `apps/web/src/app/login/page.tsx` — credentials: include
- `apps/web/src/app/register/page.tsx` — credentials: include
- `apps/web/src/app/navbar.tsx` — logout calls /auth/logout
- `apps/web/src/app/settings/page.tsx` — logout calls /auth/logout

## Test plan
- [x] All 1015 tests pass
- [x] No new tsc errors
- [ ] Manual: login → wait >1h (or set short expiry) → verify auto-refresh
- [ ] Manual: verify logout clears cookie