### PR TITLE
feat(worker): reclaim orphaned leases from dead workers (§4.5.3)

### DIFF
--- a/apps/api/src/lib/metrics.ts
+++ b/apps/api/src/lib/metrics.ts
@@ -28,6 +28,12 @@ export const stalePendingCancelledTotal = new Counter({
   registers: [register],
 });
 
+export const orphanLeasesReclaimedTotal = new Counter({
+  name: "botmarket_orphan_leases_reclaimed_total",
+  help: "BotRun leases reclaimed from dead workers by the periodic reconciler.",
+  registers: [register],
+});
+
 export const httpRequestDurationSeconds = new Histogram({
   name: "botmarket_http_request_duration_seconds",
   help: "HTTP request duration in seconds.",

--- a/apps/api/src/lib/periodicReconciler.ts
+++ b/apps/api/src/lib/periodicReconciler.ts
@@ -17,7 +17,12 @@
 import { Prisma } from "@prisma/client";
 import { prisma } from "./prisma.js";
 import { logger } from "./logger.js";
-import { stalePendingCancelledTotal } from "./metrics.js";
+import { stalePendingCancelledTotal, orphanLeasesReclaimedTotal } from "./metrics.js";
+
+const WORKER_ID = `worker-${process.pid}`;
+
+/** A lease is considered orphaned this long after expiration. */
+export const ORPHAN_GRACE_MS = parseInt(process.env.ORPHAN_GRACE_MS ?? "", 10) || 60_000;
 
 const reconcilerLog = logger.child({ module: "periodicReconciler" });
 
@@ -101,13 +106,50 @@ export async function sweepStalePendingIntents(): Promise<number> {
 }
 
 /**
+ * Reclaim orphaned leases (§4.5.3 / docs/37).
+ *
+ * A lease is orphaned when its owning worker died without releasing it:
+ * `leaseUntil` is in the past by more than ORPHAN_GRACE_MS. This function
+ * atomically transfers such leases to the current worker so it can take
+ * over polling, instead of leaving the run stuck pointing at a dead PID.
+ *
+ * Uses a single conditional updateMany so concurrent workers can't both
+ * claim the same run — the first one wins, the rest see count=0.
+ */
+export async function reclaimOrphanedLeases(): Promise<number> {
+  const cutoff = new Date(Date.now() - ORPHAN_GRACE_MS);
+  const newLeaseUntil = new Date(Date.now() + 30_000);
+
+  const result = await prisma.botRun.updateMany({
+    where: {
+      state: "RUNNING",
+      leaseUntil: { lt: cutoff },
+      NOT: { leaseOwner: WORKER_ID },
+    },
+    data: { leaseOwner: WORKER_ID, leaseUntil: newLeaseUntil },
+  });
+
+  if (result.count > 0) {
+    orphanLeasesReclaimedTotal.inc(result.count);
+    reconcilerLog.warn(
+      { reclaimed: result.count, workerId: WORKER_ID, graceMs: ORPHAN_GRACE_MS },
+      "reclaimed orphaned leases from dead workers",
+    );
+  }
+  return result.count;
+}
+
+/**
  * Start the periodic reconciliation sweep. Returns a stop function.
  * Safe to call from any process that has DB access (server / worker).
  */
 export function startPeriodicReconciler(): () => void {
   const run = () => {
     sweepStalePendingIntents().catch((err) => {
-      reconcilerLog.error({ err }, "periodic reconciler error (non-fatal)");
+      reconcilerLog.error({ err }, "stale-pending sweep error (non-fatal)");
+    });
+    reclaimOrphanedLeases().catch((err) => {
+      reconcilerLog.error({ err }, "orphan-lease reclaim error (non-fatal)");
     });
   };
   const timer = setInterval(run, STALE_PENDING_INTERVAL_MS);

--- a/apps/api/tests/lib/periodicReconciler.test.ts
+++ b/apps/api/tests/lib/periodicReconciler.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const findMany = vi.fn();
 const updateMany = vi.fn();
+const runUpdateMany = vi.fn();
 const eventCreate = vi.fn();
 
 vi.mock("@prisma/client", () => ({
@@ -15,6 +16,9 @@ vi.mock("../../src/lib/prisma.js", () => ({
       findMany: (...a: unknown[]) => findMany(...a),
       updateMany: (...a: unknown[]) => updateMany(...a),
     },
+    botRun: {
+      updateMany: (...a: unknown[]) => runUpdateMany(...a),
+    },
     botEvent: { create: (...a: unknown[]) => eventCreate(...a) },
   },
 }));
@@ -23,6 +27,7 @@ describe("periodicReconciler.sweepStalePendingIntents", () => {
   beforeEach(() => {
     findMany.mockReset();
     updateMany.mockReset();
+    runUpdateMany.mockReset();
     eventCreate.mockReset();
   });
 
@@ -83,5 +88,50 @@ describe("periodicReconciler.sweepStalePendingIntents", () => {
       (c) => (c[0] as { data: { botRunId: string } }).data.botRunId,
     );
     expect(runIds.sort()).toEqual(["runA", "runB"]);
+  });
+});
+
+describe("periodicReconciler.reclaimOrphanedLeases", () => {
+  beforeEach(() => {
+    runUpdateMany.mockReset();
+  });
+
+  it("returns 0 and does not throw when no orphans match", async () => {
+    runUpdateMany.mockResolvedValue({ count: 0 });
+    const { reclaimOrphanedLeases } = await import("../../src/lib/periodicReconciler.js");
+    expect(await reclaimOrphanedLeases()).toBe(0);
+  });
+
+  it("conditionally claims orphans: state=RUNNING, leaseUntil<cutoff, not owned by us", async () => {
+    runUpdateMany.mockResolvedValue({ count: 2 });
+
+    const { reclaimOrphanedLeases, ORPHAN_GRACE_MS } = await import(
+      "../../src/lib/periodicReconciler.js"
+    );
+    const before = Date.now();
+    const reclaimed = await reclaimOrphanedLeases();
+    const after = Date.now();
+
+    expect(reclaimed).toBe(2);
+    expect(runUpdateMany).toHaveBeenCalledTimes(1);
+
+    const arg = runUpdateMany.mock.calls[0][0] as {
+      where: { state: string; leaseUntil: { lt: Date }; NOT: { leaseOwner: string } };
+      data: { leaseOwner: string; leaseUntil: Date };
+    };
+    expect(arg.where.state).toBe("RUNNING");
+
+    const cutoffMs = arg.where.leaseUntil.lt.getTime();
+    expect(cutoffMs).toBeGreaterThanOrEqual(before - ORPHAN_GRACE_MS - 10);
+    expect(cutoffMs).toBeLessThanOrEqual(after - ORPHAN_GRACE_MS + 10);
+
+    expect(arg.where.NOT.leaseOwner).toMatch(/^worker-\d+$/);
+    expect(arg.data.leaseOwner).toMatch(/^worker-\d+$/);
+    expect(arg.data.leaseOwner).toBe(arg.where.NOT.leaseOwner);
+
+    // New leaseUntil is ~30s in the future
+    const newLeaseMs = arg.data.leaseUntil.getTime();
+    expect(newLeaseMs).toBeGreaterThanOrEqual(before + 30_000 - 10);
+    expect(newLeaseMs).toBeLessThanOrEqual(after + 30_000 + 10);
   });
 });


### PR DESCRIPTION
## Summary

Third and final slice of `docs/37` §4.5. Adds `reclaimOrphanedLeases()`
to the existing periodic reconciler: every sweep (default 5 min) atomically
transfers leases from dead workers to this one so RUNNING runs don't end
up stranded pointing at a dead PID.

A lease is orphaned when `leaseUntil` is in the past by more than
`ORPHAN_GRACE_MS` (default 60s). That's 2× the normal 30s lease window,
giving a healthy worker enough time to renew without being stolen from.

Uses a single conditional `updateMany` (`state=RUNNING AND leaseUntil<cutoff
AND leaseOwner!=WORKER_ID`) so concurrent workers can't double-claim — the
first one wins, the rest see `count=0`.

- `lib/periodicReconciler.ts`: `reclaimOrphanedLeases()` + wires it into
  the same setInterval that drives the stale-PENDING sweep (no new timer)
- New counter `botmarket_orphan_leases_reclaimed_total`
- `ORPHAN_GRACE_MS` env var for tuning in tests / ops

## Test plan

- [x] `pnpm test:api` — 1679 passed (prev 1677 + 2 new)
- [x] `pnpm build:api`
- [x] New tests cover: no-op when no orphans, correct where-clause
      (state + cutoff + NOT leaseOwner=us), new leaseUntil ~30s future,
      leaseOwner set to `worker-${pid}`
