### PR TITLE
feat: global React ErrorBoundary + client error reporting (#roadmap-v3-23)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -20,6 +20,7 @@ import { preferencesRoutes } from "./routes/preferences.js";
 import { usersRoutes } from "./routes/users.js";
 import { demoRoutes } from "./routes/demo.js";
 import { fundingRoutes } from "./routes/funding.js";
+import { clientErrorRoutes } from "./routes/clientErrors.js";
 
 /** Wrap a route plugin with a per-route rate-limit override. */
 function withRateLimit(
@@ -57,6 +58,7 @@ async function registerRoutes(scope: import("fastify").FastifyInstance) {
   await scope.register(preferencesRoutes);
   await scope.register(usersRoutes);
   await scope.register(demoRoutes);
+  await scope.register(withRateLimit(clientErrorRoutes, 10, "1 minute")); // 10 req/min
 }
 
 export async function buildApp() {

--- a/apps/api/src/routes/clientErrors.ts
+++ b/apps/api/src/routes/clientErrors.ts
@@ -1,0 +1,45 @@
+import type { FastifyInstance } from "fastify";
+import { logger } from "../lib/logger.js";
+
+const clientErrorLog = logger.child({ module: "clientError" });
+
+interface ClientErrorBody {
+  message?: string;
+  stack?: string;
+  digest?: string;
+  url?: string;
+  userAgent?: string;
+  timestamp?: string;
+}
+
+/**
+ * POST /client-errors — receive error reports from the frontend (Task #23).
+ *
+ * Public endpoint (no auth required) — the user may hit an error before
+ * they're authenticated. Rate-limited to prevent abuse.
+ */
+export async function clientErrorRoutes(app: FastifyInstance) {
+  app.post<{ Body: ClientErrorBody }>("/client-errors", async (request, reply) => {
+    const { message, stack, digest, url, userAgent, timestamp } = request.body ?? {};
+
+    // Basic validation — reject empty or oversized payloads
+    if (!message || typeof message !== "string") {
+      return reply.status(400).send({ ok: false });
+    }
+
+    clientErrorLog.warn(
+      {
+        errorMessage: message.slice(0, 500),
+        stack: stack?.slice(0, 2000),
+        digest,
+        clientUrl: url?.slice(0, 500),
+        userAgent: userAgent?.slice(0, 300),
+        clientTimestamp: timestamp,
+        ip: request.ip,
+      },
+      "client-side error reported",
+    );
+
+    return reply.status(204).send();
+  });
+}

--- a/apps/api/tests/routes/clientErrors.test.ts
+++ b/apps/api/tests/routes/clientErrors.test.ts
@@ -1,0 +1,103 @@
+/**
+ * POST /client-errors — error reporting endpoint tests (Task #23)
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@prisma/client", () => ({
+  PrismaClient: vi.fn().mockImplementation(() => ({
+    $connect: vi.fn(),
+    $disconnect: vi.fn(),
+  })),
+  Prisma: { sql: vi.fn(), join: vi.fn() },
+}));
+
+vi.mock("../../src/lib/prisma.js", () => ({
+  prisma: {
+    $queryRaw: vi.fn().mockResolvedValue([{ "?column?": 1 }]),
+    $connect: vi.fn(),
+    $disconnect: vi.fn(),
+    botRun: { count: vi.fn().mockResolvedValue(0) },
+  },
+}));
+
+vi.mock("../../src/lib/botWorker.js", () => ({
+  lastPollTimestampMs: Date.now(),
+  POLL_INTERVAL_MS: 4000,
+  startBotWorker: vi.fn(),
+}));
+
+import { buildApp } from "../../src/app.js";
+
+describe("POST /api/v1/client-errors", () => {
+  it("returns 204 for valid error report", async () => {
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/client-errors",
+      payload: {
+        message: "Cannot read property 'foo' of undefined",
+        stack: "TypeError: Cannot read...\n  at Component",
+        url: "https://botmarketplace.store/terminal",
+        timestamp: new Date().toISOString(),
+      },
+    });
+
+    expect(res.statusCode).toBe(204);
+    await app.close();
+  });
+
+  it("returns 400 for missing message", async () => {
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/client-errors",
+      payload: { stack: "some stack" },
+    });
+
+    expect(res.statusCode).toBe(400);
+    await app.close();
+  });
+
+  it("returns 400 for empty body", async () => {
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/client-errors",
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(400);
+    await app.close();
+  });
+
+  it("does not require authentication", async () => {
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/client-errors",
+      payload: { message: "Error before login" },
+    });
+
+    // Should succeed without Bearer token
+    expect(res.statusCode).toBe(204);
+    await app.close();
+  });
+
+  it("accepts minimal payload (message only)", async () => {
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/client-errors",
+      payload: { message: "Something broke" },
+    });
+
+    expect(res.statusCode).toBe(204);
+    await app.close();
+  });
+});

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Global error boundary (Next.js App Router).
+ * Catches unhandled errors from any page and displays a recovery UI.
+ * Reports errors to the backend for monitoring (Task #23).
+ */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    // Report to backend (best-effort, never throw)
+    reportError(error).catch(() => {});
+  }, [error]);
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        minHeight: "60vh",
+        padding: "2rem",
+        textAlign: "center",
+        color: "var(--text-primary)",
+      }}
+    >
+      <h2 style={{ fontSize: "1.5rem", marginBottom: "0.75rem" }}>
+        Something went wrong
+      </h2>
+      <p
+        style={{
+          color: "var(--text-secondary)",
+          marginBottom: "1.5rem",
+          maxWidth: "480px",
+        }}
+      >
+        An unexpected error occurred. You can try again, or go back to the
+        dashboard.
+      </p>
+      {process.env.NODE_ENV !== "production" && (
+        <pre
+          style={{
+            background: "var(--bg-secondary)",
+            border: "1px solid var(--border)",
+            borderRadius: "6px",
+            padding: "1rem",
+            marginBottom: "1.5rem",
+            maxWidth: "600px",
+            overflow: "auto",
+            fontSize: "0.8rem",
+            textAlign: "left",
+            color: "var(--text-secondary)",
+          }}
+        >
+          {error.message}
+          {error.digest && `\nDigest: ${error.digest}`}
+        </pre>
+      )}
+      <div style={{ display: "flex", gap: "0.75rem" }}>
+        <button
+          onClick={reset}
+          style={{
+            padding: "0.5rem 1.25rem",
+            background: "var(--accent)",
+            color: "#fff",
+            border: "none",
+            borderRadius: "6px",
+            cursor: "pointer",
+            fontSize: "0.9rem",
+          }}
+        >
+          Try again
+        </button>
+        <a
+          href="/"
+          style={{
+            padding: "0.5rem 1.25rem",
+            background: "var(--bg-secondary)",
+            color: "var(--text-primary)",
+            border: "1px solid var(--border)",
+            borderRadius: "6px",
+            textDecoration: "none",
+            fontSize: "0.9rem",
+          }}
+        >
+          Go to dashboard
+        </a>
+      </div>
+    </div>
+  );
+}
+
+async function reportError(error: Error & { digest?: string }) {
+  try {
+    const apiBase = process.env.NEXT_PUBLIC_API_URL || "";
+    await fetch(`${apiBase}/api/v1/client-errors`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        message: error.message,
+        stack: error.stack?.slice(0, 2000),
+        digest: error.digest,
+        url: typeof window !== "undefined" ? window.location.href : undefined,
+        userAgent:
+          typeof navigator !== "undefined" ? navigator.userAgent : undefined,
+        timestamp: new Date().toISOString(),
+      }),
+    });
+  } catch {
+    // Swallow — error reporting itself must never crash
+  }
+}


### PR DESCRIPTION
## Summary

- Global error.tsx catches unhandled React errors, shows recovery UI
- POST /client-errors logs frontend errors via pino (no auth, rate-limited)
- Dev mode shows error details, prod shows user-friendly message
- 5 new backend tests

https://claude.ai/code/session_011E6jWhXQqDUeUt1WN1zru4