### PR TITLE
docs(deploy): document explicit Prisma pool config (§5.3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,10 @@
 # Database
-DATABASE_URL="postgresql://botmarket:botmarket@localhost:5432/botmarket?schema=public"
+# For production set explicit pool size to avoid exhausting Postgres max_connections.
+# API + worker run as two processes; each takes `connection_limit` connections.
+# Rule of thumb: (connection_limit * process_count) ≤ (postgres max_connections - admin_slots).
+# Example for default Postgres (max_connections=100): connection_limit=10 → 20 total, leaves headroom.
+# pool_timeout is the seconds Prisma waits for a free connection before erroring.
+DATABASE_URL="postgresql://botmarket:botmarket@localhost:5432/botmarket?schema=public&connection_limit=10&pool_timeout=10"
 
 # Redis
 REDIS_URL="redis://localhost:6379"

--- a/docs/runbooks/RUNBOOK.md
+++ b/docs/runbooks/RUNBOOK.md
@@ -33,12 +33,33 @@ bash deploy/smoke-test.sh
 | `BOT_WORKER_SECRET` | Production | Произвольная строка 32+ символов | `openssl rand -hex 32` |
 | `NODE_ENV` | Нет | `production` | Установить `production` на VPS |
 | `PORT` | Нет | Число (default: 3001) | — |
+| `POOL_WAIT_THRESHOLD` | Нет | Число (default: 5) | Порог `waiting` в `/readyz` connection pool check |
+| `BYBIT_ALLOW_LIVE` | Live-прод | `true` | Обязателен при `NODE_ENV=production` + `BYBIT_ENV=live` (§5.10 guard) |
 
 ### Критические замечания
 
 - **`SECRET_ENCRYPTION_KEY`** — если изменить после создания exchange connections, все существующие зашифрованные секреты станут нечитаемы. Храни в безопасном месте, делай backup.
 - **`BOT_WORKER_SECRET`** — без него в production worker endpoints (`PATCH /state`, `POST /heartbeat`, `POST /reconcile`) доступны без аутентификации. **Обязательно установить перед production-деплоем.**
 - **`JWT_SECRET`** — изменение инвалидирует все выданные токены (все пользователи разлогинятся).
+
+### Prisma connection pool (`DATABASE_URL`)
+
+В production задавай пул явно через query-параметры:
+
+```
+postgresql://user:pass@host:5432/botmarket?schema=public&connection_limit=10&pool_timeout=10
+```
+
+- `connection_limit` — сколько коннектов откроет каждый процесс (API и worker — независимо).
+  Итоговое потребление: `connection_limit × N_процессов`. Postgres по умолчанию держит
+  `max_connections=100`; оставляй ≥10% admin-slots запаса.
+- `pool_timeout` (сек) — сколько Prisma ждёт свободный коннект перед ошибкой. Слишком
+  маленькое → «pool wait count > threshold» в `/readyz` → `degraded`. Слишком большое →
+  HTTP request'ы ждут и упираются в таймауты клиента.
+
+Живые метрики пула: `botmarket_*` на `/metrics` + `/readyz.checks.connectionPool` +
+пинованые метрики в логах (`module=prisma` каждые 60 сек). Если `waiting > 0` стабильно —
+либо поднимать `connection_limit`, либо поднимать Postgres `max_connections`.
 
 ---
 


### PR DESCRIPTION
## Summary

Addresses `docs/37` §5.3. The API and worker each open a Prisma pool to
Postgres; with defaults that's 2 × 10 = 20 connections vs the default
Postgres `max_connections=100` — workable but undocumented. Under load
or if `max_connections` is lowered (common on hosted DB tiers), the pool
silently saturates and the `/readyz` pool check starts reporting
`waiting > 0`.

- `.env.example` — `DATABASE_URL` now includes explicit
  `connection_limit=10` and `pool_timeout=10`, with inline guidance on
  sizing vs Postgres `max_connections`.
- `docs/runbooks/RUNBOOK.md §2` — new subsection "Prisma connection
  pool" explaining `connection_limit` / `pool_timeout` tradeoffs, how
  to watch live metrics, and when to bump pool size vs Postgres.
- `§2` env table now also lists `POOL_WAIT_THRESHOLD` (consumed by
  `/readyz`) and `BYBIT_ALLOW_LIVE` (§5.10 guard) — both were already
  consumed in code but weren't documented here.

## Test plan

- [x] `pnpm test:api` — 1685 passed (no code changes → no new tests)
- [x] Visual review of RUNBOOK.md — new subsection renders correctly
      under §2
