### PR TITLE
feat: optimistic locking for BotRun state transitions (#roadmap-v3-20)

### DIFF
--- a/apps/api/prisma/migrations/20260406_add_botrun_version/migration.sql
+++ b/apps/api/prisma/migrations/20260406_add_botrun_version/migration.sql
@@ -1,0 +1,3 @@
+-- Task #20: Add optimistic lock version to BotRun
+-- Additive migration — no data loss, default 0 for existing rows
+ALTER TABLE "BotRun" ADD COLUMN "version" INTEGER NOT NULL DEFAULT 0;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -164,6 +164,8 @@ model BotRun {
   workspaceId     String
   symbol          String
   state           BotRunState  @default(CREATED)
+  /// Optimistic lock version — incremented on every state transition (Task #20)
+  version         Int          @default(0)
   leaseOwner      String?
   leaseUntil      DateTime?
   startedAt       DateTime?

--- a/apps/api/src/lib/stateMachine.ts
+++ b/apps/api/src/lib/stateMachine.ts
@@ -60,6 +60,16 @@ export class RunNotFoundError extends Error {
   }
 }
 
+export class StaleStateError extends Error {
+  constructor(
+    public readonly runId: string,
+    public readonly expectedVersion: number,
+  ) {
+    super(`Optimistic lock conflict on BotRun ${runId} (expected version ${expectedVersion})`);
+    this.name = "StaleStateError";
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Transition function
 // ---------------------------------------------------------------------------
@@ -82,6 +92,7 @@ export interface TransitionOptions {
 export interface TransitionResult {
   id: string;
   state: BotRunState;
+  version: number;
   stoppedAt: Date | null;
   startedAt: Date | null;
   errorCode: string | null;
@@ -91,8 +102,12 @@ export interface TransitionResult {
 /**
  * Atomically transition a BotRun to a new state and record the event.
  *
+ * Uses optimistic locking via `version` field to prevent race conditions
+ * when multiple workers attempt concurrent state transitions (Task #20).
+ *
  * @throws {RunNotFoundError}       if runId doesn't exist
  * @throws {InvalidTransitionError} if the transition is not allowed
+ * @throws {StaleStateError}        if another process already modified the run
  */
 export async function transition(
   runId: string,
@@ -107,6 +122,7 @@ export async function transition(
     throw new InvalidTransitionError(from, to);
   }
 
+  const currentVersion = run.version;
   const now = new Date();
   const eventType = options.eventType ?? `RUN_${to}`;
   const payload: Record<string, unknown> = {
@@ -117,7 +133,10 @@ export async function transition(
     ...(options.meta ?? {}),
   };
 
-  const updateData: Record<string, unknown> = { state: to };
+  const updateData: Record<string, unknown> = {
+    state: to,
+    version: currentVersion + 1,
+  };
   if (to === "RUNNING" && options.startedAt) updateData.startedAt = options.startedAt;
   if (isTerminalState(to)) {
     updateData.stoppedAt = options.stoppedAt ?? now;
@@ -125,18 +144,15 @@ export async function transition(
   }
 
   const updated = await defaultPrisma.$transaction(async (tx) => {
-    const result = await tx.botRun.update({
-      where: { id: runId },
+    // Optimistic lock: only update if version hasn't changed since we read it
+    const result = await tx.botRun.updateMany({
+      where: { id: runId, version: currentVersion },
       data: updateData,
-      select: {
-        id: true,
-        state: true,
-        stoppedAt: true,
-        startedAt: true,
-        errorCode: true,
-        updatedAt: true,
-      },
     });
+
+    if (result.count === 0) {
+      throw new StaleStateError(runId, currentVersion);
+    }
 
     await tx.botEvent.create({
       data: {
@@ -146,7 +162,21 @@ export async function transition(
       },
     });
 
-    return result;
+    // Re-read the updated row to return the result
+    const updated = await tx.botRun.findUniqueOrThrow({
+      where: { id: runId },
+      select: {
+        id: true,
+        state: true,
+        version: true,
+        stoppedAt: true,
+        startedAt: true,
+        errorCode: true,
+        updatedAt: true,
+      },
+    });
+
+    return updated;
   });
 
   return updated as TransitionResult;

--- a/apps/api/tests/lib/stateMachine.test.ts
+++ b/apps/api/tests/lib/stateMachine.test.ts
@@ -1,0 +1,308 @@
+/**
+ * stateMachine.ts — optimistic locking tests (Roadmap V3, Task #20)
+ *
+ * Tests that transition() uses version-based optimistic locking
+ * to prevent race conditions on concurrent state transitions.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockFindUnique = vi.fn();
+const mockUpdateMany = vi.fn();
+const mockFindUniqueOrThrow = vi.fn();
+const mockEventCreate = vi.fn();
+const mockTransaction = vi.fn();
+
+vi.mock("@prisma/client", () => ({
+  Prisma: {
+    sql: vi.fn(),
+    join: vi.fn(),
+  },
+}));
+
+vi.mock("../../src/lib/prisma.js", () => ({
+  prisma: {
+    botRun: {
+      findUnique: (...args: unknown[]) => mockFindUnique(...args),
+    },
+    $transaction: (fn: (tx: unknown) => Promise<unknown>) => {
+      const tx = {
+        botRun: {
+          updateMany: (...args: unknown[]) => mockUpdateMany(...args),
+          findUniqueOrThrow: (...args: unknown[]) => mockFindUniqueOrThrow(...args),
+        },
+        botEvent: {
+          create: (...args: unknown[]) => mockEventCreate(...args),
+        },
+      };
+      return fn(tx);
+    },
+  },
+}));
+
+import {
+  transition,
+  isValidTransition,
+  isTerminalState,
+  InvalidTransitionError,
+  RunNotFoundError,
+  StaleStateError,
+  TERMINAL_STATES,
+} from "../../src/lib/stateMachine.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRun(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "run-1",
+    botId: "bot-1",
+    workspaceId: "ws-1",
+    symbol: "BTCUSDT",
+    state: "QUEUED",
+    version: 0,
+    leaseOwner: null,
+    leaseUntil: null,
+    startedAt: null,
+    stoppedAt: null,
+    errorCode: null,
+    durationMinutes: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pure function tests (no Prisma needed)
+// ---------------------------------------------------------------------------
+
+describe("isValidTransition", () => {
+  it("allows QUEUED → STARTING", () => {
+    expect(isValidTransition("QUEUED", "STARTING")).toBe(true);
+  });
+
+  it("allows RUNNING → FAILED", () => {
+    expect(isValidTransition("RUNNING", "FAILED")).toBe(true);
+  });
+
+  it("rejects FAILED → RUNNING (terminal state)", () => {
+    expect(isValidTransition("FAILED", "RUNNING")).toBe(false);
+  });
+
+  it("rejects STOPPED → anything", () => {
+    expect(isValidTransition("STOPPED", "RUNNING")).toBe(false);
+    expect(isValidTransition("STOPPED", "FAILED")).toBe(false);
+  });
+});
+
+describe("isTerminalState", () => {
+  it("STOPPED is terminal", () => expect(isTerminalState("STOPPED")).toBe(true));
+  it("FAILED is terminal", () => expect(isTerminalState("FAILED")).toBe(true));
+  it("TIMED_OUT is terminal", () => expect(isTerminalState("TIMED_OUT")).toBe(true));
+  it("RUNNING is not terminal", () => expect(isTerminalState("RUNNING")).toBe(false));
+  it("QUEUED is not terminal", () => expect(isTerminalState("QUEUED")).toBe(false));
+});
+
+describe("TERMINAL_STATES", () => {
+  it("contains exactly 3 states", () => {
+    expect(TERMINAL_STATES.size).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Transition with optimistic locking
+// ---------------------------------------------------------------------------
+
+describe("transition() — optimistic locking", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEventCreate.mockResolvedValue(undefined);
+  });
+
+  it("increments version on successful transition", async () => {
+    const run = makeRun({ state: "QUEUED", version: 3 });
+    mockFindUnique.mockResolvedValue(run);
+    mockUpdateMany.mockResolvedValue({ count: 1 });
+    mockFindUniqueOrThrow.mockResolvedValue({
+      ...run,
+      state: "STARTING",
+      version: 4,
+      updatedAt: new Date(),
+    });
+
+    const result = await transition("run-1", "STARTING", {
+      eventType: "RUN_STARTING",
+    });
+
+    expect(result.state).toBe("STARTING");
+    expect(result.version).toBe(4);
+
+    // Verify updateMany was called with version guard
+    expect(mockUpdateMany).toHaveBeenCalledWith({
+      where: { id: "run-1", version: 3 },
+      data: expect.objectContaining({
+        state: "STARTING",
+        version: 4,
+      }),
+    });
+  });
+
+  it("throws StaleStateError when version conflicts (race condition)", async () => {
+    const run = makeRun({ state: "QUEUED", version: 5 });
+    mockFindUnique.mockResolvedValue(run);
+    // Another worker already modified this row — updateMany matches 0 rows
+    mockUpdateMany.mockResolvedValue({ count: 0 });
+
+    await expect(transition("run-1", "STARTING")).rejects.toThrow(StaleStateError);
+    await expect(transition("run-1", "STARTING")).rejects.toThrow(
+      "Optimistic lock conflict",
+    );
+  });
+
+  it("throws RunNotFoundError for non-existent run", async () => {
+    mockFindUnique.mockResolvedValue(null);
+
+    await expect(transition("nonexistent", "STARTING")).rejects.toThrow(
+      RunNotFoundError,
+    );
+  });
+
+  it("throws InvalidTransitionError for illegal transition", async () => {
+    const run = makeRun({ state: "FAILED", version: 2 });
+    mockFindUnique.mockResolvedValue(run);
+
+    await expect(transition("run-1", "RUNNING")).rejects.toThrow(
+      InvalidTransitionError,
+    );
+
+    // updateMany should NOT be called — we reject before hitting DB
+    expect(mockUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it("sets startedAt when transitioning to RUNNING", async () => {
+    const run = makeRun({ state: "SYNCING", version: 2 });
+    mockFindUnique.mockResolvedValue(run);
+    mockUpdateMany.mockResolvedValue({ count: 1 });
+    mockFindUniqueOrThrow.mockResolvedValue({
+      ...run,
+      state: "RUNNING",
+      version: 3,
+      startedAt: new Date(),
+    });
+
+    const startedAt = new Date("2026-04-06T12:00:00Z");
+    await transition("run-1", "RUNNING", { startedAt });
+
+    expect(mockUpdateMany).toHaveBeenCalledWith({
+      where: { id: "run-1", version: 2 },
+      data: expect.objectContaining({
+        state: "RUNNING",
+        version: 3,
+        startedAt,
+      }),
+    });
+  });
+
+  it("sets stoppedAt and errorCode on terminal transitions", async () => {
+    const run = makeRun({ state: "RUNNING", version: 7 });
+    mockFindUnique.mockResolvedValue(run);
+    mockUpdateMany.mockResolvedValue({ count: 1 });
+    mockFindUniqueOrThrow.mockResolvedValue({
+      ...run,
+      state: "FAILED",
+      version: 8,
+      errorCode: "ACTIVATE_CRASH",
+    });
+
+    await transition("run-1", "FAILED", {
+      errorCode: "ACTIVATE_CRASH",
+      message: "crashed",
+    });
+
+    expect(mockUpdateMany).toHaveBeenCalledWith({
+      where: { id: "run-1", version: 7 },
+      data: expect.objectContaining({
+        state: "FAILED",
+        version: 8,
+        stoppedAt: expect.any(Date),
+        errorCode: "ACTIVATE_CRASH",
+      }),
+    });
+  });
+
+  it("creates BotEvent with correct payload", async () => {
+    const run = makeRun({ state: "QUEUED", version: 0 });
+    mockFindUnique.mockResolvedValue(run);
+    mockUpdateMany.mockResolvedValue({ count: 1 });
+    mockFindUniqueOrThrow.mockResolvedValue({
+      ...run,
+      state: "STARTING",
+      version: 1,
+    });
+
+    await transition("run-1", "STARTING", {
+      eventType: "RUN_STARTING",
+      message: "Worker picked up run",
+    });
+
+    expect(mockEventCreate).toHaveBeenCalledWith({
+      data: {
+        botRunId: "run-1",
+        type: "RUN_STARTING",
+        payloadJson: expect.objectContaining({
+          from: "QUEUED",
+          to: "STARTING",
+          message: "Worker picked up run",
+        }),
+      },
+    });
+  });
+
+  it("works starting from version 0 (new run)", async () => {
+    const run = makeRun({ state: "CREATED", version: 0 });
+    mockFindUnique.mockResolvedValue(run);
+    mockUpdateMany.mockResolvedValue({ count: 1 });
+    mockFindUniqueOrThrow.mockResolvedValue({
+      ...run,
+      state: "QUEUED",
+      version: 1,
+    });
+
+    const result = await transition("run-1", "QUEUED");
+    expect(result.version).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error classes
+// ---------------------------------------------------------------------------
+
+describe("error classes", () => {
+  it("StaleStateError has correct properties", () => {
+    const err = new StaleStateError("run-x", 5);
+    expect(err.name).toBe("StaleStateError");
+    expect(err.runId).toBe("run-x");
+    expect(err.expectedVersion).toBe(5);
+    expect(err.message).toContain("run-x");
+    expect(err.message).toContain("5");
+    expect(err instanceof Error).toBe(true);
+  });
+
+  it("InvalidTransitionError has from/to", () => {
+    const err = new InvalidTransitionError("FAILED", "RUNNING");
+    expect(err.from).toBe("FAILED");
+    expect(err.to).toBe("RUNNING");
+    expect(err.message).toContain("FAILED");
+  });
+
+  it("RunNotFoundError has runId", () => {
+    const err = new RunNotFoundError("run-y");
+    expect(err.runId).toBe("run-y");
+  });
+});


### PR DESCRIPTION
## Summary

- Add `version` field (Int, default 0) to BotRun — optimistic lock counter
- `transition()` uses `updateMany` with `WHERE version = N` guard
- If another process already modified the row → `StaleStateError` thrown
- Additive Prisma migration — no data loss, existing rows get version 0
- Prereq for Task #21 (worker extraction to separate process)

## Changed files

| File | Change |
|------|--------|
| `prisma/schema.prisma` | Added `version Int @default(0)` to BotRun |
| `prisma/migrations/20260406_add_botrun_version/migration.sql` | ALTER TABLE ADD COLUMN |
| `src/lib/stateMachine.ts` | updateMany with version guard + StaleStateError |
| `tests/lib/stateMachine.test.ts` | 21 new tests |

## Test plan

- [x] 21 new tests: version increment, conflict detection, error classes, graph validation
- [x] Full suite: 1096 tests pass
- [x] Migration is additive (safe rollback: just drop the column)

https://claude.ai/code/session_011E6jWhXQqDUeUt1WN1zru4