### PR TITLE
refactor(security): split CSP ownership between API and nginx (§5.8)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -134,7 +134,13 @@ export async function buildApp() {
     }
   });
 
-  // Security headers (CSP enforcement + hardening)
+  // Security headers (CSP enforcement + hardening).
+  //
+  // CSP scope (docs/37 §5.8): this strict policy is authoritative for
+  // /api/* responses (JSON, no embedded resources needed). The looser
+  // CSP for rendered Next.js pages is configured in deploy/nginx.conf
+  // under `location /` and must stay in sync there; it is deliberately
+  // NOT added on /api/ in nginx to keep this single source of truth.
   app.addHook("onSend", async (request, reply) => {
     reply.header("X-Request-Id", request.id);
     reply.header("X-Content-Type-Options", "nosniff");

--- a/apps/api/tests/routes/securityHeaders.test.ts
+++ b/apps/api/tests/routes/securityHeaders.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@prisma/client", () => ({
+  PrismaClient: vi.fn().mockImplementation(() => ({
+    $queryRaw: vi.fn().mockResolvedValue([]),
+    $connect: vi.fn(),
+    $disconnect: vi.fn(),
+  })),
+  Prisma: { sql: vi.fn(), join: vi.fn() },
+}));
+
+vi.mock("../../src/lib/prisma.js", () => ({
+  prisma: {
+    $queryRaw: vi.fn().mockResolvedValue([{ "?column?": 1 }]),
+    $connect: vi.fn(),
+    $disconnect: vi.fn(),
+  },
+}));
+
+import { buildApp } from "../../src/app.js";
+
+describe("API security headers (§5.8)", () => {
+  it("sets strict CSP + hardening headers on every response", async () => {
+    const app = await buildApp();
+    const res = await app.inject({ method: "GET", url: "/health" });
+
+    expect(res.headers["content-security-policy"]).toBe(
+      "default-src 'none'; frame-ancestors 'none'",
+    );
+    expect(res.headers["x-content-type-options"]).toBe("nosniff");
+    expect(res.headers["x-frame-options"]).toBe("DENY");
+    expect(res.headers["referrer-policy"]).toBe("strict-origin-when-cross-origin");
+    expect(res.headers["x-request-id"]).toBeTruthy();
+
+    await app.close();
+  });
+
+  it("keeps the strict CSP on /metrics too (API is single source of truth)", async () => {
+    const app = await buildApp();
+    const res = await app.inject({ method: "GET", url: "/metrics" });
+    expect(res.headers["content-security-policy"]).toBe(
+      "default-src 'none'; frame-ancestors 'none'",
+    );
+    await app.close();
+  });
+});

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -21,14 +21,19 @@ server {
     ssl_certificate     /etc/letsencrypt/live/botmarketplace.store/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/botmarketplace.store/privkey.pem;
 
-    # Security headers
+    # Security headers — applied to all responses (including proxied /api/)
+    # CSP is split per-location: see location / (web) and location ^~ /api/ (pass-through).
     add_header X-Frame-Options           "SAMEORIGIN"   always;
     add_header X-Content-Type-Options    "nosniff"      always;
     add_header Referrer-Policy           "strict-origin" always;
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none';" always;
 
     # ==== API ПРОКСИ ====
+    # CSP is set by the API process (default-src 'none'; frame-ancestors 'none')
+    # — appropriate for JSON responses. Do NOT add a second CSP here, or
+    # browsers will enforce the intersection and the policy becomes confusing
+    # to audit. See docs/37 §5.8 (CSP split) + apps/api/src/app.ts security
+    # headers hook for the authoritative API policy.
     location ^~ /api/ {
         proxy_pass         http://api_backend;
         proxy_http_version 1.1;
@@ -55,7 +60,12 @@ server {
     }
 
     # ==== WEB (Next.js) — включая WebSocket для HMR ====
+    # CSP for Next.js rendered pages. Looser than the API's JSON-only CSP
+    # because React/Next injects inline bootstrap scripts. Keep in sync
+    # with CSP expectations in apps/web/next.config.js if customised there.
     location / {
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none';" always;
+
         proxy_pass         http://web_backend;
         proxy_http_version 1.1;
         proxy_set_header   Upgrade           $http_upgrade;


### PR DESCRIPTION
## Summary

Addresses `docs/37` §5.8. Before this, nginx added a permissive CSP at
the `server` level (applied to ALL responses including proxied `/api/`),
while the API set a stricter CSP on its JSON responses. Browsers saw
both headers, had to compute the intersection, and any audit needed to
reason about two policies at once.

After:

- nginx sets CSP only inside `location /` (Next.js pages — the only
  place that actually loads scripts / styles / fonts). Other security
  headers (HSTS, X-Frame-Options, Referrer-Policy, X-Content-Type-Options)
  stay at `server` level since they're universal.
- `/api/*` passes through unchanged — the API process is now the single
  source of truth for CSP on JSON responses (`default-src 'none';
  frame-ancestors 'none'`).
- Comments in both files point to each other + `docs/37` §5.8.

Plus a new test (`tests/routes/securityHeaders.test.ts`) pinning the
API's CSP + other security headers so future refactors surface if the
policy drifts.

## Test plan

- [x] `pnpm test:api` — 1687 passed (prev 1685 + 2 new)
- [x] `pnpm build:api`
- [x] `nginx -t` equivalent sanity: kept existing directives, added
      `add_header CSP` only inside `location /`, no syntax changes to
      other blocks
