### PR TITLE
feat(safety): demo/live runtime guard on worker startup (§5.10)

### DIFF
--- a/apps/api/src/lib/bybitEnv.ts
+++ b/apps/api/src/lib/bybitEnv.ts
@@ -1,0 +1,54 @@
+import { getBybitBaseUrl, isBybitLive } from "./bybitOrder.js";
+import { logger } from "./logger.js";
+
+const bybitLog = logger.child({ module: "bybitEnv" });
+
+/**
+ * Validate exchange environment at startup and log the active mode loudly.
+ *
+ * Prevents the §5.10 scenario: operator accidentally deploys with a live
+ * Bybit URL → real-money orders get placed silently. We:
+ *   1. Log `[BYBIT MODE: LIVE|DEMO]` with the effective base URL
+ *   2. In production, require explicit opt-in to LIVE via BYBIT_ALLOW_LIVE=true
+ *   3. Warn on URLs that don't match any known Bybit host
+ *
+ * Throws in production when LIVE is active without BYBIT_ALLOW_LIVE=true.
+ * Otherwise never throws — just logs.
+ */
+export function validateBybitEnv(): void {
+  const baseUrl = getBybitBaseUrl();
+  const live = isBybitLive();
+  const mode = live ? "LIVE" : "DEMO";
+
+  bybitLog.info({ mode, baseUrl }, `[BYBIT MODE: ${mode}]`);
+
+  if (live && process.env.NODE_ENV === "production") {
+    if (process.env.BYBIT_ALLOW_LIVE !== "true") {
+      throw new Error(
+        "Refusing to start: BYBIT_ENV=live in production without BYBIT_ALLOW_LIVE=true. " +
+          "Set BYBIT_ALLOW_LIVE=true explicitly to acknowledge real-money trading.",
+      );
+    }
+    bybitLog.warn(
+      { baseUrl },
+      "[BYBIT LIVE TRADING ENABLED] real-money orders will be placed",
+    );
+  }
+
+  // Suspicious URL sanity check — help catch typos like `api.bybit.co` etc.
+  const knownHosts = ["api.bybit.com", "api-demo.bybit.com", "api-testnet.bybit.com"];
+  try {
+    const u = new URL(baseUrl);
+    if (u.protocol !== "https:" && u.hostname !== "localhost" && u.hostname !== "127.0.0.1") {
+      bybitLog.warn({ baseUrl }, "BYBIT_BASE_URL is not https — unexpected in production");
+    }
+    if (!knownHosts.includes(u.hostname) && u.hostname !== "localhost" && u.hostname !== "127.0.0.1") {
+      bybitLog.warn(
+        { baseUrl, knownHosts },
+        "BYBIT_BASE_URL host does not match any known Bybit endpoint",
+      );
+    }
+  } catch {
+    bybitLog.warn({ baseUrl }, "BYBIT_BASE_URL is not a valid URL");
+  }
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -7,6 +7,7 @@ import cron from "node-cron";
 import { runIngestion } from "./lib/funding/ingestJob.js";
 import { prisma, startPoolMetricsLogging, stopPoolMetricsLogging } from "./lib/prisma.js";
 import { startPeriodicReconciler } from "./lib/periodicReconciler.js";
+import { validateBybitEnv } from "./lib/bybitEnv.js";
 import { logger } from "./lib/logger.js";
 import { cleanupExpiredRefreshTokens } from "./routes/auth.js";
 
@@ -28,6 +29,7 @@ function validateEnv() {
 
 async function main() {
   validateEnv();
+  validateBybitEnv();
   const app = await buildApp();
 
   try {

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -15,6 +15,7 @@ import { startBotWorker } from "./lib/botWorker.js";
 import { prisma } from "./lib/prisma.js";
 import { logger } from "./lib/logger.js";
 import { startPeriodicReconciler } from "./lib/periodicReconciler.js";
+import { validateBybitEnv } from "./lib/bybitEnv.js";
 
 const workerLog = logger.child({ module: "worker-main" });
 
@@ -33,6 +34,7 @@ function validateEnv() {
 
 async function main() {
   validateEnv();
+  validateBybitEnv();
   workerLog.info("Starting standalone bot worker process");
 
   const stopWorker = startBotWorker();

--- a/apps/api/tests/lib/bybitEnv.test.ts
+++ b/apps/api/tests/lib/bybitEnv.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { validateBybitEnv } from "../../src/lib/bybitEnv.js";
+
+describe("validateBybitEnv", () => {
+  const saved = {
+    NODE_ENV: process.env.NODE_ENV,
+    BYBIT_ENV: process.env.BYBIT_ENV,
+    BYBIT_BASE_URL: process.env.BYBIT_BASE_URL,
+    BYBIT_ALLOW_LIVE: process.env.BYBIT_ALLOW_LIVE,
+  };
+
+  beforeEach(() => {
+    delete process.env.NODE_ENV;
+    delete process.env.BYBIT_ENV;
+    delete process.env.BYBIT_BASE_URL;
+    delete process.env.BYBIT_ALLOW_LIVE;
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = saved.NODE_ENV;
+    process.env.BYBIT_ENV = saved.BYBIT_ENV;
+    process.env.BYBIT_BASE_URL = saved.BYBIT_BASE_URL;
+    process.env.BYBIT_ALLOW_LIVE = saved.BYBIT_ALLOW_LIVE;
+  });
+
+  it("does not throw in demo mode (default)", () => {
+    expect(() => validateBybitEnv()).not.toThrow();
+  });
+
+  it("does not throw for live mode outside of production", () => {
+    process.env.BYBIT_ENV = "live";
+    process.env.NODE_ENV = "development";
+    expect(() => validateBybitEnv()).not.toThrow();
+  });
+
+  it("throws in production + live without BYBIT_ALLOW_LIVE", () => {
+    process.env.BYBIT_ENV = "live";
+    process.env.NODE_ENV = "production";
+    expect(() => validateBybitEnv()).toThrow(/BYBIT_ALLOW_LIVE=true/);
+  });
+
+  it("allows production + live with BYBIT_ALLOW_LIVE=true", () => {
+    process.env.BYBIT_ENV = "live";
+    process.env.NODE_ENV = "production";
+    process.env.BYBIT_ALLOW_LIVE = "true";
+    expect(() => validateBybitEnv()).not.toThrow();
+  });
+
+  it("does not throw for demo mode in production", () => {
+    process.env.BYBIT_ENV = "demo";
+    process.env.NODE_ENV = "production";
+    expect(() => validateBybitEnv()).not.toThrow();
+  });
+
+  it("does not throw for unknown BYBIT_BASE_URL host (warn only)", () => {
+    process.env.BYBIT_BASE_URL = "https://api.example.com";
+    process.env.NODE_ENV = "production";
+    expect(() => validateBybitEnv()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Addresses `docs/37` §5.10. Prevents the operator-error scenario where a
production deploy accidentally routes to the live Bybit endpoint — e.g.
a forgotten `BYBIT_ENV=live` from local testing slips into a prod `.env`.

- `lib/bybitEnv.ts`: `validateBybitEnv()`
  - Logs `[BYBIT MODE: LIVE|DEMO]` loudly with effective base URL
  - In `production` + live mode: refuses to start unless
    `BYBIT_ALLOW_LIVE=true` is set as explicit acknowledgement
  - Warns on URLs that don't match any known Bybit host (typo catch)
  - Warns on non-https URLs (except localhost for tests)
- `server.ts` + `worker.ts`: call `validateBybitEnv()` before `buildApp` /
  worker start so misconfiguration crashes loudly at boot rather than
  silently placing real orders later

Opt-in via `BYBIT_ALLOW_LIVE=true` means existing live deployments need
one additional env var, but the failure mode (crash on boot) is clearly
better than silent real-money trading on a wrong URL.

## Test plan

- [x] `pnpm test:api` — 1685 passed (prev 1679 + 6 new)
- [x] `pnpm build:api`
- [x] New tests cover: demo default, live in non-production, live in
      production without `BYBIT_ALLOW_LIVE` throws, with the env set
      it passes, unknown hosts warn but don't throw
