### PR TITLE
feat: dead-letter queue for failed intents (#roadmap-v3-22)

### DIFF
--- a/apps/api/prisma/migrations/20260406_add_intent_retry_count/migration.sql
+++ b/apps/api/prisma/migrations/20260406_add_intent_retry_count/migration.sql
@@ -1,0 +1,3 @@
+-- Task #22: Add retry counter to BotIntent for dead-letter queue
+-- Additive migration — default 0 for existing rows
+ALTER TABLE "BotIntent" ADD COLUMN "retryCount" INTEGER NOT NULL DEFAULT 0;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -246,6 +246,8 @@ model BotIntent {
   cumExecQty  Decimal?    @db.Decimal(18, 8)
   /// Average fill price reported by exchange
   avgFillPrice Decimal?   @db.Decimal(18, 8)
+  /// Number of retry attempts after transient failures (Task #22)
+  retryCount  Int         @default(0)
   /// Extra metadata (e.g., sl/tp prices, retry count, exchange response)
   metaJson    Json?
   createdAt   DateTime    @default(now())

--- a/apps/api/src/lib/botWorker.ts
+++ b/apps/api/src/lib/botWorker.ts
@@ -97,6 +97,9 @@ export let lastPollTimestampMs = 0;
 /** Exported for /readyz to check if worker is alive. */
 export { POLL_INTERVAL_MS };
 
+/** Max retries for transient intent failures before dead-lettering (Task #22). */
+const MAX_INTENT_RETRIES = parseInt(process.env.MAX_INTENT_RETRIES ?? "", 10) || 3;
+
 // Max time a run can stay in RUNNING state before auto-timeout (default: 4 hours)
 const MAX_RUN_DURATION_MS = parseInt(process.env.MAX_RUN_DURATION_MS ?? "", 10) || 4 * 60 * 60 * 1000;
 
@@ -495,6 +498,7 @@ async function executeIntent(intent: {
   side: string;
   qty: { toString: () => string };
   price: { toString: () => string } | null;
+  retryCount: number;
   metaJson: Prisma.JsonValue;
   botRun: {
     id: string;
@@ -631,44 +635,98 @@ async function executeIntent(intent: {
       workerLog.info({ intentId: intent.intentId, orderId: result.orderId }, "intent placed");
     }
   } catch (err) {
-    // Stage 8 (#141): classify execution error for retry/dead-letter semantics
+    // Stage 8 (#141) + Task #22: classify error and decide retry vs dead-letter
     const classification = classifyExecutionError(err);
+    const currentRetry = intent.retryCount;
+    const canRetry = classification.retryable && currentRetry < MAX_INTENT_RETRIES;
 
-    const meta = {
-      ...(intent.metaJson && typeof intent.metaJson === "object" ? intent.metaJson as Record<string, unknown> : {}),
-      error: String(err),
-      errorClass: classification.errorClass,
-      retryable: classification.retryable,
-      classificationReason: classification.reason,
-      failedAt: new Date().toISOString(),
-    };
-    await prisma.botIntent.update({
-      where: { id: intent.id },
-      data: { state: "FAILED", metaJson: meta as Prisma.InputJsonValue },
-    });
-    await prisma.botEvent.create({
-      data: {
-        botRunId: botRun.id,
-        type: "intent_failed",
-        payloadJson: {
+    if (canRetry) {
+      // ── Retry: put back to PENDING with incremented retryCount ──
+      const meta = {
+        ...(intent.metaJson && typeof intent.metaJson === "object" ? intent.metaJson as Record<string, unknown> : {}),
+        lastError: String(err),
+        errorClass: classification.errorClass,
+        retryAttempt: currentRetry + 1,
+        retriedAt: new Date().toISOString(),
+      };
+      await prisma.botIntent.update({
+        where: { id: intent.id },
+        data: {
+          state: "PENDING",
+          retryCount: currentRetry + 1,
+          metaJson: meta as Prisma.InputJsonValue,
+        },
+      });
+      await prisma.botEvent.create({
+        data: {
+          botRunId: botRun.id,
+          type: "intent_retry",
+          payloadJson: {
+            intentId: intent.intentId,
+            error: String(err),
+            errorClass: classification.errorClass,
+            retryAttempt: currentRetry + 1,
+            maxRetries: MAX_INTENT_RETRIES,
+            at: new Date().toISOString(),
+          } as Prisma.InputJsonValue,
+        },
+      });
+      workerLog.warn(
+        {
           intentId: intent.intentId,
-          error: String(err),
           errorClass: classification.errorClass,
-          retryable: classification.retryable,
-          classificationReason: classification.reason,
-          at: new Date().toISOString(),
-        } as Prisma.InputJsonValue,
-      },
-    });
-    workerLog.error(
-      {
-        err,
-        intentId: intent.intentId,
+          retryAttempt: currentRetry + 1,
+          maxRetries: MAX_INTENT_RETRIES,
+        },
+        `executeIntent transient error — retry ${currentRetry + 1}/${MAX_INTENT_RETRIES}`,
+      );
+    } else {
+      // ── Dead-letter: max retries exhausted or permanent error ──
+      const deadLetterReason = classification.retryable
+        ? `max retries exhausted (${currentRetry}/${MAX_INTENT_RETRIES})`
+        : `permanent error: ${classification.reason}`;
+
+      const meta = {
+        ...(intent.metaJson && typeof intent.metaJson === "object" ? intent.metaJson as Record<string, unknown> : {}),
+        error: String(err),
         errorClass: classification.errorClass,
         retryable: classification.retryable,
-      },
-      `executeIntent error (${classification.errorClass})`,
-    );
+        classificationReason: classification.reason,
+        retryCount: currentRetry,
+        deadLetterReason,
+        failedAt: new Date().toISOString(),
+      };
+      await prisma.botIntent.update({
+        where: { id: intent.id },
+        data: { state: "FAILED", metaJson: meta as Prisma.InputJsonValue },
+      });
+      await prisma.botEvent.create({
+        data: {
+          botRunId: botRun.id,
+          type: classification.retryable ? "intent_dead_lettered" : "intent_failed",
+          payloadJson: {
+            intentId: intent.intentId,
+            error: String(err),
+            errorClass: classification.errorClass,
+            retryable: classification.retryable,
+            retryCount: currentRetry,
+            deadLetterReason,
+            at: new Date().toISOString(),
+          } as Prisma.InputJsonValue,
+        },
+      });
+      workerLog.error(
+        {
+          err,
+          intentId: intent.intentId,
+          errorClass: classification.errorClass,
+          retryable: classification.retryable,
+          retryCount: currentRetry,
+          deadLetterReason,
+        },
+        `executeIntent ${classification.retryable ? "dead-lettered" : "permanent failure"}`,
+      );
+    }
   }
 }
 

--- a/apps/api/tests/lib/deadLetterQueue.test.ts
+++ b/apps/api/tests/lib/deadLetterQueue.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Dead-letter queue logic tests (Roadmap V3, Task #22)
+ *
+ * Tests the retry vs dead-letter decision logic in executeIntent's catch block.
+ * Uses pure function approach — verifies decision outcomes, not DB writes.
+ */
+
+import { describe, it, expect } from "vitest";
+import { classifyExecutionError } from "../../src/lib/errorClassifier.js";
+
+// ---------------------------------------------------------------------------
+// Replicate the DLQ decision logic from botWorker's executeIntent catch block
+// ---------------------------------------------------------------------------
+
+const MAX_INTENT_RETRIES = 3;
+
+interface DlqDecision {
+  action: "retry" | "dead_letter" | "permanent_fail";
+  retryAttempt?: number;
+  reason: string;
+}
+
+function decideDlqAction(err: unknown, retryCount: number): DlqDecision {
+  const classification = classifyExecutionError(err);
+  const canRetry = classification.retryable && retryCount < MAX_INTENT_RETRIES;
+
+  if (canRetry) {
+    return {
+      action: "retry",
+      retryAttempt: retryCount + 1,
+      reason: `transient error, retry ${retryCount + 1}/${MAX_INTENT_RETRIES}`,
+    };
+  }
+
+  if (classification.retryable) {
+    return {
+      action: "dead_letter",
+      reason: `max retries exhausted (${retryCount}/${MAX_INTENT_RETRIES})`,
+    };
+  }
+
+  return {
+    action: "permanent_fail",
+    reason: `permanent error: ${classification.reason}`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DLQ decision: transient errors", () => {
+  const transientErrors = [
+    new Error("Bybit API error 10006: too many requests"),
+    new Error("Bybit order request failed: 503 Service Unavailable"),
+    new Error("ECONNRESET"),
+    new Error("fetch failed"),
+    new Error("socket hang up"),
+    new Error("Bybit API error 10018: server timeout"),
+  ];
+
+  for (const err of transientErrors) {
+    it(`retries on first failure: ${err.message.slice(0, 50)}`, () => {
+      const decision = decideDlqAction(err, 0);
+      expect(decision.action).toBe("retry");
+      expect(decision.retryAttempt).toBe(1);
+    });
+
+    it(`retries on second failure: ${err.message.slice(0, 50)}`, () => {
+      const decision = decideDlqAction(err, 1);
+      expect(decision.action).toBe("retry");
+      expect(decision.retryAttempt).toBe(2);
+    });
+
+    it(`retries on third failure: ${err.message.slice(0, 50)}`, () => {
+      const decision = decideDlqAction(err, 2);
+      expect(decision.action).toBe("retry");
+      expect(decision.retryAttempt).toBe(3);
+    });
+
+    it(`dead-letters after max retries: ${err.message.slice(0, 50)}`, () => {
+      const decision = decideDlqAction(err, 3);
+      expect(decision.action).toBe("dead_letter");
+      expect(decision.reason).toContain("max retries exhausted");
+    });
+
+    it(`dead-letters when retryCount exceeds max: ${err.message.slice(0, 50)}`, () => {
+      const decision = decideDlqAction(err, 10);
+      expect(decision.action).toBe("dead_letter");
+    });
+  }
+});
+
+describe("DLQ decision: permanent errors", () => {
+  const permanentErrors = [
+    new Error("Bybit API error 10001: parameter error"),
+    new Error("Bybit API error 110003: insufficient balance"),
+    new Error("Bybit API error 10003: invalid API key"),
+    new Error("Bybit order request failed: 403 Forbidden"),
+    new Error("Order normalization failed: invalid qty"),
+    new Error("SECRET_ENCRYPTION_KEY not configured"),
+  ];
+
+  for (const err of permanentErrors) {
+    it(`immediately fails (no retry): ${err.message.slice(0, 50)}`, () => {
+      const decision = decideDlqAction(err, 0);
+      expect(decision.action).toBe("permanent_fail");
+      expect(decision.reason).toContain("permanent");
+    });
+
+    it(`still fails even with retryCount=0: ${err.message.slice(0, 50)}`, () => {
+      const decision = decideDlqAction(err, 0);
+      expect(decision.action).toBe("permanent_fail");
+    });
+  }
+});
+
+describe("DLQ decision: unknown errors", () => {
+  it("does not retry unknown errors (conservative)", () => {
+    const err = new Error("something completely unexpected");
+    const decision = decideDlqAction(err, 0);
+    expect(decision.action).toBe("permanent_fail");
+  });
+});
+
+describe("DLQ decision: boundary cases", () => {
+  it("retryCount exactly at max → dead letter", () => {
+    const err = new Error("ECONNRESET");
+    const decision = decideDlqAction(err, MAX_INTENT_RETRIES);
+    expect(decision.action).toBe("dead_letter");
+  });
+
+  it("retryCount one below max → still retries", () => {
+    const err = new Error("ECONNRESET");
+    const decision = decideDlqAction(err, MAX_INTENT_RETRIES - 1);
+    expect(decision.action).toBe("retry");
+    expect(decision.retryAttempt).toBe(MAX_INTENT_RETRIES);
+  });
+
+  it("classifyExecutionError is consistent for same input", () => {
+    const err = new Error("Bybit API error 10006: rate limit");
+    const c1 = classifyExecutionError(err);
+    const c2 = classifyExecutionError(err);
+    expect(c1).toEqual(c2);
+  });
+});
+
+describe("DLQ constants", () => {
+  it("MAX_INTENT_RETRIES is 3", () => {
+    expect(MAX_INTENT_RETRIES).toBe(3);
+  });
+
+  it("all transient Bybit retCodes are retryable", () => {
+    for (const code of [10006, 10016, 10018]) {
+      const err = new Error(`Bybit API error ${code}: test`);
+      const c = classifyExecutionError(err);
+      expect(c.retryable).toBe(true);
+      expect(c.errorClass).toBe("transient");
+    }
+  });
+
+  it("all permanent Bybit retCodes are not retryable", () => {
+    for (const code of [10001, 10003, 110003, 170124]) {
+      const err = new Error(`Bybit API error ${code}: test`);
+      const c = classifyExecutionError(err);
+      expect(c.retryable).toBe(false);
+      expect(c.errorClass).toBe("permanent");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Transient errors retry up to 3 times (configurable MAX_INTENT_RETRIES)
- After max retries → FAILED with intent_dead_lettered event
- Permanent errors → immediate FAILED, no retry
- retryCount field added to BotIntent schema
- 49 new tests

https://claude.ai/code/session_011E6jWhXQqDUeUt1WN1zru4