### PR TITLE
feat(alerting): /readyz probe with systemd timer + webhook alerts

### DIFF
--- a/deploy/botmarket-healthcheck.service
+++ b/deploy/botmarket-healthcheck.service
@@ -1,0 +1,22 @@
+# systemd one-shot service for API /readyz health probe
+# Triggered by: botmarket-healthcheck.timer (every 30s)
+# Install: cp deploy/botmarket-healthcheck.service /etc/systemd/system/
+#
+# Configure credentials via drop-in:
+#   systemctl edit botmarket-healthcheck.service
+# and set (example):
+#   [Service]
+#   Environment="ALERT_WEBHOOK_URL=https://api.telegram.org/bot<token>/sendMessage"
+#   Environment="ALERT_CHAT_ID=-100..."
+
+[Unit]
+Description=BotMarketplace /readyz Health Probe
+After=network-online.target botmarket-api.service
+
+[Service]
+Type=oneshot
+User=root
+ExecStart=/bin/bash /opt/-botmarketplace-site/deploy/healthcheck.sh
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=botmarket-healthcheck

--- a/deploy/botmarket-healthcheck.timer
+++ b/deploy/botmarket-healthcheck.timer
@@ -1,0 +1,20 @@
+# systemd timer — probe /readyz every 30 seconds
+# Install:
+#   cp deploy/botmarket-healthcheck.timer /etc/systemd/system/
+#   cp deploy/botmarket-healthcheck.service /etc/systemd/system/
+#   systemctl daemon-reload
+#   systemctl enable --now botmarket-healthcheck.timer
+# Status: systemctl list-timers | grep healthcheck
+# Recent runs: journalctl -u botmarket-healthcheck -n 50
+
+[Unit]
+Description=BotMarketplace /readyz Health Probe Timer
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=30s
+AccuracySec=5s
+Unit=botmarket-healthcheck.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/healthcheck.sh
+++ b/deploy/healthcheck.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# healthcheck.sh — probe the API /readyz endpoint and alert on repeated failure.
+#
+# Triggered by systemd timer (botmarket-healthcheck.timer) every 30s.
+# On two consecutive non-200 responses an alert is sent to $ALERT_WEBHOOK_URL
+# (Telegram bot API or Slack-incoming-webhook compatible JSON POST).
+#
+# Consecutive-failure state is persisted at $STATE_FILE so the check is stateless
+# between invocations.
+#
+# Environment:
+#   READYZ_URL          URL to probe (default: http://127.0.0.1:4000/readyz)
+#   ALERT_WEBHOOK_URL   Webhook to POST on alert (optional — skipped if unset)
+#   ALERT_WEBHOOK_KIND  "telegram" (default) or "slack"
+#   ALERT_CHAT_ID       Telegram chat id (required if kind=telegram)
+#   STATE_FILE          Failure counter file (default: /var/lib/botmarket/healthcheck.state)
+#   FAIL_THRESHOLD      Consecutive failures before alert (default: 2)
+
+set -u
+
+READYZ_URL="${READYZ_URL:-http://127.0.0.1:4000/readyz}"
+ALERT_WEBHOOK_URL="${ALERT_WEBHOOK_URL:-}"
+ALERT_WEBHOOK_KIND="${ALERT_WEBHOOK_KIND:-telegram}"
+ALERT_CHAT_ID="${ALERT_CHAT_ID:-}"
+STATE_FILE="${STATE_FILE:-/var/lib/botmarket/healthcheck.state}"
+FAIL_THRESHOLD="${FAIL_THRESHOLD:-2}"
+
+mkdir -p "$(dirname "$STATE_FILE")"
+prev_fails=0
+if [[ -r "$STATE_FILE" ]]; then
+  prev_fails=$(cat "$STATE_FILE" 2>/dev/null || echo 0)
+  [[ "$prev_fails" =~ ^[0-9]+$ ]] || prev_fails=0
+fi
+
+status=$(curl -s -o /tmp/healthcheck.body -w "%{http_code}" --max-time 5 "$READYZ_URL" 2>/dev/null)
+[[ -z "$status" ]] && status="000"
+
+if [[ "$status" == "200" ]]; then
+  echo 0 > "$STATE_FILE"
+  exit 0
+fi
+
+fails=$((prev_fails + 1))
+echo "$fails" > "$STATE_FILE"
+
+echo "healthcheck: $READYZ_URL returned $status (consecutive failures: $fails)" >&2
+
+if (( fails < FAIL_THRESHOLD )); then
+  exit 0
+fi
+
+# Only alert on the edge (first time we cross the threshold) to avoid spam.
+if (( fails > FAIL_THRESHOLD )); then
+  exit 0
+fi
+
+if [[ -z "$ALERT_WEBHOOK_URL" ]]; then
+  echo "healthcheck: ALERT_WEBHOOK_URL not set — skipping alert" >&2
+  exit 0
+fi
+
+host=$(hostname -f 2>/dev/null || hostname)
+body=$(head -c 500 /tmp/healthcheck.body 2>/dev/null || echo "")
+message="[botmarket] $host /readyz unhealthy (status=$status, consecutive=$fails). Body: $body"
+
+case "$ALERT_WEBHOOK_KIND" in
+  telegram)
+    if [[ -z "$ALERT_CHAT_ID" ]]; then
+      echo "healthcheck: ALERT_CHAT_ID required for telegram" >&2
+      exit 1
+    fi
+    curl -s --max-time 5 -X POST "$ALERT_WEBHOOK_URL" \
+      --data-urlencode "chat_id=$ALERT_CHAT_ID" \
+      --data-urlencode "text=$message" >/dev/null || true
+    ;;
+  slack)
+    payload=$(printf '{"text":%s}' "$(printf '%s' "$message" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')")
+    curl -s --max-time 5 -X POST -H "Content-Type: application/json" \
+      --data "$payload" "$ALERT_WEBHOOK_URL" >/dev/null || true
+    ;;
+  *)
+    echo "healthcheck: unknown ALERT_WEBHOOK_KIND=$ALERT_WEBHOOK_KIND" >&2
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/docs/runbooks/RUNBOOK.md
+++ b/docs/runbooks/RUNBOOK.md
@@ -298,12 +298,81 @@ bash deploy/smoke-test.sh
 | `botmarket-api` | Fastify API + в-процессе bot worker | 3001 |
 | `botmarket-web` | Next.js UI | 3000 |
 | `botmarket-backup.timer` | Автоматический backup по расписанию | — |
