### PR TITLE
feat(observability): /metrics endpoint with prom-client

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -24,7 +24,8 @@
     "bcryptjs": "^3.0.3",
     "fastify": "^5.8.4",
     "node-cron": "^4.2.1",
-    "pino": "^9.6.0"
+    "pino": "^9.6.0",
+    "prom-client": "^15.1.3"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -5,6 +5,8 @@ import jwt from "@fastify/jwt";
 import rateLimit from "@fastify/rate-limit";
 import { healthzRoutes } from "./routes/healthz.js";
 import { readyzRoutes } from "./routes/readyz.js";
+import { metricsRoutes } from "./routes/metrics.js";
+import { httpRequestDurationSeconds } from "./lib/metrics.js";
 import { authRoutes } from "./routes/auth.js";
 import { strategyRoutes } from "./routes/strategies.js";
 import { botRoutes } from "./routes/bots.js";
@@ -164,12 +166,23 @@ export async function buildApp() {
   });
 
   // Top-level /health for nginx/monitoring (no auth, no prefix)
-  app.get("/health", async (_request, reply) => {
+  app.get("/health", { config: { rateLimit: false } }, async (_request, reply) => {
     return reply.send({
       status: "ok",
       uptime: process.uptime(),
       timestamp: new Date().toISOString(),
     });
+  });
+
+  // Prometheus scrape endpoint (no auth, no prefix) — scraped from loopback only
+  await app.register(metricsRoutes);
+
+  // HTTP request duration histogram — observe every response
+  app.addHook("onResponse", async (request, reply) => {
+    const route = request.routeOptions?.url ?? request.url;
+    httpRequestDurationSeconds
+      .labels(request.method, route, String(reply.statusCode))
+      .observe(reply.elapsedTime / 1000);
   });
 
   // Primary versioned routes: /api/v1/*

--- a/apps/api/src/lib/botWorker.ts
+++ b/apps/api/src/lib/botWorker.ts
@@ -92,6 +92,7 @@ import {
   enforceErrorPause as enforceErrorPauseExtracted,
   processIntents as processIntentsExtracted,
 } from "./worker/tickProcessor.js";
+import { intentFilledTotal, intentFailedTotal } from "./metrics.js";
 
 const workerLog = logger.child({ module: "botWorker" });
 
@@ -1129,6 +1130,11 @@ async function reconcilePlacedIntents(): Promise<void> {
             metaJson: updateMeta as Prisma.InputJsonValue,
           },
         });
