### PR TITLE
test(api): fix positionManager.test.ts Prisma module resolution

### DIFF
--- a/apps/api/tests/lib/positionManager.test.ts
+++ b/apps/api/tests/lib/positionManager.test.ts
@@ -1,4 +1,32 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+
+// ── Mock Prisma client to avoid loading the generated client at import time ──
+// positionManager.ts imports { Prisma } and Decimal from @prisma/client at
+// module level. Those imports transitively require .prisma/client/default
+// which only exists after `prisma generate` has been run. In unit-test
+// runs this isn't always available, so we stub the entire client. The
+// functions under test (calcUnrealisedPnl) are pure and never touch these
+// imports at runtime.
+vi.mock("@prisma/client", () => ({
+  Prisma: {
+    InputJsonValue: {},
+    TransactionClient: class {},
+  },
+  PrismaClient: vi.fn().mockImplementation(() => ({})),
+}));
+
+vi.mock("@prisma/client/runtime/library", () => ({
+  Decimal: class DecimalMock {
+    private value: number;
+    constructor(v: number | string) { this.value = typeof v === "string" ? parseFloat(v) : v; }
+    toNumber(): number { return this.value; }
+  },
+}));
+
+vi.mock("../../src/lib/prisma.js", () => ({
+  prisma: {},
+}));
+
 import { calcUnrealisedPnl, type PositionSnapshot } from "../../src/lib/positionManager.js";
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the long-standing pre-existing test failure in `positionManager.test.ts` that has been carried forward since at least Task 25a. The suite failed to load with:

```
Error: Cannot find module '.prisma/client/default'
  at @prisma/client/default.js:2:6
```

## Root cause

`positionManager.ts` imports `{ Prisma }` and `Decimal` from `@prisma/client` at module scope. The generated `.prisma/client/default` module is only produced by `prisma generate`, which isn't always run in unit-test environments. Every other test file that touches Prisma-dependent modules (`ai.test.ts`, `lab.test.ts`, `labExplain.test.ts`, `bots.test.ts`, etc.) already mocks `@prisma/client` to avoid this — `positionManager.test.ts` was the one file that didn't.

The functions under test — `calcUnrealisedPnl` and `PositionSnapshot` — are a pure function and a plain interface respectively. Neither touches Prisma at runtime, so stubbing the module boundary is the correct fix.

## Changes

`apps/api/tests/lib/positionManager.test.ts` — added `vi.mock()` calls for:
- `@prisma/client` (stubs `Prisma` namespace + `PrismaClient` class)
- `@prisma/client/runtime/library` (stubs `Decimal` with minimal shape)
- `../../src/lib/prisma.js` (empty prisma instance)

Follows the exact pattern used in `ai.test.ts:14-17`.

## Test plan

- [x] `positionManager.test.ts` alone: 37 tests pass (was 0 — suite never loaded)
- [x] Full suite: **86/86 suites pass, 1665 total tests** (was 85/86 with 1 broken, 1628 tests)
- [x] No production code changes — zero risk of regression

## Impact

This was the "1 pre-existing failure" mentioned in every Task 25a/26/27/28/29 PR description. Removing it means CI can now fail meaningfully — any future `Test Files  X failed` signal will be a real regression, not noise to filter out.

https://claude.ai/code/session_01BAgSH9G5gQ4rKuvpeUmkgG