### PR TITLE
fix(worker): release leases on graceful shutdown

### DIFF
--- a/apps/api/src/lib/botWorker.ts
+++ b/apps/api/src/lib/botWorker.ts
@@ -514,6 +514,21 @@ async function renewLeases() {
   });
 }
 
+/**
+ * Release leases owned by this worker on shutdown (§4.5.1 / docs/37).
+ *
+ * Sets `leaseUntil` to now on all RUNNING runs that this worker holds so
+ * that a restarted worker can claim them immediately, instead of waiting
+ * the full 30s natural expiration window. Exported for direct testing.
+ */
+export async function releaseOwnedLeases(): Promise<number> {
+  const result = await prisma.botRun.updateMany({
+    where: { leaseOwner: WORKER_ID, state: "RUNNING" },
+    data: { leaseUntil: new Date() },
+  });
+  return result.count;
+}
+
 // ---------------------------------------------------------------------------
 // Intent execution (Stage 11) — delegated to worker/intentExecutor.ts (#230)
 // ---------------------------------------------------------------------------
@@ -1895,6 +1910,13 @@ export function startBotWorker(): () => Promise<void> {
     if (pollInFlight) {
       const timeout = new Promise<void>((resolve) => setTimeout(resolve, GRACE_PERIOD_MS));
       await Promise.race([pollInFlight, timeout]);
+    }
+
+    try {
+      const released = await releaseOwnedLeases();
+      workerLog.info({ released, workerId: WORKER_ID }, "leases released");
+    } catch (err) {
+      workerLog.error({ err, workerId: WORKER_ID }, "failed to release leases");
     }
 
     workerLog.info("botWorker stopped");

--- a/apps/api/tests/worker/releaseOwnedLeases.test.ts
+++ b/apps/api/tests/worker/releaseOwnedLeases.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const updateMany = vi.fn();
+
+vi.mock("@prisma/client", () => ({
+  PrismaClient: vi.fn().mockImplementation(() => ({})),
+  Prisma: { sql: vi.fn(), join: vi.fn() },
+}));
+
+vi.mock("../../src/lib/prisma.js", () => ({
+  prisma: {
+    botRun: { updateMany: (...args: unknown[]) => updateMany(...args) },
+  },
+  getPoolMetrics: vi.fn().mockResolvedValue(null),
+  startPoolMetricsLogging: vi.fn(),
+  stopPoolMetricsLogging: vi.fn(),
+}));
+
+describe("releaseOwnedLeases", () => {
+  beforeEach(() => {
+    updateMany.mockReset();
+  });
+
+  it("updates only RUNNING runs owned by this worker, setting leaseUntil to now", async () => {
+    updateMany.mockResolvedValue({ count: 3 });
+
+    const { releaseOwnedLeases } = await import("../../src/lib/botWorker.js");
+    const released = await releaseOwnedLeases();
+
+    expect(released).toBe(3);
+    expect(updateMany).toHaveBeenCalledTimes(1);
+
+    const call = updateMany.mock.calls[0][0] as {
+      where: { leaseOwner: string; state: string };
+      data: { leaseUntil: Date };
+    };
+    expect(call.where.state).toBe("RUNNING");
+    expect(call.where.leaseOwner).toMatch(/^worker-\d+$/);
+    expect(call.data.leaseUntil).toBeInstanceOf(Date);
+
+    // leaseUntil should be now (±5s)
+    const skew = Math.abs(Date.now() - call.data.leaseUntil.getTime());
+    expect(skew).toBeLessThan(5000);
+  });
+
+  it("returns 0 when no leases match", async () => {
+    updateMany.mockResolvedValue({ count: 0 });
+
+    const { releaseOwnedLeases } = await import("../../src/lib/botWorker.js");
+    expect(await releaseOwnedLeases()).toBe(0);
+  });
+});

--- a/deploy/botmarket-healthcheck.service
+++ b/deploy/botmarket-healthcheck.service
@@ -1,0 +1,22 @@
+# systemd one-shot service for API /readyz health probe
+# Triggered by: botmarket-healthcheck.timer (every 30s)
+# Install: cp deploy/botmarket-healthcheck.service /etc/systemd/system/
+#
+# Configure credentials via drop-in:
+#   systemctl edit botmarket-healthcheck.service
+# and set (example):
+#   [Service]
+#   Environment="ALERT_WEBHOOK_URL=https://api.telegram.org/bot<token>/sendMessage"
+#   Environment="ALERT_CHAT_ID=-100..."
+
+[Unit]
+Description=BotMarketplace /readyz Health Probe
+After=network-online.target botmarket-api.service
+
+[Service]
+Type=oneshot
+User=root
+ExecStart=/bin/bash /opt/-botmarketplace-site/deploy/healthcheck.sh
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=botmarket-healthcheck

--- a/deploy/botmarket-healthcheck.timer
+++ b/deploy/botmarket-healthcheck.timer
@@ -1,0 +1,20 @@
+# systemd timer — probe /readyz every 30 seconds
+# Install:
+#   cp deploy/botmarket-healthcheck.timer /etc/systemd/system/
+#   cp deploy/botmarket-healthcheck.service /etc/systemd/system/
+#   systemctl daemon-reload
+#   systemctl enable --now botmarket-healthcheck.timer
+# Status: systemctl list-timers | grep healthcheck
+# Recent runs: journalctl -u botmarket-healthcheck -n 50
+
+[Unit]
+Description=BotMarketplace /readyz Health Probe Timer
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=30s
+AccuracySec=5s
+Unit=botmarket-healthcheck.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/healthcheck.sh
+++ b/deploy/healthcheck.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# healthcheck.sh — probe the API /readyz endpoint and alert on repeated failure.
+#
+# Triggered by systemd timer (botmarket-healthcheck.timer) every 30s.
+# On two consecutive non-200 responses an alert is sent to $ALERT_WEBHOOK_URL
+# (Telegram bot API or Slack-incoming-webhook compatible JSON POST).
+#
+# Consecutive-failure state is persisted at $STATE_FILE so the check is stateless
+# between invocations.
+#
+# Environment:
+#   READYZ_URL          URL to probe (default: http://127.0.0.1:4000/readyz)
+#   ALERT_WEBHOOK_URL   Webhook to POST on alert (optional — skipped if unset)
+#   ALERT_WEBHOOK_KIND  "telegram" (default) or "slack"
+#   ALERT_CHAT_ID       Telegram chat id (required if kind=telegram)
+#   STATE_FILE          Failure counter file (default: /var/lib/botmarket/healthcheck.state)
+#   FAIL_THRESHOLD      Consecutive failures before alert (default: 2)
+
+set -u
+
+READYZ_URL="${READYZ_URL:-http://127.0.0.1:4000/readyz}"
+ALERT_WEBHOOK_URL="${ALERT_WEBHOOK_URL:-}"
+ALERT_WEBHOOK_KIND="${ALERT_WEBHOOK_KIND:-telegram}"
+ALERT_CHAT_ID="${ALERT_CHAT_ID:-}"
+STATE_FILE="${STATE_FILE:-/var/lib/botmarket/healthcheck.state}"
+FAIL_THRESHOLD="${FAIL_THRESHOLD:-2}"
+
+mkdir -p "$(dirname "$STATE_FILE")"
+prev_fails=0
+if [[ -r "$STATE_FILE" ]]; then
+  prev_fails=$(cat "$STATE_FILE" 2>/dev/null || echo 0)
+  [[ "$prev_fails" =~ ^[0-9]+$ ]] || prev_fails=0
+fi
+
+status=$(curl -s -o /tmp/healthcheck.body -w "%{http_code}" --max-time 5 "$READYZ_URL" 2>/dev/null)
+[[ -z "$status" ]] && status="000"
+
+if [[ "$status" == "200" ]]; then
+  echo 0 > "$STATE_FILE"
+  exit 0
+fi
+
+fails=$((prev_fails + 1))
+echo "$fails" > "$STATE_FILE"
+
+echo "healthcheck: $READYZ_URL returned $status (consecutive failures: $fails)" >&2
+
+if (( fails < FAIL_THRESHOLD )); then
+  exit 0
+fi
+
+# Only alert on the edge (first time we cross the threshold) to avoid spam.
+if (( fails > FAIL_THRESHOLD )); then
+  exit 0
+fi
+
+if [[ -z "$ALERT_WEBHOOK_URL" ]]; then
+  echo "healthcheck: ALERT_WEBHOOK_URL not set — skipping alert" >&2
+  exit 0
+fi
+
+host=$(hostname -f 2>/dev/null || hostname)
+body=$(head -c 500 /tmp/healthcheck.body 2>/dev/null || echo "")
+message="[botmarket] $host /readyz unhealthy (status=$status, consecutive=$fails). Body: $body"
+
+case "$ALERT_WEBHOOK_KIND" in
+  telegram)
+    if [[ -z "$ALERT_CHAT_ID" ]]; then
+      echo "healthcheck: ALERT_CHAT_ID required for telegram" >&2
+      exit 1
+    fi
+    curl -s --max-time 5 -X POST "$ALERT_WEBHOOK_URL" \
+      --data-urlencode "chat_id=$ALERT_CHAT_ID" \
+      --data-urlencode "text=$message" >/dev/null || true
+    ;;
+  slack)
+    payload=$(printf '{"text":%s}' "$(printf '%s' "$message" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')")
+    curl -s --max-time 5 -X POST -H "Content-Type: application/json" \
+      --data "$payload" "$ALERT_WEBHOOK_URL" >/dev/null || true
+    ;;
+  *)
+    echo "healthcheck: unknown ALERT_WEBHOOK_KIND=$ALERT_WEBHOOK_KIND" >&2
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/docs/runbooks/RUNBOOK.md
+++ b/docs/runbooks/RUNBOOK.md
@@ -298,12 +298,81 @@ bash deploy/smoke-test.sh
 | `botmarket-api` | Fastify API + в-процессе bot worker | 3001 |
 | `botmarket-web` | Next.js UI | 3000 |
 | `botmarket-backup.timer` | Автоматический backup по расписанию | — |