+
+        if (newState !== intent.state) {
+          if (newState === "FILLED") intentFilledTotal.inc();
+          else if (newState === "FAILED") intentFailedTotal.inc();
+        }
 
         if (fillDelta > 0 || newState !== intent.state) {
           await prisma.botEvent.create({

--- a/apps/api/src/lib/metrics.ts
+++ b/apps/api/src/lib/metrics.ts
@@ -1,0 +1,31 @@
+import { Registry, collectDefaultMetrics, Counter, Histogram } from "prom-client";
+
+export const register = new Registry();
+register.setDefaultLabels({ app: "botmarket-api" });
+collectDefaultMetrics({ register });
+
+export const intentCreatedTotal = new Counter({
+  name: "botmarket_intent_created_total",
+  help: "Total number of bot intents created.",
+  registers: [register],
+});
+
+export const intentFilledTotal = new Counter({
+  name: "botmarket_intent_filled_total",
+  help: "Total number of bot intents that reached FILLED state.",
+  registers: [register],
+});
+
+export const intentFailedTotal = new Counter({
+  name: "botmarket_intent_failed_total",
+  help: "Total number of bot intents that reached FAILED state.",
+  registers: [register],
+});
+
+export const httpRequestDurationSeconds = new Histogram({
+  name: "botmarket_http_request_duration_seconds",
+  help: "HTTP request duration in seconds.",
+  labelNames: ["method", "route", "status"],
+  buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+  registers: [register],
+});

--- a/apps/api/src/lib/worker/intentExecutor.ts
+++ b/apps/api/src/lib/worker/intentExecutor.ts
@@ -19,6 +19,7 @@ import {
 import { getInstrument } from "../exchange/instrumentCache.js";
 import { normalizeOrder } from "../exchange/normalizer.js";
 import { classifyExecutionError } from "../errorClassifier.js";
+import { intentFilledTotal, intentFailedTotal } from "../metrics.js";
 import type { Logger } from "pino";
 
 /** Max retries for transient intent failures before dead-lettering (Task #22). */
@@ -77,6 +78,7 @@ export async function executeIntent(intent: IntentRecord, parentLog: Logger): Pr
         where: { id: intent.id },
         data: { state: "FILLED", metaJson: meta as Prisma.InputJsonValue },
       });
+      intentFilledTotal.inc();
       await prisma.botEvent.create({
         data: {
           botRunId: botRun.id,
@@ -250,6 +252,7 @@ async function handleIntentError(
       where: { id: intent.id },
       data: { state: "FAILED", metaJson: meta as Prisma.InputJsonValue },
     });
+    intentFailedTotal.inc();
     await prisma.botEvent.create({
       data: {
         botRunId: botRun.id,

--- a/apps/api/src/routes/intents.ts
+++ b/apps/api/src/routes/intents.ts
@@ -16,6 +16,7 @@ import type { IntentState, IntentType, OrderSide } from "@prisma/client";
 import { prisma } from "../lib/prisma.js";
 import { problem } from "../lib/problem.js";
 import { resolveWorkspace } from "../lib/workspace.js";
+import { intentCreatedTotal } from "../lib/metrics.js";
 
 // ---------------------------------------------------------------------------
 // Route plugin
@@ -72,6 +73,7 @@ export async function intentRoutes(app: FastifyInstance) {
         },
       });
 
+      intentCreatedTotal.inc();
       return reply.status(201).send(intent);
     } catch (err) {
       // P2002 = unique constraint violation → race on intentId creation

--- a/apps/api/src/routes/metrics.ts
+++ b/apps/api/src/routes/metrics.ts
@@ -1,0 +1,15 @@
+import type { FastifyInstance } from "fastify";
+import { register } from "../lib/metrics.js";
+
+/**
+ * Prometheus scrape endpoint. Intentionally unauthenticated — Prometheus
+ * scrapes it over the loopback interface only (see deploy/nginx.conf).
+ */
+export async function metricsRoutes(app: FastifyInstance) {
+  app.get("/metrics", { config: { rateLimit: false } }, async (_request, reply) => {
+    const body = await register.metrics();
+    return reply
+      .header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+      .send(body);
+  });
+}

--- a/apps/api/tests/routes/metrics.test.ts
+++ b/apps/api/tests/routes/metrics.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@prisma/client", () => ({
+  PrismaClient: vi.fn().mockImplementation(() => ({
+    $queryRaw: vi.fn().mockResolvedValue([]),
+    $connect: vi.fn(),
+    $disconnect: vi.fn(),
+  })),
+  Prisma: { sql: vi.fn(), join: vi.fn() },
+}));
+
+vi.mock("../../src/lib/prisma.js", () => ({
+  prisma: {
+    $queryRaw: vi.fn().mockResolvedValue([{ "?column?": 1 }]),
+    $connect: vi.fn(),
+    $disconnect: vi.fn(),
+  },
+}));
+
+import { buildApp } from "../../src/app.js";
+import {
+  intentCreatedTotal,
+  intentFilledTotal,
+  intentFailedTotal,
+  register,
+} from "../../src/lib/metrics.js";
+
+describe("GET /metrics", () => {
+  beforeEach(() => {
+    register.resetMetrics();
+  });
+
+  it("returns 200 with text/plain content-type", async () => {
+    const app = await buildApp();
+    const res = await app.inject({ method: "GET", url: "/metrics" });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["content-type"]).toMatch(/^text\/plain; version=0\.0\.4/);
+    expect(res.payload).toContain("botmarket_intent_created_total");
+    expect(res.payload).toContain("botmarket_http_request_duration_seconds");
+    await app.close();
+  });
+
+  it("records HTTP request duration histogram", async () => {
+    const app = await buildApp();
+    // Make a request that will be observed
+    await app.inject({ method: "GET", url: "/health" });
+
+    const body = await register.metrics();
+    expect(body).toMatch(
+      /botmarket_http_request_duration_seconds_count\{[^}]*route="\/health"[^}]*\}\s+1/,
+    );
+    await app.close();
+  });
+
+  it("reflects intent counter increments", async () => {
+    intentCreatedTotal.inc();
+    intentCreatedTotal.inc();
+    intentFilledTotal.inc();
+    intentFailedTotal.inc();
+
+    const app = await buildApp();
+    const res = await app.inject({ method: "GET", url: "/metrics" });
+    expect(res.payload).toMatch(/botmarket_intent_created_total(?:\{[^}]*\})?\s+2/);
+    expect(res.payload).toMatch(/botmarket_intent_filled_total(?:\{[^}]*\})?\s+1/);
+    expect(res.payload).toMatch(/botmarket_intent_failed_total(?:\{[^}]*\})?\s+1/);
+    await app.close();
+  });
+});

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -39,6 +39,21 @@ server {
         proxy_set_header   X-Forwarded-Proto $scheme;
     }
 
