### PR TITLE
feat(lab): Compare Runs — Phase 6 task pack 23b1

### DIFF
--- a/apps/api/src/routes/lab.ts
+++ b/apps/api/src/routes/lab.ts
@@ -463,6 +463,56 @@ export async function labRoutes(app: FastifyInstance) {
     return reply.send(list);
   });
 
+  // ── GET /lab/backtests/compare ── side-by-side comparison of two runs (Phase 6, 23b1) ──
+  app.get<{ Querystring: { a: string; b: string } }>("/lab/backtests/compare", {
+    config: { rateLimit: { max: 20, timeWindow: "1 minute" } },
+    onRequest: [app.authenticate],
+  }, async (request, reply) => {
+    const workspace = await resolveWorkspace(request, reply);
+    if (!workspace) return;
+
+    const { a, b } = request.query ?? {};
+    if (!a || !b) {
+      return problem(reply, 400, "Validation Error", "Query params 'a' and 'b' (backtest IDs) are required");
+    }
+    if (a === b) {
+      return problem(reply, 400, "Validation Error", "Cannot compare a run with itself");
+    }
+
+    const [runA, runB] = await Promise.all([
+      prisma.backtestResult.findUnique({ where: { id: a }, select: BACKTEST_SELECT }),
+      prisma.backtestResult.findUnique({ where: { id: b }, select: BACKTEST_SELECT }),
+    ]);
+
+    if (!runA || runA.workspaceId !== workspace.id) {
+      return problem(reply, 404, "Not Found", "Run A not found");
+    }
+    if (!runB || runB.workspaceId !== workspace.id) {
+      return problem(reply, 404, "Not Found", "Run B not found");
+    }
+
+    // Compute deltas from reportJson
+    const reportA = (runA.reportJson ?? {}) as Record<string, unknown>;
+    const reportB = (runB.reportJson ?? {}) as Record<string, unknown>;
+
+    const num = (v: unknown) => (typeof v === "number" && Number.isFinite(v) ? v : null);
+
+    const delta = {
+      pnlDelta: num(reportA.totalPnlPct) !== null && num(reportB.totalPnlPct) !== null
+        ? (num(reportA.totalPnlPct)! - num(reportB.totalPnlPct)!) : null,
+      winrateDelta: num(reportA.winrate) !== null && num(reportB.winrate) !== null
+        ? (num(reportA.winrate)! - num(reportB.winrate)!) : null,
+      drawdownDelta: num(reportA.maxDrawdownPct) !== null && num(reportB.maxDrawdownPct) !== null
+        ? (num(reportA.maxDrawdownPct)! - num(reportB.maxDrawdownPct)!) : null,
+      tradeDelta: num(reportA.trades) !== null && num(reportB.trades) !== null
+        ? (num(reportA.trades)! - num(reportB.trades)!) : null,
+      sharpeDelta: num(reportA.sharpe) !== null && num(reportB.sharpe) !== null
+        ? (num(reportA.sharpe)! - num(reportB.sharpe)!) : null,
+    };
+
+    return reply.send({ a: runA, b: runB, delta });
+  });
+
   // ── POST /lab/backtest/sweep ── trigger parametric grid search (Phase C1) ──
   // Per docs/25-lab-improvements-plan.md §Phase C1
   app.post<{ Body: SweepRequestBody }>("/lab/backtest/sweep", {

--- a/apps/api/tests/routes/lab.test.ts
+++ b/apps/api/tests/routes/lab.test.ts
@@ -426,3 +426,60 @@ describe("GET /api/v1/lab/backtest/sweeps", () => {
     expect(res.json()).toBeInstanceOf(Array);
   });
 });