+| `botmarket-healthcheck.timer` | Проверка `/readyz` каждые 30 сек + alert | — |
 
 Nginx слушает 80/443 и проксирует на 3001 (API: `/api/`) и 3000 (Web).
 
 ---
 
-## 10. Полезные команды
+## 10. Мониторинг и алерты
+
+### 10.1 Prometheus scrape
+
+API экспортирует метрики на `/metrics` (без auth, стандарт Prometheus). nginx
+разрешает доступ только с loopback — снаружи endpoint недоступен. Метрики:
+
+- `botmarket_intent_created_total` / `_filled_total` / `_failed_total` — counters
+- `botmarket_http_request_duration_seconds` — histogram (method/route/status)
+- `process_*`, `nodejs_*` — defaults от `prom-client`
+
+Пример scrape-конфига (`prometheus.yml`):
+
+```yaml
+scrape_configs:
+  - job_name: botmarket-api
+    static_configs:
+      - targets: ["127.0.0.1:4000"]
+```
+
+### 10.2 Sentry (ошибки)
+
+Опциональная интеграция. Включается установкой `SENTRY_DSN` в `.env`. Если DSN
+не задан — init пропускается (no-op). Все 5xx из Fastify error handler'а
+отправляются как `captureException` с тегом `reqId` и контекстом `request`.
+
+Дополнительно:
+
+- `SENTRY_RELEASE` — тег release (рекомендуется: git sha из `deploy.sh`)
+- `SENTRY_TRACES_SAMPLE_RATE` — доля traces (по умолчанию 0 — без traces)
+
+### 10.3 Алерты по `/readyz`
+
+Скрипт `deploy/healthcheck.sh` + systemd timer дёргают `/readyz` каждые 30 сек.
+При **2 подряд** non-200 ответах шлётся webhook (Telegram / Slack).
+Состояние счётчика хранится в `/var/lib/botmarket/healthcheck.state`.
+
+**Установка:**
+
+```bash
+cp deploy/botmarket-healthcheck.{service,timer} /etc/systemd/system/
+systemctl daemon-reload
+
+# Прописать credentials в drop-in:
+systemctl edit botmarket-healthcheck.service
+# В редакторе:
+#   [Service]
+#   Environment="ALERT_WEBHOOK_URL=https://api.telegram.org/bot<TOKEN>/sendMessage"
+#   Environment="ALERT_CHAT_ID=-1001234567890"
+#   # Для Slack:
+#   # Environment="ALERT_WEBHOOK_KIND=slack"
+#   # Environment="ALERT_WEBHOOK_URL=https://hooks.slack.com/services/..."
+
+systemctl enable --now botmarket-healthcheck.timer
+```
+
+**Проверка:**
+
+```bash
+systemctl list-timers | grep healthcheck     # ближайшее срабатывание
+journalctl -u botmarket-healthcheck -n 50    # последние запуски
+```
+
+**Кастомизация:** переменные в drop-in — `READYZ_URL`, `FAIL_THRESHOLD`,
+`STATE_FILE` (см. комментарии в `deploy/healthcheck.sh`).
+
+---
+
+## 11. Полезные команды
 
 ```bash
 # Версия приложения (из package.json)


### PR DESCRIPTION
## Summary

First slice of `docs/37` §4.5 (graceful shutdown + reconciliation).

When `stopWorker()` runs (SIGTERM / SIGINT / explicit stop), after draining
the in-flight poll we now set `leaseUntil = now` on all RUNNING runs owned
by this `WORKER_ID`.

- **Before:** a restarted worker had to wait up to 30s for the natural lease
  expiration window before claiming the run, even though the previous process
  had cleanly exited.
- **After:** a restarted worker can claim immediately.

`releaseOwnedLeases()` is extracted as an exported helper so it is unit-testable
without spinning up the full polling loop. `stopWorker()` wraps it in
try/catch — if DB is already down, the worker still terminates cleanly.

## Test plan

- [x] `pnpm test:api` — 1674 passed (prev 1672 + 2 new in
      `tests/worker/releaseOwnedLeases.test.ts`)
- [x] `pnpm build:api`
- [x] New tests cover: correct filter (`leaseOwner=WORKER_ID, state=RUNNING`),
      `leaseUntil` set to ~now, returns `count` from prisma