+    # ==== Prometheus scrape endpoint ====
+    # /metrics is unauthenticated by design (Prometheus scrape convention).
+    # Only accept connections from loopback; Prometheus runs on the same host
+    # and scrapes http://127.0.0.1:4000/metrics directly (or via this proxy
+    # bound to localhost). External access is rejected.
+    location = /metrics {
+        allow 127.0.0.1;
+        allow ::1;
+        deny  all;
+        proxy_pass         http://api_backend;
+        proxy_http_version 1.1;
+        proxy_set_header   Connection "";
+        proxy_set_header   Host       $host;
+    }
+
     # ==== WEB (Next.js) — включая WebSocket для HMR ====
     location / {
         proxy_pass         http://web_backend;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       pino:
         specifier: ^9.6.0
         version: 9.14.0
+      prom-client:
+        specifier: ^15.1.3
+        version: 15.1.3
     devDependencies:
       '@types/bcryptjs':
         specifier: ^2.4.6
@@ -68,7 +71,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@22.19.11)(vite@8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.19.11)(vite@8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0))
 
   apps/web:
     dependencies:
@@ -86,7 +89,7 @@ importers:
         version: 5.1.0
       next:
         specifier: ^15.5.15
-        version: 15.5.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 15.5.15(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: ^19.1.0
         version: 19.2.4
@@ -540,6 +543,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
   '@oxc-project/types@0.120.0':
     resolution: {integrity: sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg==}
 
@@ -812,6 +819,9 @@ packages:
   bcryptjs@3.0.3:
     resolution: {integrity: sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==}
     hasBin: true
+
+  bintrees@1.0.2:
+    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
 
   bn.js@4.12.3:
     resolution: {integrity: sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==}
@@ -1275,6 +1285,10 @@ packages:
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
+  prom-client@15.1.3:
+    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
+    engines: {node: ^16 || ^18 || >=20}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -1407,6 +1421,9 @@ packages:
         optional: true
       babel-plugin-macros:
         optional: true
+
+  tdigest@0.1.2:
+    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
   thread-stream@3.1.0:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
@@ -1863,6 +1880,8 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.15':
     optional: true
 
+  '@opentelemetry/api@1.9.1': {}
+
   '@oxc-project/types@0.120.0': {}
 
   '@pinojs/redact@0.4.0': {}
@@ -2120,6 +2139,8 @@ snapshots:
       fastq: 1.20.1
 
   bcryptjs@3.0.3: {}
+
+  bintrees@1.0.2: {}
 
   bn.js@4.12.3: {}
 
@@ -2470,7 +2491,7 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  next@15.5.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@15.5.15(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 15.5.15
       '@swc/helpers': 0.5.15
@@ -2488,6 +2509,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.5.15
       '@next/swc-win32-arm64-msvc': 15.5.15
       '@next/swc-win32-x64-msvc': 15.5.15
+      '@opentelemetry/api': 1.9.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -2609,6 +2631,11 @@ snapshots:
   process-warning@4.0.1: {}
 
   process-warning@5.0.0: {}
+
+  prom-client@15.1.3:
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      tdigest: 0.1.2
 
   pump@3.0.4:
     dependencies:
@@ -2757,6 +2784,10 @@ snapshots:
       client-only: 0.0.1
       react: 19.2.4
 
+  tdigest@0.1.2:
+    dependencies:
+      bintrees: 1.0.2
+
   thread-stream@3.1.0:
     dependencies:
       real-require: 0.2.0
@@ -2819,7 +2850,7 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vitest@4.1.0(@types/node@22.19.11)(vite@8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)):
+  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.19.11)(vite@8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.0
       '@vitest/mocker': 4.1.0(vite@8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0))
@@ -2842,6 +2873,7 @@ snapshots:
       vite: 8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 22.19.11
     transitivePeerDependencies:
       - msw


### PR DESCRIPTION
## Summary

First slice of the observability stack (Action 3 from `docs/37` §6). Exposes a
Prometheus-format `/metrics` endpoint so the API can be scraped.

- `prom-client` registry with default process metrics (`app="botmarket-api"` label)
- Counters: `botmarket_intent_{created,filled,failed}_total`
- Histogram: `botmarket_http_request_duration_seconds` by `method` / `route` / `status`,
  recorded via Fastify `onResponse` hook using `reply.elapsedTime`
- Business counters wired at state-transition sites:
  - `routes/intents.ts` — increments on create
  - `lib/worker/intentExecutor.ts` — FILLED (demo path) / FAILED
  - `lib/botWorker.ts` reconciler — FILLED / FAILED for live orders
- `/metrics` is unauthenticated (Prometheus scrape convention);
  `deploy/nginx.conf` restricts external access to loopback only.

## Test plan

- [x] `pnpm test:api` — 1668 passed (prev 1665 + 3 new in `tests/routes/metrics.test.ts`)
- [x] `pnpm build:api`
- [x] New tests cover: 200 response, `text/plain; version=0.0.4` content-type,
      histogram records request duration, counters increment correctly
