### PR TITLE
feat: extend /readyz with worker health checks (#roadmap-v3-18)

### DIFF
--- a/apps/api/src/lib/botWorker.ts
+++ b/apps/api/src/lib/botWorker.ts
@@ -87,6 +87,16 @@ const workerLog = logger.child({ module: "botWorker" });
 const WORKER_ID = `worker-${process.pid}`;
 const POLL_INTERVAL_MS = 4_000;
 
+// ---------------------------------------------------------------------------
+// Worker health observability (Task #18)
+// ---------------------------------------------------------------------------
+
+/** Timestamp (ms) of the last completed poll cycle. 0 = worker never ran. */
+export let lastPollTimestampMs = 0;
+
+/** Exported for /readyz to check if worker is alive. */
+export { POLL_INTERVAL_MS };
+
 // Max time a run can stay in RUNNING state before auto-timeout (default: 4 hours)
 const MAX_RUN_DURATION_MS = parseInt(process.env.MAX_RUN_DURATION_MS ?? "", 10) || 4 * 60 * 60 * 1000;
 
@@ -1705,6 +1715,9 @@ async function poll() {
   if (Date.now() - lastRetentionRunMs >= RETENTION_INTERVAL_MS) {
     await safeStep("marketCandleRetention", () => runMarketCandleRetention());
   }
+
+  // Mark poll completion for health checks (Task #18)
+  lastPollTimestampMs = Date.now();
 }
 
 /**

--- a/apps/api/src/routes/readyz.ts
+++ b/apps/api/src/routes/readyz.ts
@@ -1,18 +1,81 @@
 import type { FastifyInstance } from "fastify";
 import { prisma } from "../lib/prisma.js";
+import { lastPollTimestampMs, POLL_INTERVAL_MS } from "../lib/botWorker.js";
+
+/**
+ * Worker is considered stale if its last poll completed more than
+ * 3× the poll interval ago (default: 12 seconds).
+ */
+const WORKER_STALENESS_FACTOR = 3;
 
 export async function readyzRoutes(app: FastifyInstance) {
   app.get("/readyz", async (_request, reply) => {
+    const checks: Record<string, { ok: boolean; detail?: string }> = {};
+
+    // 1. Database connectivity
     try {
       await prisma.$queryRaw`SELECT 1`;
-      return reply.send({ status: "ok" });
+      checks.database = { ok: true };
     } catch {
-      return reply.status(503).send({
-        type: "about:blank",
-        title: "Service Unavailable",
-        status: 503,
-        detail: "Database connection failed",
-      });
+      checks.database = { ok: false, detail: "Database connection failed" };
     }
+
+    // 2. Worker health — has poll run recently?
+    const now = Date.now();
+    const maxStaleMs = POLL_INTERVAL_MS * WORKER_STALENESS_FACTOR;
+    if (lastPollTimestampMs === 0) {
+      // Worker hasn't completed its first poll yet — may still be starting
+      checks.worker = { ok: true, detail: "Worker starting (no poll completed yet)" };
+    } else {
+      const elapsed = now - lastPollTimestampMs;
+      if (elapsed < maxStaleMs) {
+        checks.worker = { ok: true, detail: `Last poll ${Math.round(elapsed / 1000)}s ago` };
+      } else {
+        checks.worker = {
+          ok: false,
+          detail: `Worker stale: last poll ${Math.round(elapsed / 1000)}s ago (threshold: ${Math.round(maxStaleMs / 1000)}s)`,
+        };
+      }
+    }
+
+    // 3. Encryption key availability
+    try {
+      const raw = process.env.SECRET_ENCRYPTION_KEY;
+      if (raw && raw.length === 64) {
+        checks.encryptionKey = { ok: true };
+      } else if (!raw) {
+        checks.encryptionKey = { ok: false, detail: "SECRET_ENCRYPTION_KEY not set" };
+      } else {
+        checks.encryptionKey = { ok: false, detail: `SECRET_ENCRYPTION_KEY wrong length: ${raw.length}` };
+      }
+    } catch {
+      checks.encryptionKey = { ok: false, detail: "Failed to check encryption key" };
+    }
+
+    // 4. Stuck runs — ephemeral states older than 5 min
+    try {
+      const stuckCount = await prisma.botRun.count({
+        where: {
+          state: { in: ["STARTING", "SYNCING"] },
+          updatedAt: { lt: new Date(now - 5 * 60 * 1000) },
+        },
+      });
+      if (stuckCount === 0) {
+        checks.stuckRuns = { ok: true };
+      } else {
+        checks.stuckRuns = { ok: false, detail: `${stuckCount} run(s) stuck in ephemeral state` };
+      }
+    } catch {
+      checks.stuckRuns = { ok: true, detail: "Could not check (non-critical)" };
+    }
+
+    // Overall status: database + worker are critical; others are warnings
+    const critical = checks.database.ok && checks.worker.ok;
+    const allOk = Object.values(checks).every((c) => c.ok);
+
+    const status = critical ? (allOk ? "ok" : "degraded") : "unavailable";
+    const httpStatus = critical ? 200 : 503;
+
+    return reply.status(httpStatus).send({ status, checks });
   });
 }

--- a/apps/api/tests/routes/readyz.test.ts
+++ b/apps/api/tests/routes/readyz.test.ts
@@ -1,0 +1,175 @@
+/**
+ * /readyz — extended health check tests (Roadmap V3, Task #18)
+ *
+ * Tests worker health, encryption key, stuck runs checks.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@prisma/client", () => ({
+  PrismaClient: vi.fn().mockImplementation(() => ({
+    $connect: vi.fn(),
+    $disconnect: vi.fn(),
+  })),
+  Prisma: { sql: vi.fn(), join: vi.fn() },
+}));
+
+const mockQueryRaw = vi.fn();
+const mockBotRunCount = vi.fn();
+
+vi.mock("../../src/lib/prisma.js", () => ({
+  prisma: {
+    $queryRaw: (...args: unknown[]) => mockQueryRaw(...args),
+    $connect: vi.fn(),
+    $disconnect: vi.fn(),
+    botRun: {
+      count: (...args: unknown[]) => mockBotRunCount(...args),
+    },
+  },
+}));
+
+// Mock botWorker exports — we'll override lastPollTimestampMs per test
+let mockLastPollTimestampMs = 0;
+vi.mock("../../src/lib/botWorker.js", () => ({
+  get lastPollTimestampMs() {
+    return mockLastPollTimestampMs;
+  },
+  POLL_INTERVAL_MS: 4_000,
+  startBotWorker: vi.fn(),
+}));
+
+import { buildApp } from "../../src/app.js";
+
+async function getApp() {
+  const app = await buildApp();
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GET /readyz", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQueryRaw.mockResolvedValue([{ "?column?": 1 }]);
+    mockBotRunCount.mockResolvedValue(0);
+    mockLastPollTimestampMs = Date.now() - 1000; // 1s ago — healthy
+    process.env.SECRET_ENCRYPTION_KEY = "a".repeat(64);
+  });
+
+  it("returns 200 with status ok when all checks pass", async () => {
+    const app = await getApp();
+    const res = await app.inject({ method: "GET", url: "/api/v1/readyz" });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.payload);
+    expect(body.status).toBe("ok");
+    expect(body.checks.database.ok).toBe(true);
+    expect(body.checks.worker.ok).toBe(true);
+    expect(body.checks.encryptionKey.ok).toBe(true);
+    expect(body.checks.stuckRuns.ok).toBe(true);
+
+    await app.close();
+  });
+
+  it("returns 503 when database is down", async () => {
+    mockQueryRaw.mockRejectedValue(new Error("connection refused"));
+
+    const app = await getApp();
+    const res = await app.inject({ method: "GET", url: "/api/v1/readyz" });
+
+    expect(res.statusCode).toBe(503);
+    const body = JSON.parse(res.payload);
+    expect(body.status).toBe("unavailable");
+    expect(body.checks.database.ok).toBe(false);
+
+    await app.close();
+  });
+
+  it("returns 503 when worker is stale", async () => {
+    // Last poll 60 seconds ago — way beyond 3×4s = 12s threshold
+    mockLastPollTimestampMs = Date.now() - 60_000;
+
+    const app = await getApp();
+    const res = await app.inject({ method: "GET", url: "/api/v1/readyz" });
+
+    expect(res.statusCode).toBe(503);
+    const body = JSON.parse(res.payload);
+    expect(body.status).toBe("unavailable");
+    expect(body.checks.worker.ok).toBe(false);
+    expect(body.checks.worker.detail).toContain("stale");
+
+    await app.close();
+  });
+
+  it("returns 200 (ok) when worker hasn't polled yet (starting)", async () => {
+    mockLastPollTimestampMs = 0;
+
+    const app = await getApp();
+    const res = await app.inject({ method: "GET", url: "/api/v1/readyz" });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.payload);
+    expect(body.checks.worker.ok).toBe(true);
+    expect(body.checks.worker.detail).toContain("starting");
+
+    await app.close();
+  });
+
+  it("returns degraded when encryption key is missing", async () => {
+    delete process.env.SECRET_ENCRYPTION_KEY;
+
+    const app = await getApp();
+    const res = await app.inject({ method: "GET", url: "/api/v1/readyz" });
+
+    expect(res.statusCode).toBe(200); // not critical — degraded, not 503
+    const body = JSON.parse(res.payload);
+    expect(body.status).toBe("degraded");
+    expect(body.checks.encryptionKey.ok).toBe(false);
+
+    await app.close();
+  });
+
+  it("returns degraded when encryption key has wrong length", async () => {
+    process.env.SECRET_ENCRYPTION_KEY = "short";
+
+    const app = await getApp();
+    const res = await app.inject({ method: "GET", url: "/api/v1/readyz" });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.payload);
+    expect(body.status).toBe("degraded");
+    expect(body.checks.encryptionKey.ok).toBe(false);
+    expect(body.checks.encryptionKey.detail).toContain("wrong length");
+
+    await app.close();
+  });
+
+  it("returns degraded when stuck runs exist", async () => {
+    mockBotRunCount.mockResolvedValue(2);
+
+    const app = await getApp();
+    const res = await app.inject({ method: "GET", url: "/api/v1/readyz" });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.payload);
+    expect(body.status).toBe("degraded");
+    expect(body.checks.stuckRuns.ok).toBe(false);
+    expect(body.checks.stuckRuns.detail).toContain("2 run(s) stuck");
+
+    await app.close();
+  });
+
+  it("does not require authentication", async () => {
+    const app = await getApp();
+    // readyz should be accessible without Bearer token
+    const res = await app.inject({ method: "GET", url: "/api/v1/readyz" });
+    expect(res.statusCode).toBe(200);
+    await app.close();
+  });
+});


### PR DESCRIPTION
## Summary\n\n- `/readyz` now checks 4 dimensions instead of just DB connectivity:\n  1. **Database** — `SELECT 1` (critical)\n  2. **Worker health** — `lastPollTimestampMs` stale check, threshold 3× poll interval (critical)\n  3. **Encryption key** — `SECRET_ENCRYPTION_KEY` presence and length (warning)\n  4. **Stuck runs** — STARTING/SYNCING runs older than 5 min (warning)\n- Returns `\"ok\"` / `\"degraded\"` (200) or `\"unavailable\"` (503)\n- Export `lastPollTimestampMs` + `POLL_INTERVAL_MS` from botWorker for observability\n\n## Changed files\n\n| File | Change |\n|------|--------|\n| `apps/api/src/routes/readyz.ts` | Expanded with 4 health checks |\n| `apps/api/src/lib/botWorker.ts` | Added `lastPollTimestampMs` export, updated at end of poll() |\n| `apps/api/tests/routes/readyz.test.ts` | 8 new tests |\n\n## Test plan\n\n- [x] 8 new tests: all checks ok, DB down→503, worker stale→503, worker starting→ok, missing encryption key→degraded, wrong key length→degraded, stuck runs→degraded, no auth required\n- [x] Full suite: 1075 tests pass\n\nhttps://claude.ai/code/session_011E6jWhXQqDUeUt1WN1zru4