### PR TITLE
feat(worker): periodic stale-PENDING sweep (§4.5.2)

### DIFF
--- a/apps/api/src/lib/metrics.ts
+++ b/apps/api/src/lib/metrics.ts
@@ -22,6 +22,12 @@ export const intentFailedTotal = new Counter({
   registers: [register],
 });
 
+export const stalePendingCancelledTotal = new Counter({
+  name: "botmarket_stale_pending_cancelled_total",
+  help: "PENDING intents cancelled by the periodic reconciliation sweep.",
+  registers: [register],
+});
+
 export const httpRequestDurationSeconds = new Histogram({
   name: "botmarket_http_request_duration_seconds",
   help: "HTTP request duration in seconds.",

--- a/apps/api/src/lib/periodicReconciler.ts
+++ b/apps/api/src/lib/periodicReconciler.ts
@@ -1,0 +1,123 @@
+/**
+ * Periodic reconciliation (§4.5.2 / docs/37).
+ *
+ * The in-poll reconcile loop in botWorker.ts handles PLACED intents against
+ * the exchange, but only when the worker tick is alive. If the worker gets
+ * wedged (stuck HTTP call, unhandled rejection blocking the event loop,
+ * Prisma pool exhaustion…), PENDING intents accumulate indefinitely with
+ * nobody to place them.
+ *
+ * This module is a safety net that runs independently from the poll loop.
+ * Every STALE_PENDING_INTERVAL_MS it cancels PENDING intents belonging to
+ * RUNNING runs that were created more than STALE_PENDING_MIN_AGE_MS ago —
+ * on a healthy worker, PENDING → PLACED happens within one poll cycle
+ * (~4s), so a PENDING older than the threshold is definitely stuck.
+ */
+
+import { Prisma } from "@prisma/client";
+import { prisma } from "./prisma.js";
+import { logger } from "./logger.js";
+import { stalePendingCancelledTotal } from "./metrics.js";
+
+const reconcilerLog = logger.child({ module: "periodicReconciler" });
+
+/** PENDING intents older than this are considered stuck and get cancelled. */
+export const STALE_PENDING_MIN_AGE_MS = parseInt(
+  process.env.STALE_PENDING_MIN_AGE_MS ?? "",
+  10,
+) || 10 * 60_000;
+
+/** How often the periodic sweep runs. */
+export const STALE_PENDING_INTERVAL_MS = parseInt(
+  process.env.STALE_PENDING_INTERVAL_MS ?? "",
+  10,
+) || 5 * 60_000;
+
+/**
+ * Find and cancel PENDING intents attached to RUNNING runs that are older
+ * than STALE_PENDING_MIN_AGE_MS. Returns the number of intents cancelled.
+ *
+ * Emits a `periodic_reconciliation` BotEvent for each affected run so the
+ * action is visible in the run's event log.
+ */
+export async function sweepStalePendingIntents(): Promise<number> {
+  const cutoff = new Date(Date.now() - STALE_PENDING_MIN_AGE_MS);
+
+  const stale = await prisma.botIntent.findMany({
+    where: {
+      state: "PENDING",
+      createdAt: { lt: cutoff },
+      botRun: { state: "RUNNING" },
+    },
+    select: { id: true, intentId: true, botRunId: true, createdAt: true },
+    take: 500,
+  });
+
+  if (stale.length === 0) return 0;
+
+  const ids = stale.map((i) => i.id);
+  const updated = await prisma.botIntent.updateMany({
+    where: { id: { in: ids }, state: "PENDING" },
+    data: {
+      state: "CANCELLED",
+      metaJson: {
+        reason: "periodic_reconciliation_stale_pending",
+        cancelledAt: new Date().toISOString(),
+        minAgeMs: STALE_PENDING_MIN_AGE_MS,
+      } as Prisma.InputJsonValue,
+    },
+  });
+
+  // Group by run for event log
+  const byRun = new Map<string, typeof stale>();
+  for (const i of stale) {
+    const arr = byRun.get(i.botRunId) ?? [];
+    arr.push(i);
+    byRun.set(i.botRunId, arr);
+  }
+
+  for (const [botRunId, intents] of byRun) {
+    await prisma.botEvent.create({
+      data: {
+        botRunId,
+        type: "periodic_reconciliation",
+        payloadJson: {
+          action: "cancel_stale_pending",
+          cancelledCount: intents.length,
+          cancelledIntentIds: intents.map((i) => i.intentId),
+          oldestAgeMs: Date.now() - Math.min(...intents.map((i) => i.createdAt.getTime())),
+          minAgeMs: STALE_PENDING_MIN_AGE_MS,
+        } as Prisma.InputJsonValue,
+      },
+    });
+  }
+
+  stalePendingCancelledTotal.inc(updated.count);
+  reconcilerLog.warn(
+    { cancelled: updated.count, runs: byRun.size, minAgeMs: STALE_PENDING_MIN_AGE_MS },
+    "periodic reconciliation: cancelled stale PENDING intents (worker may be wedged)",
+  );
+  return updated.count;
+}
+
+/**
+ * Start the periodic reconciliation sweep. Returns a stop function.
+ * Safe to call from any process that has DB access (server / worker).
+ */
+export function startPeriodicReconciler(): () => void {
+  const run = () => {
+    sweepStalePendingIntents().catch((err) => {
+      reconcilerLog.error({ err }, "periodic reconciler error (non-fatal)");
+    });
+  };
+  const timer = setInterval(run, STALE_PENDING_INTERVAL_MS);
+  if (timer.unref) timer.unref();
+  reconcilerLog.info(
+    { intervalMs: STALE_PENDING_INTERVAL_MS, minAgeMs: STALE_PENDING_MIN_AGE_MS },
+    "periodic reconciler started",
+  );
+  return () => {
+    clearInterval(timer);
+    reconcilerLog.info("periodic reconciler stopped");
+  };
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -6,6 +6,7 @@ import { startBotWorker } from "./lib/botWorker.js";
 import cron from "node-cron";
 import { runIngestion } from "./lib/funding/ingestJob.js";
 import { prisma, startPoolMetricsLogging, stopPoolMetricsLogging } from "./lib/prisma.js";
+import { startPeriodicReconciler } from "./lib/periodicReconciler.js";
 import { logger } from "./lib/logger.js";
 import { cleanupExpiredRefreshTokens } from "./routes/auth.js";
 
@@ -42,6 +43,9 @@ async function main() {
 
     // Start pool metrics logging (Rec C)
     startPoolMetricsLogging();
+
+    // Periodic reconciler — safety net if the worker tick gets wedged (§4.5.2)
+    const stopReconciler = embeddedWorker ? startPeriodicReconciler() : null;
 
     // Funding ingestion cron — every 8 hours (matches Bybit settlement schedule)
     const fundingCron = cron.schedule("0 */8 * * *", () => {
@@ -81,6 +85,7 @@ async function main() {
         fundingCron.stop();
         tokenCleanupCron.stop();
         stopPoolMetricsLogging();
+        if (stopReconciler) stopReconciler();
         if (stopWorker) await stopWorker();
         await app.close();
         await prisma.$disconnect();

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -14,6 +14,7 @@
 import { startBotWorker } from "./lib/botWorker.js";
 import { prisma } from "./lib/prisma.js";
 import { logger } from "./lib/logger.js";
+import { startPeriodicReconciler } from "./lib/periodicReconciler.js";
 
 const workerLog = logger.child({ module: "worker-main" });
 
@@ -35,11 +36,13 @@ async function main() {
   workerLog.info("Starting standalone bot worker process");
 
   const stopWorker = startBotWorker();
+  const stopReconciler = startPeriodicReconciler();
 
   // Graceful shutdown
   for (const signal of ["SIGINT", "SIGTERM"] as const) {
     process.once(signal, async () => {
       workerLog.info({ signal }, "Received shutdown signal");
+      stopReconciler();
       await stopWorker();
       await prisma.$disconnect();
       workerLog.info("Standalone worker stopped");

--- a/apps/api/tests/lib/periodicReconciler.test.ts
+++ b/apps/api/tests/lib/periodicReconciler.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const findMany = vi.fn();
+const updateMany = vi.fn();
+const eventCreate = vi.fn();
+
+vi.mock("@prisma/client", () => ({
+  PrismaClient: vi.fn().mockImplementation(() => ({})),
+  Prisma: { sql: vi.fn(), join: vi.fn(), InputJsonValue: null },
+}));
+
+vi.mock("../../src/lib/prisma.js", () => ({
+  prisma: {
+    botIntent: {
+      findMany: (...a: unknown[]) => findMany(...a),
+      updateMany: (...a: unknown[]) => updateMany(...a),
+    },
+    botEvent: { create: (...a: unknown[]) => eventCreate(...a) },
+  },
+}));
+
+describe("periodicReconciler.sweepStalePendingIntents", () => {
+  beforeEach(() => {
+    findMany.mockReset();
+    updateMany.mockReset();
+    eventCreate.mockReset();
+  });
+
+  it("returns 0 and does no writes when no stale intents exist", async () => {
+    findMany.mockResolvedValue([]);
+    const { sweepStalePendingIntents } = await import("../../src/lib/periodicReconciler.js");
+    expect(await sweepStalePendingIntents()).toBe(0);
+    expect(updateMany).not.toHaveBeenCalled();
+    expect(eventCreate).not.toHaveBeenCalled();
+  });
+
+  it("queries only PENDING intents older than the cutoff, attached to RUNNING runs", async () => {
+    findMany.mockResolvedValue([]);
+    const { sweepStalePendingIntents, STALE_PENDING_MIN_AGE_MS } = await import(
+      "../../src/lib/periodicReconciler.js"
+    );
+    const before = Date.now();
+    await sweepStalePendingIntents();
+    const after = Date.now();
+
+    expect(findMany).toHaveBeenCalledTimes(1);
+    const arg = findMany.mock.calls[0][0] as {
+      where: { state: string; createdAt: { lt: Date }; botRun: { state: string } };
+    };
+    expect(arg.where.state).toBe("PENDING");
+    expect(arg.where.botRun.state).toBe("RUNNING");
+    const cutoffMs = arg.where.createdAt.lt.getTime();
+    expect(cutoffMs).toBeGreaterThanOrEqual(before - STALE_PENDING_MIN_AGE_MS - 10);
+    expect(cutoffMs).toBeLessThanOrEqual(after - STALE_PENDING_MIN_AGE_MS + 10);
+  });
+
+  it("cancels stale PENDING and creates one BotEvent per run", async () => {
+    const now = Date.now();
+    findMany.mockResolvedValue([
+      { id: "i1", intentId: "int-1", botRunId: "runA", createdAt: new Date(now - 20 * 60_000) },
+      { id: "i2", intentId: "int-2", botRunId: "runA", createdAt: new Date(now - 15 * 60_000) },
+      { id: "i3", intentId: "int-3", botRunId: "runB", createdAt: new Date(now - 11 * 60_000) },
+    ]);
+    updateMany.mockResolvedValue({ count: 3 });
+
+    const { sweepStalePendingIntents } = await import("../../src/lib/periodicReconciler.js");
+    const cancelled = await sweepStalePendingIntents();
+
+    expect(cancelled).toBe(3);
+    expect(updateMany).toHaveBeenCalledTimes(1);
+    const updArg = updateMany.mock.calls[0][0] as {
+      where: { id: { in: string[] }; state: string };
+      data: { state: string; metaJson: { reason: string } };
+    };
+    expect(updArg.where.id.in.sort()).toEqual(["i1", "i2", "i3"]);
+    expect(updArg.where.state).toBe("PENDING");
+    expect(updArg.data.state).toBe("CANCELLED");
+    expect(updArg.data.metaJson.reason).toBe("periodic_reconciliation_stale_pending");
+
+    // One event per distinct runId
+    expect(eventCreate).toHaveBeenCalledTimes(2);
+    const runIds = eventCreate.mock.calls.map(
+      (c) => (c[0] as { data: { botRunId: string } }).data.botRunId,
+    );
+    expect(runIds.sort()).toEqual(["runA", "runB"]);
+  });
+});


### PR DESCRIPTION
## Summary

Second slice of `docs/37` §4.5. Adds a safety-net reconciler that runs
independently from the poll loop every `STALE_PENDING_INTERVAL_MS`
(default 5m). Cancels any PENDING intent attached to a RUNNING run that
is older than `STALE_PENDING_MIN_AGE_MS` (default 10m).

**Rationale:** on a healthy worker, `PENDING` → `PLACED` happens within
one poll cycle (~4s). A PENDING older than 10m is definitely stuck — the
worker tick is wedged (Prisma pool exhaustion, stuck HTTP call,
unhandled rejection blocking the event loop). The in-poll reconciler
can't catch this because it also depends on the poll loop.

- `lib/periodicReconciler.ts`:
  - `sweepStalePendingIntents()` — find + cancel stale PENDING in RUNNING runs
  - `startPeriodicReconciler()` — setInterval wrapper, returns stop fn
  - Emits one `periodic_reconciliation` BotEvent per affected run
- New counter `botmarket_stale_pending_cancelled_total` (prom-client)
- `server.ts` — starts reconciler alongside embedded worker; stops it in
  graceful-shutdown path
- `worker.ts` — starts reconciler alongside standalone worker

Config: `STALE_PENDING_INTERVAL_MS` (sweep cadence), `STALE_PENDING_MIN_AGE_MS`
(age threshold) — both tunable via env, so short-lived tests can set them lower.

## Test plan

- [x] `pnpm test:api` — 1677 passed (prev 1674 + 3 new in
      `tests/lib/periodicReconciler.test.ts`)
- [x] `pnpm build:api`
- [x] New tests cover: no-op when no matches, correct where-clause
      (PENDING + cutoff + RUNNING filter), cancel + one event per run
