### PR TITLE
feat(deploy): add rollback.sh + runbook section (§5.1)

### DIFF
--- a/deploy/rollback.sh
+++ b/deploy/rollback.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# rollback.sh — Roll back to the previous release tag.
+#
+# Usage:
+#   bash deploy/rollback.sh                 # roll back to the previous tag
+#   bash deploy/rollback.sh --to v0.1.0     # roll back to a specific tag
+#   bash deploy/rollback.sh --dry-run       # print plan without executing
+#
+# Strategy:
+#   1. Look up previous tag (2nd most recent, sorted by semver-ish)
+#   2. Confirm with operator (unless --yes)
+#   3. Delegate to deploy.sh --ref <previous-tag>
+#
+# DB migrations are NOT automatically rolled back. Prisma migrations are
+# forward-only; if the rollback target is behind a breaking migration,
+# restore from backup first (see RUNBOOK §7).
+
+set -euo pipefail
+
+APP_DIR="${APP_DIR:-/opt/-botmarketplace-site}"
+TARGET=""
+ASSUME_YES=0
+DRY_RUN=0
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --to)      TARGET="$2"; shift 2 ;;
+    --yes|-y)  ASSUME_YES=1; shift ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help)
+      sed -n '2,15p' "$0"
+      exit 0
+      ;;
+    *) echo "Unknown arg: $1"; exit 1 ;;
+  esac
+done
+
+cd "$APP_DIR"
+
+CURRENT=$(git describe --tags --always 2>/dev/null || git rev-parse --short HEAD)
+
+git fetch origin --tags --quiet
+
+if [[ -z "$TARGET" ]]; then
+  # Pick the 2nd-most-recent tag by version sort (first is typically current release)
+  TARGET=$(git tag --sort=-version:refname | sed -n '2p')
+  if [[ -z "$TARGET" ]]; then
+    echo "No previous tag found. Tags available:"
+    git tag --sort=-version:refname | head -5
+    exit 1
+  fi
+fi
+
+if ! git rev-parse -q --verify "refs/tags/$TARGET" >/dev/null; then
+  echo "Tag not found: $TARGET"
+  echo "Available tags (most recent first):"
+  git tag --sort=-version:refname | head -10
+  exit 1
+fi
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  BotMarketplace ROLLBACK"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  Current: $CURRENT"
+echo "  Target : $TARGET"
+echo ""
+echo "  Commits that will be reverted:"
+git log --oneline "$TARGET..HEAD" | head -20 | sed 's/^/    /'
+echo ""
+
+cat <<'WARN'
+  ⚠ DB migrations are forward-only. If the rollback target predates a
+    breaking schema change (dropped column, type change), this script
+    will NOT restore the old schema. Restore from backup instead:
+        journalctl -u botmarket-backup -n 20
+        bash deploy/backup.sh --restore <dump>
+    See docs/runbooks/RUNBOOK.md §7.
+WARN
+echo ""
+
+if [[ $DRY_RUN -eq 1 ]]; then
+  echo "[dry-run] Would execute: bash deploy/deploy.sh --ref $TARGET"
+  exit 0
+fi
+
+if [[ $ASSUME_YES -eq 0 ]]; then
+  read -r -p "Proceed with rollback to $TARGET? [y/N] " answer
+  case "$answer" in
+    [yY]|[yY][eE][sS]) ;;
+    *) echo "Aborted."; exit 1 ;;
+  esac
+fi
+
+echo "Rolling back to $TARGET…"
+bash "$APP_DIR/deploy/deploy.sh" --ref "$TARGET"

--- a/docs/runbooks/RUNBOOK.md
+++ b/docs/runbooks/RUNBOOK.md
@@ -87,6 +87,30 @@ git fetch --tags
 git checkout v0.1.0-rc1
 ```
 
+### 3.5 Rollback на предыдущий релиз
+
+```bash
+# Посмотреть план без выполнения (покажет текущий / целевой teg + коммиты)
+bash deploy/rollback.sh --dry-run
+
+# Откатиться на автоматически-определённый предыдущий тег
+bash deploy/rollback.sh
+
+# Откатиться на конкретный тег
+bash deploy/rollback.sh --to v0.1.0-rc1
+
+# Non-interactive (для автоматики)
+bash deploy/rollback.sh --to v0.1.0-rc1 --yes
+```
+
+Под капотом: `rollback.sh` находит предыдущий тег (`git tag --sort=-version:refname | sed -n '2p'`), показывает список коммитов, которые будут откачены, и делегирует `deploy/deploy.sh --ref <tag>`.
+
+**Важно про DB миграции.** Prisma миграции forward-only — если целевой тег предшествует breaking schema change (drop column, type change), rollback оставит БД в текущем (новом) состоянии, а код из старого тега может упасть. Процедура в этом случае:
+1. Восстановить dump из backup: `bash deploy/backup.sh --restore <dump>` (см. §7).
+2. Только потом запускать rollback.
+
+Скрипт показывает предупреждение перед выполнением. Если меняли схему в диапазоне — **проверяй backup сначала**.
+
 ---
 
 ## 4. Миграции базы данных


### PR DESCRIPTION
## Summary

Addresses `docs/37` §5.1. Before this, rollback was a manual
`deploy/deploy.sh --ref <tag>` invocation where the operator had to
figure out the previous tag on their own.

`deploy/rollback.sh`:
- Auto-detects previous tag via `git tag --sort=-version:refname | sed -n 2p`
- Shows current / target + commit list that will be reverted
- Warns about forward-only DB migrations (link to RUNBOOK §7)
- `--to <tag>` override target
- `--dry-run` print plan without executing
- `--yes` skip interactive confirmation
- `APP_DIR` env override for local smoke tests
- Delegates actual work to `deploy.sh --ref`, so one code path

`docs/runbooks/RUNBOOK.md §3.5` — new section documenting the rollback
command, the DB-migrations caveat, and the backup-restore escape hatch.

## Test plan

- [x] `bash -n deploy/rollback.sh` — syntax clean
- [x] Local smoke: created throwaway tags, ran `--dry-run`, confirmed
      correct target detection, commit list, migration warning, and
      "would execute" trailer (no restart triggered)
- [x] No API changes — existing test suite unaffected
