### PR TITLE
ci(repo): add GitHub Actions CI + Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      production-deps:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+      dev-deps:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-typecheck-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm --filter @botmarketplace/api exec prisma generate
+
+      - name: Typecheck API
+        run: pnpm --filter @botmarketplace/api exec tsc --noEmit
+
+      - name: Build Web
+        run: pnpm build:web
+
+      - name: Run API tests
+        run: pnpm test:api
+
+      - name: Check stray TS artifacts
+        run: pnpm check:stray
+
+      - name: Security audit (fail on critical)
+        run: pnpm audit --prod --audit-level=critical


### PR DESCRIPTION
## Summary

Action 2 из `docs/37 §6`: GitHub Actions CI + Dependabot. Закрывает §4.1 (нет CI pipeline) и §5.4 (нет dependabot/renovate).

## `.github/workflows/ci.yml`

Триггеры: каждый PR в main + push в main. Один job, 7 шагов:

1. `pnpm install --frozen-lockfile`
2. `prisma generate` (regenerate client из schema)
3. `tsc --noEmit` (typecheck API)
4. `next build` (build Web)
5. `vitest run` (1665 tests)
6. `pnpm check:stray` (no orphan .js next to .ts, PR #253)
7. `pnpm audit --prod --audit-level=critical` (fail on CRITICAL CVE, PR #256 closes baseline)

`concurrency` с `cancel-in-progress: true` — быстрые pushes не копят очередь.

## `.github/dependabot.yml`

- npm: еженедельно (пн), grouped по production/dev + minor/patch
- github-actions: еженедельно (пн)
- Лимит: 10 npm PRs + 5 actions PRs

## Test plan

- [x] YAML синтаксис валиден
- [x] Все referenced скрипты (`test:api`, `check:stray`, `build:web`) существуют в `package.json`
- [x] `pnpm/action-setup@v4` автоматически берёт `packageManager` из root `package.json` (pnpm 10.29.3)
- [x] `actions/setup-node@v4` с `cache: pnpm` ускоряет повторные запуски
- [ ] Первый реальный CI-run — после merge этой PR (CI триггер на push в main)