+
+// ── GET /lab/backtests/compare ──────────────────────────────────────────────
+
+describe("GET /api/v1/lab/backtests/compare", () => {
+  it("returns 400 when query params missing", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/v1/lab/backtests/compare", headers: authHeaders() });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 400 when comparing run with itself", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/v1/lab/backtests/compare?a=bt-1&b=bt-1", headers: authHeaders() });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 404 when run A not found", async () => {
+    mockBacktests["bt-2"] = { id: "bt-2", workspaceId: WS_ID, status: "DONE", reportJson: { totalPnlPct: 5, winrate: 60, maxDrawdownPct: 3, trades: 10 } };
+    const res = await app.inject({ method: "GET", url: "/api/v1/lab/backtests/compare?a=missing&b=bt-2", headers: authHeaders() });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 404 when run B not found", async () => {
+    mockBacktests["bt-1"] = { id: "bt-1", workspaceId: WS_ID, status: "DONE", reportJson: { totalPnlPct: 10, winrate: 55, maxDrawdownPct: 5, trades: 20 } };
+    const res = await app.inject({ method: "GET", url: "/api/v1/lab/backtests/compare?a=bt-1&b=missing", headers: authHeaders() });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 404 for cross-workspace access", async () => {
+    mockBacktests["bt-1"] = { id: "bt-1", workspaceId: WS_ID, status: "DONE", reportJson: {} };
+    mockBacktests["bt-other"] = { id: "bt-other", workspaceId: "ws-other", status: "DONE", reportJson: {} };
+    const res = await app.inject({ method: "GET", url: "/api/v1/lab/backtests/compare?a=bt-1&b=bt-other", headers: authHeaders() });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns comparison with delta on success", async () => {
+    mockBacktests["bt-a"] = { id: "bt-a", workspaceId: WS_ID, status: "DONE", reportJson: { totalPnlPct: 15.5, winrate: 62, maxDrawdownPct: 5.2, trades: 50, sharpe: 1.24 }, feeBps: 10, slippageBps: 5, engineVersion: "abc123" };
+    mockBacktests["bt-b"] = { id: "bt-b", workspaceId: WS_ID, status: "DONE", reportJson: { totalPnlPct: 12.3, winrate: 58.5, maxDrawdownPct: 7.1, trades: 48, sharpe: 0.98 }, feeBps: 10, slippageBps: 5, engineVersion: "abc123" };
+    const res = await app.inject({ method: "GET", url: "/api/v1/lab/backtests/compare?a=bt-a&b=bt-b", headers: authHeaders() });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.a.id).toBe("bt-a");
+    expect(body.b.id).toBe("bt-b");
+    expect(body.delta.pnlDelta).toBeCloseTo(3.2, 1);
+    expect(body.delta.winrateDelta).toBeCloseTo(3.5, 1);
+    expect(body.delta.tradeDelta).toBe(2);
+    expect(body.delta.sharpeDelta).toBeCloseTo(0.26, 2);
+  });
+
+  it("returns null deltas when reports missing fields", async () => {
+    mockBacktests["bt-x"] = { id: "bt-x", workspaceId: WS_ID, status: "DONE", reportJson: {} };
+    mockBacktests["bt-y"] = { id: "bt-y", workspaceId: WS_ID, status: "DONE", reportJson: null };
+    const res = await app.inject({ method: "GET", url: "/api/v1/lab/backtests/compare?a=bt-x&b=bt-y", headers: authHeaders() });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.delta.pnlDelta).toBeNull();
+    expect(body.delta.winrateDelta).toBeNull();
+  });
+});