+| `botmarket-healthcheck.timer` | Проверка `/readyz` каждые 30 сек + alert | — |
 
 Nginx слушает 80/443 и проксирует на 3001 (API: `/api/`) и 3000 (Web).
 
 ---
 
-## 10. Полезные команды
+## 10. Мониторинг и алерты
+
+### 10.1 Prometheus scrape
+
+API экспортирует метрики на `/metrics` (без auth, стандарт Prometheus). nginx
+разрешает доступ только с loopback — снаружи endpoint недоступен. Метрики:
+
+- `botmarket_intent_created_total` / `_filled_total` / `_failed_total` — counters
+- `botmarket_http_request_duration_seconds` — histogram (method/route/status)
+- `process_*`, `nodejs_*` — defaults от `prom-client`
+
+Пример scrape-конфига (`prometheus.yml`):
+
+```yaml
+scrape_configs:
+  - job_name: botmarket-api
+    static_configs:
+      - targets: ["127.0.0.1:4000"]
+```
+
+### 10.2 Sentry (ошибки)
+
+Опциональная интеграция. Включается установкой `SENTRY_DSN` в `.env`. Если DSN
+не задан — init пропускается (no-op). Все 5xx из Fastify error handler'а
+отправляются как `captureException` с тегом `reqId` и контекстом `request`.
+
+Дополнительно:
+
+- `SENTRY_RELEASE` — тег release (рекомендуется: git sha из `deploy.sh`)
+- `SENTRY_TRACES_SAMPLE_RATE` — доля traces (по умолчанию 0 — без traces)
+
+### 10.3 Алерты по `/readyz`
+
+Скрипт `deploy/healthcheck.sh` + systemd timer дёргают `/readyz` каждые 30 сек.
+При **2 подряд** non-200 ответах шлётся webhook (Telegram / Slack).
+Состояние счётчика хранится в `/var/lib/botmarket/healthcheck.state`.
+
+**Установка:**
+
+```bash
+cp deploy/botmarket-healthcheck.{service,timer} /etc/systemd/system/
+systemctl daemon-reload
+
+# Прописать credentials в drop-in:
+systemctl edit botmarket-healthcheck.service
+# В редакторе:
+#   [Service]
+#   Environment="ALERT_WEBHOOK_URL=https://api.telegram.org/bot<TOKEN>/sendMessage"
+#   Environment="ALERT_CHAT_ID=-1001234567890"
+#   # Для Slack:
+#   # Environment="ALERT_WEBHOOK_KIND=slack"
+#   # Environment="ALERT_WEBHOOK_URL=https://hooks.slack.com/services/..."
+
+systemctl enable --now botmarket-healthcheck.timer
+```
+
+**Проверка:**
+
+```bash
+systemctl list-timers | grep healthcheck     # ближайшее срабатывание
+journalctl -u botmarket-healthcheck -n 50    # последние запуски
+```
+
+**Кастомизация:** переменные в drop-in — `READYZ_URL`, `FAIL_THRESHOLD`,
+`STATE_FILE` (см. комментарии в `deploy/healthcheck.sh`).
+
+---
+
+## 11. Полезные команды
 
 ```bash
 # Версия приложения (из package.json)


### PR DESCRIPTION
## Summary

Third slice of the observability stack (Action 3 from `docs/37` §6). Simple
external liveness alerting using only systemd + bash + curl — no extra daemon.

- `deploy/healthcheck.sh` probes `/readyz` and tracks consecutive failures
  in `/var/lib/botmarket/healthcheck.state`. Alert fires only on the edge
  where failures hit `FAIL_THRESHOLD` (default 2) to avoid spam. Supports
  Telegram (`sendMessage`) and Slack (incoming webhook) payload formats.
- `deploy/botmarket-healthcheck.service` + `.timer`: oneshot timer every 30s
  (`OnUnitActiveSec=30s`, `OnBootSec=1min`).
- `docs/runbooks/RUNBOOK.md`: new §10 "Мониторинг и алерты" covering
  Prometheus scrape, Sentry, and `/readyz` alerting install + ops.

Credentials are provisioned via `systemctl edit` drop-in
(`ALERT_WEBHOOK_URL`, `ALERT_CHAT_ID`, `ALERT_WEBHOOK_KIND`). Without a
webhook URL the probe still runs and logs — install is safe before
credentials are set up.

## Test plan

- [x] `bash -n deploy/healthcheck.sh` — syntax clean
- [x] Manual run with unreachable URL: state counter climbs 1 → 2 → 3, alert
      only attempted at exactly threshold (no spam)
- [x] Manual run with 200 URL: state resets to 0
- [x] No API code changes — existing test suite unaffected
