### PR TITLE
fix: Smoke test alignment + V3 Follow-up audit (12/12 complete)

### DIFF
--- a/deploy/smoke-test.sh
+++ b/deploy/smoke-test.sh
@@ -808,20 +808,21 @@ fi
 
 S12_BT_ID=""
 
-# 12.1 POST /lab/backtest (dataset-first) → 202 PENDING
-if [[ -n "$S12_STRAT_ID" && -n "$S12_DATASET_ID" ]]; then
+# 12.1 POST /lab/backtest (dataset-first, Phase 5) → 202 PENDING
+# Phase 5 requires strategyVersionId (not strategyId) for reproducibility.
+if [[ -n "$S12_VER_ENABLED_ID" && -n "$S12_DATASET_ID" ]]; then
   S12_BT_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE_URL/api/v1/lab/backtest" \
     -H "Authorization: Bearer $TOKEN" \
     -H "Content-Type: application/json" \
     -H "X-Workspace-Id: $WS_ID" \
-    -d "{\"strategyId\":\"$S12_STRAT_ID\",\"datasetId\":\"$S12_DATASET_ID\"}")
+    -d "{\"strategyVersionId\":\"$S12_VER_ENABLED_ID\",\"datasetId\":\"$S12_DATASET_ID\"}")
   check "POST /lab/backtest (dataset-first) → 202" "202" "$S12_BT_CODE"
 
   S12_BT=$(curl -s -X POST "$BASE_URL/api/v1/lab/backtest" \
     -H "Authorization: Bearer $TOKEN" \
     -H "Content-Type: application/json" \
     -H "X-Workspace-Id: $WS_ID" \
-    -d "{\"strategyId\":\"$S12_STRAT_ID\",\"datasetId\":\"$S12_DATASET_ID\"}")
+    -d "{\"strategyVersionId\":\"$S12_VER_ENABLED_ID\",\"datasetId\":\"$S12_DATASET_ID\"}")
   S12_BT_ID=$(echo "$S12_BT" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4) || true
   S12_BT_STATUS=$(echo "$S12_BT" | grep -o '"status":"[^"]*"' | head -1 | cut -d'"' -f4) || true
   if [[ "$S12_BT_STATUS" == "PENDING" ]] || [[ "$S12_BT_STATUS" == "RUNNING" ]]; then
@@ -832,7 +833,7 @@ if [[ -n "$S12_STRAT_ID" && -n "$S12_DATASET_ID" ]]; then
     ((++FAIL))
   fi
 else
-  red "Skipping backtest tests (no strategy or dataset created)"
+  red "Skipping backtest tests (no strategy version or dataset created)"
   ((++FAIL)); ((++FAIL))
 fi
 
@@ -1153,6 +1154,7 @@ check "POST /ai/execute missing actionId → 400" "400" "$S18_EXEC_NOACTION"
 S18_EXEC_404=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE_URL/api/v1/ai/execute" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
+  -H "X-Workspace-Id: $WS_ID" \
   -d '{"planId":"00000000-0000-0000-0000-000000000000","actionId":"x"}')
 check "POST /ai/execute non-existent planId → 404" "404" "$S18_EXEC_404"
 


### PR DESCRIPTION
## Summary

Fixes 3 pre-existing smoke test failures that were causing false negatives on every deploy.

### Fixes

1. **Section 12.1** (`POST /lab/backtest`): Updated to use `strategyVersionId` instead of deprecated `strategyId`. Phase 5 dataset-first contract requires explicit version binding for reproducibility.

2. **Section 18.5** (`POST /ai/execute`): Added missing `X-Workspace-Id` header. Without it, workspace resolution fails with 400 before plan lookup can return 404.

### V3 Follow-up Audit

Full audit of `docs/33-roadmap-v3-followup.md` confirms **all 12/12 tasks are already implemented**:

| Task | Status | Where |
|------|--------|-------|
| A1 Auth route tests | ✅ Done | 29 tests in `tests/routes/auth.test.ts` |
| A2 Graceful shutdown | ✅ Done | 30s timeout + guard in `server.ts` |
| A3 Notify cache invalidation | ✅ Done | `invalidateNotifyCache()` in notifications.ts |
| B1 Hedge exit qty validation | ✅ Done | `exitQty <= 0` check in hedges.ts |
| B2 CORS/TRUST_PROXY env | ✅ Done | `CORS_ORIGIN` + `TRUST_PROXY` in app.ts |
| B3 Worker intent tests | ✅ Done | intentExecutor + processIntents tests |
| B4 Map cleanup | ✅ Done | `delete()` in stopRun/timeoutExpiredRuns |
| C1 Token revocation | ✅ Done | RefreshToken model + rotation in auth.ts |
| C2 Structured DCA logging | ✅ Done | Child loggers in enforcement functions |
| C3 Client-errors rate limit | ✅ Done | 3 req/min in app.ts |
| C4 chatId validation | ✅ Done | Regex in notifications.ts |
| C5 Pool threshold env | ✅ Done | `POOL_WAIT_THRESHOLD` in readyz.ts |

## Test plan

- [x] All 1561 tests pass
- [ ] Deploy and run `bash deploy/smoke-test.sh` — expect 88/88

https://claude.ai/code/session_01UV2bif2VGQ4qGfzd1KMQpg