### PR TITLE
test(api): route tests for bots, runs, strategies (Roadmap V4 Batch 1)

### DIFF
--- a/apps/api/tests/routes/bots.test.ts
+++ b/apps/api/tests/routes/bots.test.ts
@@ -1,0 +1,405 @@
+/**
+ * Route tests: bots.ts — Issue #223 (Roadmap V4, Batch 1, A1)
+ *
+ * Covers: GET /bots, POST /bots, PATCH /bots/:id, GET /bots/:id,
+ *         GET /bots/:id/runs, GET /bots/:id/positions, POST /bots/:id/kill
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from "vitest";
+
+// ── Mock state ──────────────────────────────────────────────────────────────
+
+const mockBots: Record<string, Record<string, unknown>> = {};
+const mockStrategyVersions: Record<string, Record<string, unknown>> = {};
+const mockExchangeConns: Record<string, Record<string, unknown>> = {};
+const mockBotRuns: Record<string, Record<string, unknown>> = {};
+const mockWorkspaceMemberships: Array<Record<string, unknown>> = [];
+let botIdCounter = 0;
+
+// ── Mock Prisma ─────────────────────────────────────────────────────────────
+
+vi.mock("@prisma/client", () => ({
+  PrismaClient: vi.fn().mockImplementation(() => ({})),
+  Prisma: { sql: vi.fn(), join: vi.fn(), JsonNull: "DbNull", InputJsonValue: {} as never },
+}));
+
+vi.mock("../../src/lib/prisma.js", () => ({
+  prisma: {
+    bot: {
+      findMany: vi.fn().mockImplementation(({ where }: { where: { workspaceId: string } }) => {
+        return Promise.resolve(Object.values(mockBots).filter((b) => b.workspaceId === where.workspaceId));
+      }),
+      findUnique: vi.fn().mockImplementation(({ where, include }: { where: { id?: string; workspaceId_name?: { workspaceId: string; name: string } }; include?: unknown }) => {
+        if (where.id) {
+          const bot = mockBots[where.id] ?? null;
+          if (bot && include) {
+            return Promise.resolve({
+              ...bot,
+              strategyVersion: mockStrategyVersions[bot.strategyVersionId as string] ?? null,
+              runs: [],
+            });
+          }
+          return Promise.resolve(bot);
+        }
+        if (where.workspaceId_name) {
+          const match = Object.values(mockBots).find(
+            (b) => b.workspaceId === where.workspaceId_name!.workspaceId && b.name === where.workspaceId_name!.name,
+          );
+          return Promise.resolve(match ?? null);
+        }
+        return Promise.resolve(null);
+      }),
+      create: vi.fn().mockImplementation(({ data }: { data: Record<string, unknown> }) => {
+        const id = `bot-${++botIdCounter}`;
+        const record = { id, ...data, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() };
+        mockBots[id] = record;
+        return Promise.resolve(record);
+      }),
+      update: vi.fn().mockImplementation(({ where, data }: { where: { id: string }; data: Record<string, unknown> }) => {
+        const bot = mockBots[where.id];
+        if (bot) Object.assign(bot, data, { updatedAt: new Date().toISOString() });
+        return Promise.resolve(bot);
+      }),
+    },
+    strategyVersion: {
+      findUnique: vi.fn().mockImplementation(({ where, include }: { where: { id: string }; include?: unknown }) => {
+        const sv = mockStrategyVersions[where.id] ?? null;
+        if (sv && include) {
+          return Promise.resolve({ ...sv, strategy: { workspaceId: sv.workspaceId } });
+        }
+        return Promise.resolve(sv);
+      }),
+    },
+    exchangeConnection: {
+      findUnique: vi.fn().mockImplementation(({ where }: { where: { id: string } }) => {
+        return Promise.resolve(mockExchangeConns[where.id] ?? null);
+      }),
+    },
+    botRun: {
+      findMany: vi.fn().mockImplementation(({ where }: { where: { botId: string } }) => {
+        return Promise.resolve(
+          Object.values(mockBotRuns)
+            .filter((r) => r.botId === where.botId)
+            .sort((a, b) => new Date(b.createdAt as string).getTime() - new Date(a.createdAt as string).getTime()),
+        );
+      }),
+    },
+    position: {
+      findUnique: vi.fn().mockResolvedValue(null),
+    },
+    botIntent: {
+      updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+    },
+    botEvent: {
+      create: vi.fn().mockResolvedValue({}),
+    },
+    workspaceMember: {
+      findUnique: vi.fn().mockImplementation(() => {
+        const m = mockWorkspaceMemberships[0];
+        if (!m) return Promise.resolve(null);
+        return Promise.resolve({ ...m, workspace: { id: m.workspaceId, name: "Test WS" } });
+      }),
+    },
+    $queryRaw: vi.fn().mockResolvedValue([]),
+    $connect: vi.fn(),
+    $disconnect: vi.fn(),
+  },
+}));
+
+// Mock position manager (imports Prisma directly)
+vi.mock("../../src/lib/positionManager.js", () => ({
+  listBotPositions: vi.fn().mockResolvedValue([]),
+  getActiveBotPosition: vi.fn().mockResolvedValue(null),
+  getPositionEvents: vi.fn().mockResolvedValue([]),
+  calcUnrealisedPnl: vi.fn().mockReturnValue(0),
+}));
+
+// Mock DCA bridge
+vi.mock("../../src/lib/runtime/dcaBridge.js", () => ({
+  recoverDcaState: vi.fn().mockReturnValue(null),
+}));
+
+// Mock state machine for kill endpoint
+vi.mock("../../src/lib/stateMachine.js", () => ({
+  transition: vi.fn().mockResolvedValue({}),
+  isValidTransition: vi.fn().mockReturnValue(true),
+  isTerminalState: vi.fn().mockReturnValue(false),
+}));
+
+import { buildApp } from "../../src/app.js";
+import type { FastifyInstance } from "fastify";
+
+// ── Setup ───────────────────────────────────────────────────────────────────
+
+let app: FastifyInstance;
+let token: string;
+const WS_ID = "ws-bot-test";
+const USER_ID = "user-bot-1";
+
+beforeAll(async () => {
+  app = await buildApp();
+  token = app.jwt.sign({ sub: USER_ID, email: "bot@test.com" });
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+beforeEach(() => {
+  Object.keys(mockBots).forEach((k) => delete mockBots[k]);
+  Object.keys(mockStrategyVersions).forEach((k) => delete mockStrategyVersions[k]);
+  Object.keys(mockExchangeConns).forEach((k) => delete mockExchangeConns[k]);
+  Object.keys(mockBotRuns).forEach((k) => delete mockBotRuns[k]);
+  mockWorkspaceMemberships.length = 0;
+  botIdCounter = 0;
+
+  mockWorkspaceMemberships.push({ userId: USER_ID, workspaceId: WS_ID, role: "OWNER" });
+
+  // Seed a strategy version
+  mockStrategyVersions["sv-1"] = {
+    id: "sv-1", strategyId: "strat-1", version: 1,
+    workspaceId: WS_ID, strategy: { workspaceId: WS_ID },
+    dslJson: {}, executionPlanJson: {},
+  };
+
+  // Seed an exchange connection
+  mockExchangeConns["conn-1"] = { id: "conn-1", workspaceId: WS_ID };
+});
+
+function headers() {
+  return { authorization: `Bearer ${token}`, "x-workspace-id": WS_ID };
+}
+
+function seedBot(name = "TestBot", overrides: Record<string, unknown> = {}) {
+  const id = `bot-${++botIdCounter}`;
+  const record = {
+    id, workspaceId: WS_ID, name, symbol: "BTCUSDT", timeframe: "M15",
+    status: "DRAFT", strategyVersionId: "sv-1", exchangeConnectionId: null,
+    createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+  mockBots[id] = record;
+  return record;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("GET /api/v1/bots", () => {
+  it("returns 200 with empty list", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/v1/bots", headers: headers() });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual([]);
+  });
+
+  it("returns bots for the workspace", async () => {
+    seedBot("Bot A");
+    seedBot("Bot B");
+    const res = await app.inject({ method: "GET", url: "/api/v1/bots", headers: headers() });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toHaveLength(2);
+  });
+
+  it("returns 401 without token", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/v1/bots" });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns 400 without X-Workspace-Id", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/v1/bots", headers: { authorization: `Bearer ${token}` } });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 403 for non-member workspace", async () => {
+    mockWorkspaceMemberships.length = 0;
+    const res = await app.inject({ method: "GET", url: "/api/v1/bots", headers: headers() });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+describe("POST /api/v1/bots", () => {
+  it("creates a bot (201)", async () => {
+    const res = await app.inject({
+      method: "POST", url: "/api/v1/bots",
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: { name: "NewBot", strategyVersionId: "sv-1", symbol: "ETHUSDT", timeframe: "H1" },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(res.json().name).toBe("NewBot");
+    expect(res.json().status).toBe("DRAFT");
+  });
+
+  it("returns 400 for missing required fields", async () => {
+    const res = await app.inject({
+      method: "POST", url: "/api/v1/bots",
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: { name: "X" },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 400 for invalid timeframe", async () => {
+    const res = await app.inject({
+      method: "POST", url: "/api/v1/bots",
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: { name: "X", strategyVersionId: "sv-1", symbol: "BTC", timeframe: "BAD" },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 400 for nonexistent strategyVersionId", async () => {
+    const res = await app.inject({
+      method: "POST", url: "/api/v1/bots",
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: { name: "X", strategyVersionId: "nonexistent", symbol: "BTC", timeframe: "M15" },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 409 for duplicate name", async () => {
+    seedBot("DupeBot");
+    const res = await app.inject({
+      method: "POST", url: "/api/v1/bots",
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: { name: "DupeBot", strategyVersionId: "sv-1", symbol: "BTC", timeframe: "M15" },
+    });
+    expect(res.statusCode).toBe(409);
+  });
+
+  it("accepts optional exchangeConnectionId", async () => {
+    const res = await app.inject({
+      method: "POST", url: "/api/v1/bots",
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: { name: "ConnBot", strategyVersionId: "sv-1", symbol: "BTC", timeframe: "M15", exchangeConnectionId: "conn-1" },
+    });
+    expect(res.statusCode).toBe(201);
+  });
+
+  it("returns 400 for nonexistent exchangeConnectionId", async () => {
+    const res = await app.inject({
+      method: "POST", url: "/api/v1/bots",
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: { name: "Bad", strategyVersionId: "sv-1", symbol: "BTC", timeframe: "M15", exchangeConnectionId: "bad" },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe("GET /api/v1/bots/:id", () => {
+  it("returns bot with details", async () => {
+    const bot = seedBot("DetailBot");
+    const res = await app.inject({ method: "GET", url: `/api/v1/bots/${bot.id}`, headers: headers() });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().name).toBe("DetailBot");
+  });
+
+  it("returns 404 for nonexistent id", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/v1/bots/nope", headers: headers() });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 404 for bot in another workspace", async () => {
+    const id = `bot-${++botIdCounter}`;
+    mockBots[id] = { id, workspaceId: "ws-other", name: "Secret", status: "DRAFT" };
+    const res = await app.inject({ method: "GET", url: `/api/v1/bots/${id}`, headers: headers() });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("PATCH /api/v1/bots/:id", () => {
+  it("updates bot name", async () => {
+    const bot = seedBot("OldName");
+    const res = await app.inject({
+      method: "PATCH", url: `/api/v1/bots/${bot.id}`,
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: { name: "NewName" },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("returns 404 for nonexistent bot", async () => {
+    const res = await app.inject({
+      method: "PATCH", url: "/api/v1/bots/nope",
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: { name: "X" },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 409 for duplicate name on update", async () => {
+    seedBot("Existing");
+    const bot = seedBot("Rename");
+    const res = await app.inject({
+      method: "PATCH", url: `/api/v1/bots/${bot.id}`,
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: { name: "Existing" },
+    });
+    expect(res.statusCode).toBe(409);
+  });
+
+  it("returns 400 for empty body", async () => {
+    const bot = seedBot("NoChange");
+    const res = await app.inject({
+      method: "PATCH", url: `/api/v1/bots/${bot.id}`,
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: {},
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe("GET /api/v1/bots/:id/runs", () => {
+  it("returns runs for a bot", async () => {
+    const bot = seedBot("RunBot");
+    mockBotRuns["run-1"] = { id: "run-1", botId: bot.id, state: "STOPPED", createdAt: new Date().toISOString() };
+    const res = await app.inject({ method: "GET", url: `/api/v1/bots/${bot.id}/runs`, headers: headers() });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toHaveLength(1);
+  });
+
+  it("returns 404 for nonexistent bot", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/v1/bots/nope/runs", headers: headers() });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("GET /api/v1/bots/:id/positions", () => {
+  it("returns 200 with positions array", async () => {
+    const bot = seedBot("PosBot");
+    const res = await app.inject({ method: "GET", url: `/api/v1/bots/${bot.id}/positions`, headers: headers() });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual([]);
+  });
+
+  it("returns 404 for nonexistent bot", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/v1/bots/nope/positions", headers: headers() });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("POST /api/v1/bots/:id/kill", () => {
+  it("kills a bot with active runs", async () => {
+    const bot = seedBot("KillBot");
+    mockBotRuns["run-kill"] = { id: "run-kill", botId: bot.id, state: "RUNNING" };
+    const res = await app.inject({
+      method: "POST", url: `/api/v1/bots/${bot.id}/kill`,
+      headers: headers(),
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().killed).toBe(true);
+  });
+
+  it("returns 404 for nonexistent bot", async () => {
+    const res = await app.inject({ method: "POST", url: "/api/v1/bots/nope/kill", headers: headers() });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("is safe to kill a bot with no active runs", async () => {
+    const bot = seedBot("IdleBot");
+    const res = await app.inject({ method: "POST", url: `/api/v1/bots/${bot.id}/kill`, headers: headers() });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().killed).toBe(true);
+    expect(res.json().stoppedRuns).toEqual([]);
+  });
+});

--- a/apps/api/tests/routes/runs.test.ts
+++ b/apps/api/tests/routes/runs.test.ts
@@ -1,0 +1,440 @@
+/**
+ * Route tests: runs.ts — Issue #224 (Roadmap V4, Batch 1, A2)
+ *
+ * Covers: POST /bots/:botId/runs, GET /bots/:botId/runs/:runId, GET /runs/:runId,
+ *         POST /bots/:botId/runs/:runId/stop, POST /runs/stop-all,
+ *         PATCH /runs/:runId/state, POST /runs/:runId/heartbeat,
+ *         GET /runs/:runId/events, POST /runs/:runId/signal, POST /runs/reconcile
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from "vitest";
+
+// ── Mock state ──────────────────────────────────────────────────────────────
+
+const mockBots: Record<string, Record<string, unknown>> = {};
+const mockBotRuns: Record<string, Record<string, unknown>> = {};
+const mockBotEvents: Array<Record<string, unknown>> = [];
+const mockBotIntents: Record<string, Record<string, unknown>> = {};
+const mockWorkspaceMemberships: Array<Record<string, unknown>> = [];
+let runIdCounter = 0;
+
+// ── Mock Prisma ─────────────────────────────────────────────────────────────
+
+vi.mock("@prisma/client", () => ({
+  PrismaClient: vi.fn().mockImplementation(() => ({})),
+  Prisma: { sql: vi.fn(), join: vi.fn(), JsonNull: "DbNull", InputJsonValue: {} as never },
+  BotRunState: {},
+}));
+
+vi.mock("../../src/lib/prisma.js", () => ({
+  prisma: {
+    bot: {
+      findUnique: vi.fn().mockImplementation(({ where }: { where: { id: string } }) => {
+        return Promise.resolve(mockBots[where.id] ?? null);
+      }),
+    },
+    botRun: {
+      findUnique: vi.fn().mockImplementation(({ where }: { where: { id: string } }) => {
+        return Promise.resolve(mockBotRuns[where.id] ?? null);
+      }),
+      findFirst: vi.fn().mockImplementation(({ where }: { where: { botId: string; state?: unknown } }) => {
+        const match = Object.values(mockBotRuns).find(
+          (r) => r.botId === where.botId && !["STOPPED", "FAILED", "TIMED_OUT"].includes(r.state as string),
+        );
+        return Promise.resolve(match ?? null);
+      }),
+      findMany: vi.fn().mockImplementation(({ where }: { where: { workspaceId?: string; botId?: string } }) => {
+        let results = Object.values(mockBotRuns);
+        if (where.workspaceId) results = results.filter((r) => r.workspaceId === where.workspaceId);
+        if (where.botId) results = results.filter((r) => r.botId === where.botId);
+        return Promise.resolve(results);
+      }),
+      create: vi.fn().mockImplementation(({ data }: { data: Record<string, unknown> }) => {
+        const id = `run-${++runIdCounter}`;
+        const record = { id, ...data, version: 0, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() };
+        mockBotRuns[id] = record;
+        return Promise.resolve(record);
+      }),
+      update: vi.fn().mockImplementation(({ where, data }: { where: { id: string }; data: Record<string, unknown> }) => {
+        const run = mockBotRuns[where.id];
+        if (run) Object.assign(run, data, { updatedAt: new Date().toISOString() });
+        return Promise.resolve(run);
+      }),
+    },
+    botEvent: {
+      findMany: vi.fn().mockImplementation(() => Promise.resolve(mockBotEvents)),
+      create: vi.fn().mockImplementation(({ data }: { data: Record<string, unknown> }) => {
+        const record = { id: `evt-${Date.now()}`, ...data, ts: new Date() };
+        mockBotEvents.push(record);
+        return Promise.resolve(record);
+      }),
+    },
+    botIntent: {
+      findUnique: vi.fn().mockImplementation(({ where }: { where: { botRunId_intentId?: { botRunId: string; intentId: string } } }) => {
+        if (where.botRunId_intentId) {
+          const key = `${where.botRunId_intentId.botRunId}:${where.botRunId_intentId.intentId}`;
+          return Promise.resolve(mockBotIntents[key] ?? null);
+        }
+        return Promise.resolve(null);
+      }),
+      create: vi.fn().mockImplementation(({ data }: { data: Record<string, unknown> }) => {
+        const record = { id: `intent-${Date.now()}`, ...data, createdAt: new Date(), updatedAt: new Date() };
+        const key = `${data.botRunId}:${data.intentId}`;
+        mockBotIntents[key] = record;
+        return Promise.resolve(record);
+      }),
+    },
+    workspaceMember: {
+      findUnique: vi.fn().mockImplementation(() => {
+        const m = mockWorkspaceMemberships[0];
+        if (!m) return Promise.resolve(null);
+        return Promise.resolve({ ...m, workspace: { id: m.workspaceId, name: "Test WS" } });
+      }),
+    },
+    $transaction: vi.fn().mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      // Simulate transaction by passing the prisma mock itself
+      const { prisma } = await import("../../src/lib/prisma.js");
+      return fn(prisma);
+    }),
+    $queryRaw: vi.fn().mockResolvedValue([]),
+    $connect: vi.fn(),
+    $disconnect: vi.fn(),
+  },
+}));
+
+// Mock state machine
+const mockTransition = vi.fn().mockImplementation(async (runId: string, toState: string) => {
+  const run = mockBotRuns[runId];
+  if (run) {
+    run.state = toState;
+    if (toState === "STOPPED") run.stoppedAt = new Date().toISOString();
+  }
+  return run;
+});
+
+vi.mock("../../src/lib/stateMachine.js", () => ({
+  transition: (...args: unknown[]) => mockTransition(...args),
+  isTerminalState: vi.fn().mockImplementation((state: string) => ["STOPPED", "FAILED", "TIMED_OUT"].includes(state)),
+  isValidTransition: vi.fn().mockReturnValue(true),
+  InvalidTransitionError: class extends Error { constructor(m: string) { super(m); this.name = "InvalidTransitionError"; } },
+  RunNotFoundError: class extends Error { constructor(m: string) { super(m); this.name = "RunNotFoundError"; } },
+}));
+
+import { buildApp } from "../../src/app.js";
+import type { FastifyInstance } from "fastify";
+
+// ── Setup ───────────────────────────────────────────────────────────────────
+
+let app: FastifyInstance;
+let token: string;
+const WS_ID = "ws-run-test";
+const USER_ID = "user-run-1";
+const BOT_ID = "bot-run-1";
+
+beforeAll(async () => {
+  app = await buildApp();
+  token = app.jwt.sign({ sub: USER_ID, email: "run@test.com" });
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+beforeEach(() => {
+  Object.keys(mockBots).forEach((k) => delete mockBots[k]);
+  Object.keys(mockBotRuns).forEach((k) => delete mockBotRuns[k]);
+  Object.keys(mockBotIntents).forEach((k) => delete mockBotIntents[k]);
+  mockBotEvents.length = 0;
+  mockWorkspaceMemberships.length = 0;
+  runIdCounter = 0;
+  mockTransition.mockClear();
+
+  mockWorkspaceMemberships.push({ userId: USER_ID, workspaceId: WS_ID, role: "OWNER" });
+  mockBots[BOT_ID] = { id: BOT_ID, workspaceId: WS_ID, name: "TestBot", symbol: "BTCUSDT" };
+});
+
+function headers() {
+  return { authorization: `Bearer ${token}`, "x-workspace-id": WS_ID };
+}
+
+function seedRun(state = "RUNNING", botId = BOT_ID) {
+  const id = `run-${++runIdCounter}`;
+  const record = { id, botId, workspaceId: WS_ID, symbol: "BTCUSDT", state, version: 0, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() };
+  mockBotRuns[id] = record;
+  return record;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("POST /api/v1/bots/:botId/runs (start run)", () => {
+  it("creates a run (201)", async () => {
+    const res = await app.inject({
+      method: "POST", url: `/api/v1/bots/${BOT_ID}/runs`,
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: {},
+    });
+    expect(res.statusCode).toBe(201);
+  });
+
+  it("returns 404 for nonexistent bot", async () => {
+    const res = await app.inject({
+      method: "POST", url: "/api/v1/bots/nonexistent/runs",
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: {},
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 409 when active run already exists", async () => {
+    seedRun("RUNNING");
+    const res = await app.inject({
+      method: "POST", url: `/api/v1/bots/${BOT_ID}/runs`,
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: {},
+    });
+    expect(res.statusCode).toBe(409);
+  });
+
+  it("accepts optional durationMinutes", async () => {
+    const res = await app.inject({
+      method: "POST", url: `/api/v1/bots/${BOT_ID}/runs`,
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: { durationMinutes: 60 },
+    });
+    expect(res.statusCode).toBe(201);
+  });
+
+  it("returns 400 for invalid durationMinutes", async () => {
+    const res = await app.inject({
+      method: "POST", url: `/api/v1/bots/${BOT_ID}/runs`,
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: { durationMinutes: 9999 },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 401 without auth", async () => {
+    const res = await app.inject({
+      method: "POST", url: `/api/v1/bots/${BOT_ID}/runs`,
+      headers: { "content-type": "application/json" },
+      payload: {},
+    });
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe("GET /api/v1/bots/:botId/runs/:runId", () => {
+  it("returns a specific run", async () => {
+    const run = seedRun("RUNNING");
+    const res = await app.inject({ method: "GET", url: `/api/v1/bots/${BOT_ID}/runs/${run.id}`, headers: headers() });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().id).toBe(run.id);
+  });
+
+  it("returns 404 for nonexistent run", async () => {
+    const res = await app.inject({ method: "GET", url: `/api/v1/bots/${BOT_ID}/runs/nope`, headers: headers() });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("GET /api/v1/runs/:runId", () => {
+  it("returns run by ID within workspace", async () => {
+    const run = seedRun("QUEUED");
+    const res = await app.inject({ method: "GET", url: `/api/v1/runs/${run.id}`, headers: headers() });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("returns 404 for run in another workspace", async () => {
+    const id = `run-${++runIdCounter}`;
+    mockBotRuns[id] = { id, botId: BOT_ID, workspaceId: "ws-other", state: "RUNNING" };
+    const res = await app.inject({ method: "GET", url: `/api/v1/runs/${id}`, headers: headers() });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("POST /api/v1/bots/:botId/runs/:runId/stop", () => {
+  it("stops a running run", async () => {
+    const run = seedRun("RUNNING");
+    const res = await app.inject({
+      method: "POST", url: `/api/v1/bots/${BOT_ID}/runs/${run.id}/stop`,
+      headers: headers(),
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("returns 404 for nonexistent run", async () => {
+    const res = await app.inject({
+      method: "POST", url: `/api/v1/bots/${BOT_ID}/runs/nope/stop`,
+      headers: headers(),
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 409 for already stopped run", async () => {
+    const run = seedRun("STOPPED");
+    const res = await app.inject({
+      method: "POST", url: `/api/v1/bots/${BOT_ID}/runs/${run.id}/stop`,
+      headers: headers(),
+    });
+    expect(res.statusCode).toBe(409);
+  });
+});
+
+describe("POST /api/v1/runs/stop-all", () => {
+  it("stops all active runs in workspace", async () => {
+    seedRun("RUNNING");
+    seedRun("QUEUED");
+    const res = await app.inject({ method: "POST", url: "/api/v1/runs/stop-all", headers: headers() });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.total).toBe(2);
+  });
+
+  it("returns empty when no active runs", async () => {
+    const res = await app.inject({ method: "POST", url: "/api/v1/runs/stop-all", headers: headers() });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().total).toBe(0);
+  });
+});
+
+describe("PATCH /api/v1/runs/:runId/state", () => {
+  it("advances run state", async () => {
+    const run = seedRun("QUEUED");
+    const res = await app.inject({
+      method: "PATCH", url: `/api/v1/runs/${run.id}/state`,
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: { state: "RUNNING", message: "Worker acquired" },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("returns 404 for nonexistent run", async () => {
+    const res = await app.inject({
+      method: "PATCH", url: "/api/v1/runs/nope/state",
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: { state: "RUNNING" },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 400 for missing state in body", async () => {
+    const run = seedRun("QUEUED");
+    const res = await app.inject({
+      method: "PATCH", url: `/api/v1/runs/${run.id}/state`,
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: {},
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe("POST /api/v1/runs/:runId/heartbeat", () => {
+  it("renews lease for a running run", async () => {
+    const run = seedRun("RUNNING");
+    const res = await app.inject({
+      method: "POST", url: `/api/v1/runs/${run.id}/heartbeat`,
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: { workerId: "worker-1" },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("returns 409 for terminal run", async () => {
+    const run = seedRun("STOPPED");
+    const res = await app.inject({
+      method: "POST", url: `/api/v1/runs/${run.id}/heartbeat`,
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: { workerId: "worker-1" },
+    });
+    expect(res.statusCode).toBe(409);
+  });
+});
+
+describe("GET /api/v1/runs/:runId/events", () => {
+  it("returns events list", async () => {
+    const run = seedRun("RUNNING");
+    mockBotEvents.push({ id: "e1", botRunId: run.id, type: "signal", ts: new Date(), payloadJson: {} });
+    const res = await app.inject({ method: "GET", url: `/api/v1/runs/${run.id}/events`, headers: headers() });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toHaveLength(1);
+  });
+
+  it("returns 404 for nonexistent run", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/v1/runs/nope/events", headers: headers() });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("POST /api/v1/runs/:runId/signal", () => {
+  it("creates a signal intent (201)", async () => {
+    const run = seedRun("RUNNING");
+    const res = await app.inject({
+      method: "POST", url: `/api/v1/runs/${run.id}/signal`,
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: { side: "BUY", qty: 0.01 },
+    });
+    expect(res.statusCode).toBe(201);
+  });
+
+  it("returns 409 for non-RUNNING run", async () => {
+    const run = seedRun("QUEUED");
+    const res = await app.inject({
+      method: "POST", url: `/api/v1/runs/${run.id}/signal`,
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: { side: "BUY", qty: 0.01 },
+    });
+    expect(res.statusCode).toBe(409);
+  });
+
+  it("returns 400 for invalid side", async () => {
+    const run = seedRun("RUNNING");
+    const res = await app.inject({
+      method: "POST", url: `/api/v1/runs/${run.id}/signal`,
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: { side: "INVALID", qty: 0.01 },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 400 for non-positive qty", async () => {
+    const run = seedRun("RUNNING");
+    const res = await app.inject({
+      method: "POST", url: `/api/v1/runs/${run.id}/signal`,
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: { side: "BUY", qty: -1 },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("idempotent: returns existing intent for same intentId", async () => {
+    const run = seedRun("RUNNING");
+    // First call
+    const res1 = await app.inject({
+      method: "POST", url: `/api/v1/runs/${run.id}/signal`,
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: { side: "BUY", qty: 0.01, intentId: "idem-1" },
+    });
+    expect(res1.statusCode).toBe(201);
+
+    // Second call with same intentId
+    const res2 = await app.inject({
+      method: "POST", url: `/api/v1/runs/${run.id}/signal`,
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: { side: "BUY", qty: 0.01, intentId: "idem-1" },
+    });
+    expect(res2.statusCode).toBe(200);
+  });
+});
+
+describe("POST /api/v1/runs/reconcile", () => {
+  it("reconciles stale runs", async () => {
+    const res = await app.inject({ method: "POST", url: "/api/v1/runs/reconcile", headers: headers() });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().at).toBeDefined();
+  });
+
+  it("returns 401 without auth", async () => {
+    const res = await app.inject({ method: "POST", url: "/api/v1/runs/reconcile" });
+    expect(res.statusCode).toBe(401);
+  });
+});

--- a/apps/api/tests/routes/strategies.test.ts
+++ b/apps/api/tests/routes/strategies.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Route tests: strategies.ts — Issue #225 (Roadmap V4, Batch 1, A3)
+ *
+ * Covers: GET/POST /strategies, GET /strategies/:id,
+ *         POST /strategies/:id/versions, POST /strategies/validate
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from "vitest";
+
+// ── Mock state ──────────────────────────────────────────────────────────────
+
+const mockStrategies: Record<string, Record<string, unknown>> = {};
+const mockVersions: Record<string, Record<string, unknown>> = {};
+const mockWorkspaceMemberships: Array<Record<string, unknown>> = [];
+let strategyIdCounter = 0;
+let versionIdCounter = 0;
+
+// ── Mock Prisma ─────────────────────────────────────────────────────────────
+
+vi.mock("@prisma/client", () => ({
+  PrismaClient: vi.fn().mockImplementation(() => ({})),
+  Prisma: { sql: vi.fn(), join: vi.fn(), JsonNull: "DbNull" },
+}));
+
+vi.mock("../../src/lib/prisma.js", () => ({
+  prisma: {
+    strategy: {
+      findMany: vi.fn().mockImplementation(({ where }: { where: { workspaceId: string } }) => {
+        const results = Object.values(mockStrategies).filter(
+          (s) => s.workspaceId === where.workspaceId,
+        );
+        return Promise.resolve(results.sort((a, b) =>
+          new Date(b.createdAt as string).getTime() - new Date(a.createdAt as string).getTime(),
+        ));
+      }),
+      findUnique: vi.fn().mockImplementation(({ where }: { where: { id?: string; workspaceId_name?: { workspaceId: string; name: string } } }) => {
+        if (where.id) {
+          return Promise.resolve(mockStrategies[where.id] ?? null);
+        }
+        if (where.workspaceId_name) {
+          const match = Object.values(mockStrategies).find(
+            (s) => s.workspaceId === where.workspaceId_name!.workspaceId && s.name === where.workspaceId_name!.name,
+          );
+          return Promise.resolve(match ?? null);
+        }
+        return Promise.resolve(null);
+      }),
+      create: vi.fn().mockImplementation(({ data }: { data: Record<string, unknown> }) => {
+        const id = `strat-${++strategyIdCounter}`;
+        const record = { id, ...data, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() };
+        mockStrategies[id] = record;
+        return Promise.resolve(record);
+      }),
+    },
+    strategyVersion: {
+      findFirst: vi.fn().mockImplementation(({ where }: { where: { strategyId: string } }) => {
+        const versions = Object.values(mockVersions).filter(
+          (v) => v.strategyId === where.strategyId,
+        );
+        if (versions.length === 0) return Promise.resolve(null);
+        return Promise.resolve(versions.sort((a, b) => (b.version as number) - (a.version as number))[0]);
+      }),
+      create: vi.fn().mockImplementation(({ data }: { data: Record<string, unknown> }) => {
+        const id = `ver-${++versionIdCounter}`;
+        const record = { id, ...data, createdAt: new Date().toISOString() };
+        mockVersions[id] = record;
+        return Promise.resolve(record);
+      }),
+    },
+    workspaceMember: {
+      findUnique: vi.fn().mockImplementation(() => {
+        const m = mockWorkspaceMemberships[0];
+        if (!m) return Promise.resolve(null);
+        return Promise.resolve({ ...m, workspace: { id: m.workspaceId, name: "Test WS" } });
+      }),
+    },
+    $queryRaw: vi.fn().mockResolvedValue([]),
+    $connect: vi.fn(),
+    $disconnect: vi.fn(),
+  },
+}));
+
+import { buildApp } from "../../src/app.js";
+import type { FastifyInstance } from "fastify";
+
+// ── Setup ───────────────────────────────────────────────────────────────────
+
+let app: FastifyInstance;
+let token: string;
+const WS_ID = "ws-strat-test";
+const USER_ID = "user-strat-1";
+
+beforeAll(async () => {
+  app = await buildApp();
+  token = app.jwt.sign({ sub: USER_ID, email: "strat@test.com" });
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+beforeEach(() => {
+  Object.keys(mockStrategies).forEach((k) => delete mockStrategies[k]);
+  Object.keys(mockVersions).forEach((k) => delete mockVersions[k]);
+  mockWorkspaceMemberships.length = 0;
+  strategyIdCounter = 0;
+  versionIdCounter = 0;
+
+  mockWorkspaceMemberships.push({ userId: USER_ID, workspaceId: WS_ID, role: "OWNER" });
+});
+
+function headers() {
+  return { authorization: `Bearer ${token}`, "x-workspace-id": WS_ID };
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function seedStrategy(name = "Test Strategy", symbol = "BTCUSDT", timeframe = "M15") {
+  const id = `strat-${++strategyIdCounter}`;
+  const record = { id, workspaceId: WS_ID, name, symbol, timeframe, status: "DRAFT", createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() };
+  mockStrategies[id] = record;
+  return record;
+}
+
+// Minimal valid DSL v2 for testing
+const VALID_DSL = {
+  id: "test-1", name: "Test", dslVersion: 2, enabled: true,
+  market: { exchange: "bybit", env: "demo", category: "linear", symbol: "BTCUSDT" },
+  timeframes: ["M15"],
+  entry: {
+    side: "Buy",
+    signal: { type: "crossover", fast: { blockType: "SMA", length: 10 }, slow: { blockType: "SMA", length: 20 } },
+    indicators: [{ type: "SMA", length: 10 }, { type: "SMA", length: 20 }],
+  },
+  exit: {
+    stopLoss: { type: "fixed_pct", value: 2.0 },
+    takeProfit: { type: "fixed_pct", value: 4.0 },
+  },
+  risk: { maxPositionSizeUsd: 100, riskPerTradePct: 2.0, cooldownSeconds: 60 },
+  execution: { orderType: "Market", clientOrderIdPrefix: "test_", maxSlippageBps: 50 },
+  guards: { maxOpenPositions: 1, maxOrdersPerMinute: 10, pauseOnError: true },
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("GET /api/v1/strategies", () => {
+  it("returns 200 with empty list", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/v1/strategies", headers: headers() });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual([]);
+  });
+
+  it("returns strategies for the workspace", async () => {
+    seedStrategy("Alpha");
+    seedStrategy("Beta");
+    const res = await app.inject({ method: "GET", url: "/api/v1/strategies", headers: headers() });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body).toHaveLength(2);
+  });
+
+  it("returns 401 without token", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/v1/strategies" });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns 400 without X-Workspace-Id", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/v1/strategies", headers: { authorization: `Bearer ${token}` } });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 403 for non-member workspace", async () => {
+    mockWorkspaceMemberships.length = 0;
+    const res = await app.inject({ method: "GET", url: "/api/v1/strategies", headers: headers() });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+describe("POST /api/v1/strategies", () => {
+  it("creates a strategy (201)", async () => {
+    const res = await app.inject({
+      method: "POST", url: "/api/v1/strategies",
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: { name: "My Strat", symbol: "ETHUSDT", timeframe: "H1" },
+    });
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.name).toBe("My Strat");
+    expect(body.symbol).toBe("ETHUSDT");
+    expect(body.status).toBe("DRAFT");
+  });
+
+  it("returns 400 for missing fields", async () => {
+    const res = await app.inject({
+      method: "POST", url: "/api/v1/strategies",
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: { name: "X" },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 400 for invalid timeframe", async () => {
+    const res = await app.inject({
+      method: "POST", url: "/api/v1/strategies",
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: { name: "X", symbol: "BTCUSDT", timeframe: "INVALID" },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 409 for duplicate name in workspace", async () => {
+    seedStrategy("Dupe");
+    const res = await app.inject({
+      method: "POST", url: "/api/v1/strategies",
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: { name: "Dupe", symbol: "BTCUSDT", timeframe: "M15" },
+    });
+    expect(res.statusCode).toBe(409);
+  });
+
+  it("returns 401 without auth", async () => {
+    const res = await app.inject({
+      method: "POST", url: "/api/v1/strategies",
+      headers: { "content-type": "application/json" },
+      payload: { name: "X", symbol: "BTCUSDT", timeframe: "M15" },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe("GET /api/v1/strategies/:id", () => {
+  it("returns strategy with versions", async () => {
+    const strat = seedStrategy("Lookup");
+    const res = await app.inject({ method: "GET", url: `/api/v1/strategies/${strat.id}`, headers: headers() });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().name).toBe("Lookup");
+  });
+
+  it("returns 404 for nonexistent id", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/v1/strategies/nonexistent", headers: headers() });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 404 for strategy in another workspace", async () => {
+    const id = `strat-${++strategyIdCounter}`;
+    mockStrategies[id] = { id, workspaceId: "ws-other", name: "Secret", symbol: "BTC", timeframe: "M15", status: "DRAFT", createdAt: new Date().toISOString() };
+    const res = await app.inject({ method: "GET", url: `/api/v1/strategies/${id}`, headers: headers() });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("POST /api/v1/strategies/:id/versions", () => {
+  it("creates a version with valid DSL (201)", async () => {
+    const strat = seedStrategy("Versioned");
+    const res = await app.inject({
+      method: "POST", url: `/api/v1/strategies/${strat.id}/versions`,
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: { dslJson: VALID_DSL },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(res.json().strategyId).toBe(strat.id);
+    expect(res.json().version).toBe(1);
+  });
+
+  it("returns 400 for invalid DSL", async () => {
+    const strat = seedStrategy("BadDSL");
+    const res = await app.inject({
+      method: "POST", url: `/api/v1/strategies/${strat.id}/versions`,
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: { dslJson: { invalid: true } },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 404 for nonexistent strategy", async () => {
+    const res = await app.inject({
+      method: "POST", url: "/api/v1/strategies/nonexistent/versions",
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: { dslJson: VALID_DSL },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("POST /api/v1/strategies/validate", () => {
+  it("returns ok for valid DSL", async () => {
+    const res = await app.inject({
+      method: "POST", url: "/api/v1/strategies/validate",
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: { dslJson: VALID_DSL },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().ok).toBe(true);
+  });
+
+  it("returns 400 for invalid DSL", async () => {
+    const res = await app.inject({
+      method: "POST", url: "/api/v1/strategies/validate",
+      headers: { ...headers(), "content-type": "application/json" },
+      payload: { dslJson: {} },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 401 without auth", async () => {
+    const res = await app.inject({
+      method: "POST", url: "/api/v1/strategies/validate",
+      headers: { "content-type": "application/json" },
+      payload: { dslJson: VALID_DSL },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+});


### PR DESCRIPTION
## Roadmap V4 Batch 1 — Route tests for business core

### 74 new tests

| File | Tests | Endpoints covered |
|------|-------|-------------------|
| strategies.test.ts | 19 | GET/POST /strategies, GET /:id, POST /:id/versions, POST /validate |
| bots.test.ts | 26 | GET/POST /bots, PATCH/GET /:id, GET /:id/runs, GET /:id/positions, POST /:id/kill |
| runs.test.ts | 29 | POST start, GET run, stop, stop-all, PATCH state, heartbeat, events, signal (idempotent), reconcile |

### Coverage
- Auth gates: 401 without token, 400 without X-Workspace-Id, 403 for non-member
- Workspace isolation: cross-workspace access returns 404
- Validation: missing fields → 400, invalid values → 400
- Conflict: duplicate names → 409, active run exists → 409, terminal state → 409
- Idempotency: signal with same intentId returns existing intent
- Edge cases: empty lists, nonexistent IDs, kill on idle bot

### A4 (#226) — Crypto roundtrip
Already covered by existing encryptionKeyFix.test.ts (16 tests): roundtrip, tampered ciphertext, unicode, empty string, random IV.

### Test baseline
- **Before**: ~1295 tests
- **After**: 1369 tests (+74)
- Only pre-existing failure: positionManager.test.ts (Prisma client)

Closes #223, #224, #225, #226

https://claude.ai/code/session_01T4a4NeCbCbuV5EUz69kE6U