--- a/apps/web/src/app/lab/test/page.tsx
+++ b/apps/web/src/app/lab/test/page.tsx
@@ -537,15 +537,183 @@ function FormRow({ label, children }: { label: string; children: React.ReactNode
 }
 
 // ---------------------------------------------------------------------------
-// Result detail — tabs: Run | Metrics | Trades | Equity | Logs
+// ---------------------------------------------------------------------------
+// Phase 6 (23b1) — Compare Runs Tab
 // ---------------------------------------------------------------------------
 
-type ResultTab = "run" | "metrics" | "trades" | "equity" | "logs";
+interface CompareResult {
+  a: BacktestListItem;
+  b: BacktestListItem;
+  delta: {
+    pnlDelta: number | null;
+    winrateDelta: number | null;
+    drawdownDelta: number | null;
+    tradeDelta: number | null;
+    sharpeDelta: number | null;
+  };
+}
+
+function CompareRunsTab({ runs, currentRunId }: { runs: BacktestListItem[]; currentRunId: string | null }) {
+  const [idA, setIdA] = useState<string>(currentRunId ?? runs[0]?.id ?? "");
+  const [idB, setIdB] = useState<string>(() => {
+    const other = runs.find((r) => r.id !== (currentRunId ?? runs[0]?.id));
+    return other?.id ?? runs[1]?.id ?? "";
+  });
+  const [result, setResult] = useState<CompareResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchComparison = useCallback(async (a: string, b: string) => {
+    if (!a || !b || a === b) { setResult(null); return; }
+    setLoading(true);
+    setError(null);
+    const res = await apiFetch<CompareResult>(`/lab/backtests/compare?a=${a}&b=${b}`);
+    setLoading(false);
+    if (res.ok) { setResult(res.data); }
+    else { setError("Failed to load comparison"); setResult(null); }
+  }, []);
+
+  useEffect(() => { fetchComparison(idA, idB); }, [idA, idB, fetchComparison]);
+
+  const fmt = (v: number | null | undefined, suffix = "%") => {
+    if (v === null || v === undefined) return "—";
+    return `${v >= 0 ? "+" : ""}${v.toFixed(2)}${suffix}`;
+  };
+  const fmtInt = (v: number | null | undefined) => {
+    if (v === null || v === undefined) return "—";
+    return `${v >= 0 ? "+" : ""}${v}`;
+  };
+  const deltaColor = (v: number | null | undefined, invert = false) => {
+    if (v === null || v === undefined) return "rgba(255,255,255,0.4)";
+    const positive = invert ? v < 0 : v > 0;
+    return positive ? "#4ade80" : v === 0 ? "rgba(255,255,255,0.4)" : "#f87171";
+  };
+
+  const runLabel = (r: BacktestListItem) => {
+    const date = new Date(r.createdAt).toLocaleDateString("en-GB", { day: "2-digit", month: "short", hour: "2-digit", minute: "2-digit" });
+    return `${r.symbol} ${r.interval} — ${date}`;
+  };
+
+  const reportA = result?.a.reportJson as BacktestReport | null;
+  const reportB = result?.b.reportJson as BacktestReport | null;
+
+  const metrics: { label: string; a: string; b: string; delta: string; deltaColor: string }[] = result ? [
+    { label: "Total PnL", a: fmt(reportA?.totalPnlPct), b: fmt(reportB?.totalPnlPct), delta: fmt(result.delta.pnlDelta), deltaColor: deltaColor(result.delta.pnlDelta) },
+    { label: "Win Rate", a: fmt(reportA?.winrate), b: fmt(reportB?.winrate), delta: fmt(result.delta.winrateDelta), deltaColor: deltaColor(result.delta.winrateDelta) },
+    { label: "Max Drawdown", a: fmt(reportA?.maxDrawdownPct), b: fmt(reportB?.maxDrawdownPct), delta: fmt(result.delta.drawdownDelta), deltaColor: deltaColor(result.delta.drawdownDelta, true) },
+    { label: "Trades", a: String(reportA?.trades ?? "—"), b: String(reportB?.trades ?? "—"), delta: fmtInt(result.delta.tradeDelta), deltaColor: deltaColor(result.delta.tradeDelta) },
+    { label: "Fee (bps)", a: String(result.a.feeBps), b: String(result.b.feeBps), delta: "", deltaColor: "transparent" },
+    { label: "Engine", a: result.a.engineVersion?.slice(0, 8) ?? "—", b: result.b.engineVersion?.slice(0, 8) ?? "—", delta: "", deltaColor: "transparent" },
+  ] : [];
+
+  return (
+    <div style={{ padding: 16 }}>
+      {/* Run selectors */}
+      <div style={{ display: "flex", gap: 12, marginBottom: 16 }}>
+        <label style={compareLabelStyle}>
+          <span style={{ fontSize: 11, color: "rgba(255,255,255,0.5)", marginBottom: 4 }}>Run A</span>
+          <select value={idA} onChange={(e) => setIdA(e.target.value)} style={compareSelectStyle}>
+            {runs.map((r) => <option key={r.id} value={r.id}>{runLabel(r)}</option>)}
+          </select>
+        </label>
+        <label style={compareLabelStyle}>
+          <span style={{ fontSize: 11, color: "rgba(255,255,255,0.5)", marginBottom: 4 }}>Run B</span>
+          <select value={idB} onChange={(e) => setIdB(e.target.value)} style={compareSelectStyle}>
+            {runs.map((r) => <option key={r.id} value={r.id}>{runLabel(r)}</option>)}
+          </select>
+        </label>
+      </div>
+
+      {idA === idB && <div style={{ color: "#fbbf24", fontSize: 12, marginBottom: 12 }}>Select two different runs to compare.</div>}
+      {loading && <div style={{ color: "rgba(255,255,255,0.5)", fontSize: 12 }}>Loading comparison...</div>}
+      {error && <div style={{ color: "#f87171", fontSize: 12 }}>{error}</div>}
+
+      {/* Provenance blocks */}
+      {result && (
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10, marginBottom: 16 }}>
+          <ProvenanceBlock label="Run A" bt={result.a} />
+          <ProvenanceBlock label="Run B" bt={result.b} />
+        </div>
+      )}
+
+      {/* Metrics comparison table */}
+      {result && metrics.length > 0 && (
+        <table style={compareTableStyle}>
+          <thead>
+            <tr>
+              <th style={compareTh}>Metric</th>
+              <th style={compareTh}>Run A</th>
+              <th style={compareTh}>Run B</th>
+              <th style={compareTh}>Delta</th>
+            </tr>
+          </thead>
+          <tbody>
+            {metrics.map((m) => (
+              <tr key={m.label}>
+                <td style={compareTd}>{m.label}</td>
+                <td style={compareTdVal}>{m.a}</td>
+                <td style={compareTdVal}>{m.b}</td>
+                <td style={{ ...compareTdVal, color: m.deltaColor, fontWeight: 600 }}>{m.delta}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+function ProvenanceBlock({ label, bt }: { label: string; bt: BacktestListItem }) {
+  return (
+    <div style={provenanceStyle}>
+      <div style={{ fontWeight: 700, fontSize: 11, color: "#3b82f6", marginBottom: 6 }}>{label}</div>
+      <div style={provenanceRow}><span>Symbol</span><span>{bt.symbol}</span></div>
+      <div style={provenanceRow}><span>Interval</span><span>{bt.interval}</span></div>
+      <div style={provenanceRow}><span>Dataset</span><span>{bt.datasetId?.slice(0, 12) ?? "—"}...</span></div>
+      <div style={provenanceRow}><span>Hash</span><span>{bt.datasetHash?.slice(0, 8) ?? "—"}</span></div>
+      <div style={provenanceRow}><span>Version</span><span>{bt.strategyVersionId?.slice(0, 12) ?? "—"}...</span></div>
+      <div style={provenanceRow}><span>Date</span><span>{new Date(bt.createdAt).toLocaleDateString("en-GB", { day: "2-digit", month: "short", year: "numeric" })}</span></div>
+    </div>
+  );
+}
+
+const compareLabelStyle: React.CSSProperties = { display: "flex", flexDirection: "column", flex: 1 };
+const compareSelectStyle: React.CSSProperties = {
+  background: "rgba(255,255,255,0.06)", border: "1px solid rgba(255,255,255,0.12)",
+  borderRadius: 6, padding: "6px 8px", color: "#e0e0e0", fontSize: 12, fontFamily: "inherit",
+};
+const compareTableStyle: React.CSSProperties = {
+  width: "100%", borderCollapse: "collapse", fontSize: 12,
+};
+const compareTh: React.CSSProperties = {
+  textAlign: "left", padding: "6px 10px", borderBottom: "1px solid rgba(255,255,255,0.1)",
+  color: "rgba(255,255,255,0.45)", fontWeight: 600, fontSize: 11,
+};
+const compareTd: React.CSSProperties = {
+  padding: "8px 10px", borderBottom: "1px solid rgba(255,255,255,0.06)", color: "rgba(255,255,255,0.7)",
+};
+const compareTdVal: React.CSSProperties = {
+  ...compareTd, fontFamily: "'SF Mono', 'Fira Code', monospace", textAlign: "right",
+};
+const provenanceStyle: React.CSSProperties = {
+  background: "rgba(255,255,255,0.03)", border: "1px solid rgba(255,255,255,0.08)",
+  borderRadius: 8, padding: "10px 12px", fontSize: 11,
+};
+const provenanceRow: React.CSSProperties = {
+  display: "flex", justifyContent: "space-between", padding: "2px 0",
+  color: "rgba(255,255,255,0.5)",
+};
+
+// Result detail — tabs: Run | Metrics | Trades | Equity | Logs | Compare
+// ---------------------------------------------------------------------------
+
+type ResultTab = "run" | "metrics" | "trades" | "equity" | "logs" | "compare";
 
 function ResultDetail({
   bt,
   datasets,
   strategyVersions,
+  allBacktests,
   onStartNew,
   submitting,
   submitError,
@@ -556,6 +724,7 @@ function ResultDetail({
   bt: BacktestListItem | null;
   datasets: DatasetListItem[];
   strategyVersions: StrategyVersionItem[];
+  allBacktests: BacktestListItem[];
   onStartNew: () => void;
   submitting: boolean;
   submitError: string | null;
@@ -573,12 +742,14 @@ function ResultDetail({
   const report = bt?.reportJson as BacktestReport | null | undefined;
   const isDone = bt?.status === "DONE";
 
+  const doneRuns = allBacktests.filter((b) => b.status === "DONE");
   const tabs: { id: ResultTab; label: string; disabled?: boolean }[] = [
     { id: "run",     label: "New run" },
     { id: "metrics", label: "Metrics",      disabled: !isDone },
     { id: "trades",  label: "Trades",       disabled: !isDone },
     { id: "equity",  label: "Equity curve", disabled: !isDone },
     { id: "logs",    label: "Logs",         disabled: !isDone },
+    { id: "compare", label: "Compare",      disabled: doneRuns.length < 2 },
   ];
 
   return (
@@ -651,6 +822,10 @@ function ResultDetail({
               <LogsTab report={report} />
             )}
           </>
+        )}
+
+        {activeTab === "compare" && (
+          <CompareRunsTab runs={doneRuns} currentRunId={bt?.id ?? null} />
         )}
       </div>
     </div>
@@ -857,6 +1032,7 @@ export default function LabTestPage() {
             bt={selectedBt}
             datasets={datasets}
             strategyVersions={strategyVersions}
+            allBacktests={backtests}
             onStartNew={() => setSelectedBtId(null)}
             submitting={submitting}
             submitError={submitError}


### PR DESCRIPTION
## Summary

First feature of Lab Phase 6 (task pack 23b1): side-by-side backtest run comparison with provenance metadata.

### Backend

New endpoint: `GET /api/v1/lab/backtests/compare?a=:id&b=:id`
- Returns both `BacktestResult` records with full `reportJson`
- Computes deltas: PnL, winrate, max drawdown, trades, sharpe
- Workspace isolation enforced for both runs
- Self-comparison blocked (a !== b)
- 20 req/min rate limit

### Frontend

New "Compare" tab in Lab Test results panel:
- **Disabled** until workspace has 2+ completed backtest runs
- **Run selectors**: Two dropdowns (Run A, Run B) showing recent runs with date labels
- **Provenance blocks**: Symbol, interval, dataset hash, strategy version, date for each run
- **Metrics table**: Total PnL, Win Rate, Max Drawdown, Trades, Fee, Engine — with delta column
- **Color-coded deltas**: Green for improvements, red for degradation (drawdown inverted)

### Test results
- **+7 new tests** for compare endpoint (validation, 404s, cross-workspace, delta computation, null handling)
- **1568 tests pass** total (1 pre-existing failure)

## Test plan
- [x] All 1568 tests pass
- [x] Compare endpoint returns correct deltas for known values
- [x] Workspace isolation prevents cross-workspace comparison
- [x] Self-comparison returns 400
- [x] Missing runs return 404
- [x] Null reportJson handled gracefully
- [ ] Manual: open `/lab/test`, create 2+ backtests, verify Compare tab activates
- [ ] Manual: select different runs, verify provenance + metrics grid

https://claude.ai/code/session_01UV2bif2VGQ4qGfzd1KMQpg