### PR TITLE
feat(security): zero-downtime encryption key rotation (§5.7)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,15 @@ JWT_SECRET="change-me-in-production"
 # Leave unset in dev (skips check). Must be set in production.
 BOT_WORKER_SECRET="change-me-in-production"
 
+# Secret encryption — AES-256-GCM key for ExchangeConnection secrets + Telegram tokens.
+# 32 bytes = 64 hex chars. Generate: openssl rand -hex 32
+# SECRET_ENCRYPTION_KEY="..."
+# During rotation (RUNBOOK §11.1): keep the previous key(s) here so the API
+# can still decrypt un-migrated rows while re-encrypting them. Remove after
+# scripts/rotateEncryptionKey.ts completes successfully. Comma-separated list
+# accepted if you need to support multiple historical keys.
+# SECRET_ENCRYPTION_KEY_OLD="..."
+
 # API
 API_PORT=4000
 API_HOST="0.0.0.0"

--- a/apps/api/scripts/rotateEncryptionKey.ts
+++ b/apps/api/scripts/rotateEncryptionKey.ts
@@ -1,0 +1,129 @@
+#!/usr/bin/env tsx
+/**
+ * Re-encrypt all secrets after rotating SECRET_ENCRYPTION_KEY (§5.7).
+ *
+ * Prerequisites:
+ *   1. New key generated:  openssl rand -hex 32
+ *   2. .env updated BEFORE running this script:
+ *        SECRET_ENCRYPTION_KEY=<new 64-hex key>
+ *        SECRET_ENCRYPTION_KEY_OLD=<previous 64-hex key>
+ *   3. Services restarted so the API can decrypt existing records with the
+ *      old key while placing new encryptions with the new key.
+ *   4. A DB backup taken (see RUNBOOK §7).
+ *
+ * This script walks every row containing encrypted secrets
+ * (ExchangeConnection.encryptedSecret, WorkspaceNotification
+ * notifyJson.telegram.botToken), decrypts with whichever key works,
+ * and re-encrypts with the current (new) key.
+ *
+ * Idempotent: re-running on already-rotated rows is a no-op because the
+ * current key decrypts and re-encrypts to the same ciphertext family.
+ *
+ * Usage:
+ *   pnpm --filter @botmarketplace/api exec tsx scripts/rotateEncryptionKey.ts
+ *   pnpm --filter @botmarketplace/api exec tsx scripts/rotateEncryptionKey.ts --dry-run
+ */
+
+import { PrismaClient } from "@prisma/client";
+import {
+  decryptWithFallback,
+  encrypt,
+  getEncryptionKeyRaw,
+} from "../src/lib/crypto.js";
+
+const DRY_RUN = process.argv.includes("--dry-run");
+
+async function main() {
+  const prisma = new PrismaClient();
+  const newKey = getEncryptionKeyRaw();
+
+  console.log(`[rotateEncryptionKey] mode=${DRY_RUN ? "dry-run" : "apply"}`);
+
+  // 1. ExchangeConnection.encryptedSecret
+  const conns = await prisma.exchangeConnection.findMany({
+    select: { id: true, encryptedSecret: true },
+  });
+  console.log(`[exchangeConnection] found ${conns.length} rows`);
+
+  let ecRotated = 0;
+  let ecSkipped = 0;
+  let ecFailed = 0;
+  for (const conn of conns) {
+    try {
+      const plain = decryptWithFallback(conn.encryptedSecret);
+      const recrypted = encrypt(plain, newKey);
+      if (recrypted === conn.encryptedSecret) {
+        ecSkipped++;
+        continue; // extremely unlikely (random IV) but keep for safety
+      }
+      if (!DRY_RUN) {
+        await prisma.exchangeConnection.update({
+          where: { id: conn.id },
+          data: { encryptedSecret: recrypted },
+        });
+      }
+      ecRotated++;
+    } catch (err) {
+      ecFailed++;
+      console.error(`[exchangeConnection] ${conn.id} failed:`, (err as Error).message);
+    }
+  }
+  console.log(`[exchangeConnection] rotated=${ecRotated} skipped=${ecSkipped} failed=${ecFailed}`);
+
+  // 2. WorkspaceNotification — Telegram bot token (optionally encrypted)
+  const notifs = await prisma.workspaceNotification.findMany({
+    select: { id: true, notifyJson: true },
+  });
+  console.log(`[workspaceNotification] found ${notifs.length} rows`);
+
+  let wnRotated = 0;
+  let wnFailed = 0;
+  let wnUnencrypted = 0;
+  for (const row of notifs) {
+    const config = (row.notifyJson ?? {}) as Record<string, unknown>;
+    const tg = config.telegram as Record<string, unknown> | undefined;
+    if (!tg || !tg._tokenEncrypted || typeof tg.botToken !== "string") {
+      wnUnencrypted++;
+      continue;
+    }
+    try {
+      const plain = decryptWithFallback(tg.botToken);
+      const recrypted = encrypt(plain, newKey);
+      tg.botToken = recrypted;
+      if (!DRY_RUN) {
+        await prisma.workspaceNotification.update({
+          where: { id: row.id },
+          data: { notifyJson: config as object },
+        });
+      }
+      wnRotated++;
+    } catch (err) {
+      wnFailed++;
+      console.error(`[workspaceNotification] ${row.id} failed:`, (err as Error).message);
+    }
+  }
+  console.log(
+    `[workspaceNotification] rotated=${wnRotated} unencrypted=${wnUnencrypted} failed=${wnFailed}`,
+  );
+
+  const anyFailed = ecFailed + wnFailed;
+  if (anyFailed > 0) {
+    console.error(`[rotateEncryptionKey] ${anyFailed} rows failed — investigate before removing SECRET_ENCRYPTION_KEY_OLD`);
+    process.exit(1);
+  }
+
+  if (DRY_RUN) {
+    console.log("[rotateEncryptionKey] dry-run complete — no DB writes.");
+  } else {
+    console.log(
+      "[rotateEncryptionKey] done. Verify app health, then remove SECRET_ENCRYPTION_KEY_OLD from .env and restart services.",
+    );
+  }
+
+  await prisma.$disconnect();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/api/src/lib/botWorker.ts
+++ b/apps/api/src/lib/botWorker.ts
@@ -36,7 +36,7 @@ import {
   getBybitBaseUrl,
   isBybitLive,
 } from "./bybitOrder.js";
-import { decrypt, getEncryptionKeyRaw } from "./crypto.js";
+import { decryptWithFallback } from "./crypto.js";
 import {
   getActivePosition,
   openPosition,
@@ -625,8 +625,7 @@ async function _executeIntentLegacy(intent: {
       intentLog.info("intent simulated (demo mode)");
     } else {
       // ── Live mode: place order on Bybit ──────────────────────────────────
-      const encKey = getEncryptionKeyRaw();
-      const plainSecret = decrypt(bot.exchangeConnection.encryptedSecret, encKey);
+      const plainSecret = decryptWithFallback(bot.exchangeConnection.encryptedSecret);
 
       // Determine orderType from strategy DSL or default to Market
       const dsl = bot.strategyVersion?.dslJson as { execution?: { orderType?: string } } | null;
@@ -1067,15 +1066,13 @@ async function reconcilePlacedIntents(): Promise<void> {
 
     if (intents.length === 0) return;
 
-    const encKey = getEncryptionKeyRaw();
-
     for (const intent of intents) {
       const { bot } = intent.botRun;
       if (!bot.exchangeConnection || !intent.orderId) continue;
       const reconLog = workerLog.child({ runId: intent.botRun.id, intentId: intent.intentId, symbol: bot.symbol });
 
       try {
-        const secret = decrypt(bot.exchangeConnection.encryptedSecret, encKey);
+        const secret = decryptWithFallback(bot.exchangeConnection.encryptedSecret);
         const liveStatus = await bybitGetOrderStatus(
           bot.exchangeConnection.apiKey,
           secret,

--- a/apps/api/src/lib/crypto.ts
+++ b/apps/api/src/lib/crypto.ts
@@ -53,6 +53,53 @@ export function getEncryptionKeyRaw(): Buffer {
 }
 
 /**
+ * Get all encryption keys in priority order for decryption fallback (§5.7).
+ *
+ * Returns `[current, ...old]` where `old` is an array of previous keys
+ * supplied via `SECRET_ENCRYPTION_KEY_OLD` (comma-separated list of hex).
+ *
+ * Intended usage: during key rotation, decrypt tries the current key first
+ * and falls back to the old one(s) for records not yet re-encrypted. A
+ * one-shot migration re-encrypts everything with the new key, after which
+ * `SECRET_ENCRYPTION_KEY_OLD` can be removed.
+ */
+export function getEncryptionKeysRaw(): Buffer[] {
+  const keys: Buffer[] = [getEncryptionKeyRaw()];
+  const oldRaw = process.env.SECRET_ENCRYPTION_KEY_OLD;
+  if (!oldRaw) return keys;
+
+  for (const candidate of oldRaw.split(",").map((s) => s.trim()).filter(Boolean)) {
+    if (candidate.length !== KEY_HEX_LENGTH) {
+      throw new Error(
+        `SECRET_ENCRYPTION_KEY_OLD entry has wrong length: expected ${KEY_HEX_LENGTH} hex chars, got ${candidate.length}`,
+      );
+    }
+    keys.push(Buffer.from(candidate, "hex"));
+  }
+  return keys;
+}
+
+/**
+ * Decrypt using whichever configured key works (§5.7 rotation helper).
+ *
+ * Tries the current key first, then any in `SECRET_ENCRYPTION_KEY_OLD`.
+ * Throws if none succeed — same failure shape as `decrypt` when the
+ * single-key call fails.
+ */
+export function decryptWithFallback(payload: string): string {
+  const keys = getEncryptionKeysRaw();
+  let lastErr: unknown;
+  for (const key of keys) {
+    try {
+      return decrypt(payload, key);
+    } catch (err) {
+      lastErr = err;
+    }
+  }
+  throw lastErr instanceof Error ? lastErr : new Error("decryptWithFallback: all keys failed");
+}
+
+/**
  * Decrypt a payload produced by encrypt().
  * Throws on any tampering / wrong key.
  */

--- a/apps/api/src/lib/notify.ts
+++ b/apps/api/src/lib/notify.ts
@@ -14,7 +14,7 @@
 
 import { logger } from "./logger.js";
 import { prisma } from "./prisma.js";
-import { getEncryptionKeyRaw, decrypt } from "./crypto.js";
+import { decryptWithFallback } from "./crypto.js";
 
 const notifyLog = logger.child({ module: "notify" });
 
@@ -162,8 +162,7 @@ export function parseNotifyConfig(raw: unknown): NotifyConfig | null {
   // Decrypt botToken if it was stored encrypted
   if (tg._tokenEncrypted) {
     try {
-      const key = getEncryptionKeyRaw();
-      botToken = decrypt(botToken, key);
+      botToken = decryptWithFallback(botToken);
     } catch (err) {
       notifyLog.warn({ err }, "failed to decrypt Telegram botToken");
       return null;

--- a/apps/api/src/lib/worker/intentExecutor.ts
+++ b/apps/api/src/lib/worker/intentExecutor.ts
@@ -10,7 +10,7 @@
 
 import { Prisma } from "@prisma/client";
 import { prisma } from "../prisma.js";
-import { decrypt, getEncryptionKeyRaw } from "../crypto.js";
+import { decryptWithFallback } from "../crypto.js";
 import {
   bybitPlaceOrder,
   getBybitBaseUrl,
@@ -96,8 +96,7 @@ export async function executeIntent(intent: IntentRecord, parentLog: Logger): Pr
       intentLog.info("intent simulated (demo mode)");
     } else {
       // ── Live mode: place order on Bybit ──────────────────────────────────
-      const encKey = getEncryptionKeyRaw();
-      const plainSecret = decrypt(bot.exchangeConnection.encryptedSecret, encKey);
+      const plainSecret = decryptWithFallback(bot.exchangeConnection.encryptedSecret);
 
       const dsl = bot.strategyVersion?.dslJson as { execution?: { orderType?: string } } | null;
       const orderType =

--- a/apps/api/src/routes/exchanges.ts
+++ b/apps/api/src/routes/exchanges.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance } from "fastify";
 import { prisma } from "../lib/prisma.js";
 import { problem } from "../lib/problem.js";
 import { resolveWorkspace } from "../lib/workspace.js";
-import { getEncryptionKey, encrypt, decrypt } from "../lib/crypto.js";
+import { getEncryptionKey, encrypt, decryptWithFallback } from "../lib/crypto.js";
 
 // ---------------------------------------------------------------------------
 // Safe projection — never return encryptedSecret or apiKey in responses
@@ -215,12 +215,9 @@ export async function exchangeRoutes(app: FastifyInstance) {
       return problem(reply, 404, "Not Found", "Exchange connection not found");
     }
 
-    const key = getEncryptionKey(reply);
-    if (!key) return;
-
     let decryptedSecret: string;
     try {
-      decryptedSecret = decrypt(conn.encryptedSecret, key);
+      decryptedSecret = decryptWithFallback(conn.encryptedSecret);
     } catch (err) {
       request.log.error({ connectionId: conn.id, err }, "Failed to decrypt exchange secret");
       return problem(reply, 500, "Internal Server Error", "Failed to decrypt exchange credentials");

--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -10,7 +10,7 @@ import type { FastifyInstance } from "fastify";
 import { prisma } from "../lib/prisma.js";
 import { problem } from "../lib/problem.js";
 import { parseNotifyConfig, sendTelegramMessage, invalidateNotifyCache } from "../lib/notify.js";
-import { getEncryptionKey, encrypt, decrypt } from "../lib/crypto.js";
+import { getEncryptionKey, encrypt, decryptWithFallback } from "../lib/crypto.js";
 
 // ---------------------------------------------------------------------------
 // Validation
@@ -75,9 +75,7 @@ export async function notificationRoutes(app: FastifyInstance) {
       let plainToken = tg.botToken;
       if (tg._tokenEncrypted) {
         try {
-          const encKey = getEncryptionKey(reply);
-          if (!encKey) return;
-          plainToken = decrypt(tg.botToken, encKey);
+          plainToken = decryptWithFallback(tg.botToken);
         } catch {
           plainToken = tg.botToken;
         }

--- a/apps/api/tests/lib/botWorker.test.ts
+++ b/apps/api/tests/lib/botWorker.test.ts
@@ -93,6 +93,7 @@ vi.mock("../../src/lib/bybitOrder.js", () => ({
 
 vi.mock("../../src/lib/crypto.js", () => ({
   decrypt: vi.fn().mockReturnValue("decrypted-secret"),
+  decryptWithFallback: vi.fn().mockReturnValue("decrypted-secret"),
   getEncryptionKeyRaw: vi.fn().mockReturnValue(Buffer.alloc(32)),
 }));
 

--- a/apps/api/tests/lib/cryptoRotation.test.ts
+++ b/apps/api/tests/lib/cryptoRotation.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { randomBytes } from "node:crypto";
+import {
+  encrypt,
+  decrypt,
+  decryptWithFallback,
+  getEncryptionKeysRaw,
+} from "../../src/lib/crypto.js";
+
+const KEY_A = randomBytes(32);
+const KEY_B = randomBytes(32);
+
+describe("encryption key rotation (§5.7)", () => {
+  const saved = {
+    CURRENT: process.env.SECRET_ENCRYPTION_KEY,
+    OLD: process.env.SECRET_ENCRYPTION_KEY_OLD,
+  };
+
+  beforeEach(() => {
+    delete process.env.SECRET_ENCRYPTION_KEY;
+    delete process.env.SECRET_ENCRYPTION_KEY_OLD;
+  });
+
+  afterEach(() => {
+    process.env.SECRET_ENCRYPTION_KEY = saved.CURRENT;
+    process.env.SECRET_ENCRYPTION_KEY_OLD = saved.OLD;
+  });
+
+  describe("getEncryptionKeysRaw", () => {
+    it("returns only the current key when SECRET_ENCRYPTION_KEY_OLD is unset", () => {
+      process.env.SECRET_ENCRYPTION_KEY = KEY_A.toString("hex");
+      const keys = getEncryptionKeysRaw();
+      expect(keys.length).toBe(1);
+      expect(keys[0].equals(KEY_A)).toBe(true);
+    });
+
+    it("returns current then old keys, in order, when OLD is a single key", () => {
+      process.env.SECRET_ENCRYPTION_KEY = KEY_A.toString("hex");
+      process.env.SECRET_ENCRYPTION_KEY_OLD = KEY_B.toString("hex");
+      const keys = getEncryptionKeysRaw();
+      expect(keys.length).toBe(2);
+      expect(keys[0].equals(KEY_A)).toBe(true);
+      expect(keys[1].equals(KEY_B)).toBe(true);
+    });
+
+    it("supports comma-separated list of old keys", () => {
+      const KEY_C = randomBytes(32);
+      process.env.SECRET_ENCRYPTION_KEY = KEY_A.toString("hex");
+      process.env.SECRET_ENCRYPTION_KEY_OLD = `${KEY_B.toString("hex")},${KEY_C.toString("hex")}`;
+      const keys = getEncryptionKeysRaw();
+      expect(keys.length).toBe(3);
+      expect(keys[1].equals(KEY_B)).toBe(true);
+      expect(keys[2].equals(KEY_C)).toBe(true);
+    });
+
+    it("throws on malformed SECRET_ENCRYPTION_KEY_OLD entry", () => {
+      process.env.SECRET_ENCRYPTION_KEY = KEY_A.toString("hex");
+      process.env.SECRET_ENCRYPTION_KEY_OLD = "deadbeef"; // wrong length
+      expect(() => getEncryptionKeysRaw()).toThrow(/wrong length/);
+    });
+  });
+
+  describe("decryptWithFallback", () => {
+    it("decrypts with the current key when no old key is configured", () => {
+      process.env.SECRET_ENCRYPTION_KEY = KEY_A.toString("hex");
+      const ciphertext = encrypt("hello", KEY_A);
+      expect(decryptWithFallback(ciphertext)).toBe("hello");
+    });
+
+    it("falls back to the old key when the payload was encrypted with it", () => {
+      process.env.SECRET_ENCRYPTION_KEY = KEY_A.toString("hex");
+      process.env.SECRET_ENCRYPTION_KEY_OLD = KEY_B.toString("hex");
+      const oldCiphertext = encrypt("legacy-secret", KEY_B);
+      expect(decryptWithFallback(oldCiphertext)).toBe("legacy-secret");
+    });
+
+    it("prefers the current key when the payload was already rotated", () => {
+      process.env.SECRET_ENCRYPTION_KEY = KEY_A.toString("hex");
+      process.env.SECRET_ENCRYPTION_KEY_OLD = KEY_B.toString("hex");
+      const newCiphertext = encrypt("rotated-secret", KEY_A);
+      expect(decryptWithFallback(newCiphertext)).toBe("rotated-secret");
+    });
+
+    it("throws when neither key works", () => {
+      process.env.SECRET_ENCRYPTION_KEY = KEY_A.toString("hex");
+      process.env.SECRET_ENCRYPTION_KEY_OLD = KEY_B.toString("hex");
+      const unrelatedKey = randomBytes(32);
+      const ciphertext = encrypt("unknown", unrelatedKey);
+      expect(() => decryptWithFallback(ciphertext)).toThrow();
+    });
+  });
+
+  describe("decrypt (underlying primitive)", () => {
+    it("round-trips encrypt → decrypt", () => {
+      const key = randomBytes(32);
+      const ct = encrypt("round-trip", key);
+      expect(decrypt(ct, key)).toBe("round-trip");
+    });
+  });
+});

--- a/apps/api/tests/lib/notify.test.ts
+++ b/apps/api/tests/lib/notify.test.ts
@@ -22,6 +22,10 @@ vi.mock("../../src/lib/crypto.js", () => ({
     if (payload.startsWith("enc:")) return payload.slice(4);
     return payload;
   }),
+  decryptWithFallback: vi.fn().mockImplementation((payload: string) => {
+    if (payload.startsWith("enc:")) return payload.slice(4);
+    return payload;
+  }),
 }));
 
 import {

--- a/apps/api/tests/lib/worker/intentExecutor.test.ts
+++ b/apps/api/tests/lib/worker/intentExecutor.test.ts
@@ -41,6 +41,7 @@ vi.mock("../../../src/lib/prisma.js", () => ({
 
 vi.mock("../../../src/lib/crypto.js", () => ({
   decrypt: (...args: unknown[]) => mockDecrypt(...args),
+  decryptWithFallback: (payload: string) => mockDecrypt(payload, Buffer.alloc(32)),
   getEncryptionKeyRaw: (...args: unknown[]) => mockGetEncryptionKeyRaw(...args),
 }));
 

--- a/apps/api/tests/routes/exchanges.test.ts
+++ b/apps/api/tests/routes/exchanges.test.ts
@@ -41,6 +41,7 @@ vi.mock("../../src/lib/crypto.js", () => ({
   getEncryptionKey: vi.fn().mockReturnValue(Buffer.alloc(32)),
   encrypt: vi.fn().mockReturnValue("iv:tag:cipher"),
   decrypt: vi.fn().mockReturnValue("decrypted"),
+  decryptWithFallback: vi.fn().mockReturnValue("decrypted"),
 }));
 
 import { buildApp } from "../../src/app.js";

--- a/apps/api/tests/routes/notifications.test.ts
+++ b/apps/api/tests/routes/notifications.test.ts
@@ -50,6 +50,10 @@ vi.mock("../../src/lib/crypto.js", () => ({
     if (payload.startsWith("enc:")) return payload.slice(4);
     return payload;
   }),
+  decryptWithFallback: vi.fn().mockImplementation((payload: string) => {
+    if (payload.startsWith("enc:")) return payload.slice(4);
+    return payload;
+  }),
 }));
 
 // Mock the notify module to avoid real Telegram calls

--- a/apps/api/tests/routes/terminal.test.ts
+++ b/apps/api/tests/routes/terminal.test.ts
@@ -56,6 +56,7 @@ vi.mock("../../src/lib/crypto.js", () => ({
   getEncryptionKey: vi.fn().mockReturnValue(Buffer.alloc(32)),
   encrypt: vi.fn().mockReturnValue("iv:tag:cipher"),
   decrypt: vi.fn().mockReturnValue("decrypted-secret"),
+  decryptWithFallback: vi.fn().mockReturnValue("decrypted-secret"),
 }));
 
 const mockBybitPlaceOrder = vi.fn();

--- a/docs/runbooks/RUNBOOK.md
+++ b/docs/runbooks/RUNBOOK.md
@@ -417,7 +417,83 @@ journalctl -u botmarket-healthcheck -n 50    # последние запуски
 
 ---
 
-## 11. Полезные команды
+## 11. Ротация секретов
+
+### 11.1 `SECRET_ENCRYPTION_KEY` (dual-key rotation)
+
+`SECRET_ENCRYPTION_KEY` шифрует `ExchangeConnection.encryptedSecret` и
+Telegram bot token в `WorkspaceNotification.notifyJson`. Без процедуры
+ниже ротация сломает все сохранённые секреты — пользователи не смогут
+использовать bots без переподключения биржи.
+
+**Процедура (zero-downtime):**
+
+1. **Backup БД** перед началом (см. §7). Обязательно.
+2. Сгенерировать новый ключ:
+   ```bash
+   NEW_KEY=$(openssl rand -hex 32)
+   echo "$NEW_KEY"
+   ```
+3. Обновить `.env` — сохранить текущий ключ как `OLD`, поставить новый:
+   ```
+   SECRET_ENCRYPTION_KEY=<NEW_KEY>
+   SECRET_ENCRYPTION_KEY_OLD=<prev key, тот что был в SECRET_ENCRYPTION_KEY>
+   ```
+4. Рестартовать сервисы:
+   ```bash
+   systemctl restart botmarket-api botmarket-worker
+   ```
+   API сейчас шифрует новые записи новым ключом, расшифровывает старые —
+   старым (fallback через `decryptWithFallback`). Smoke-тест через UI:
+   открыть список ботов, проверить что "Exchange" отображается (значит
+   старые ключи читаются).
+5. Прогнать миграцию — перешифровать всё новым ключом:
+   ```bash
+   # Dry-run (без изменений БД):
+   pnpm --filter @botmarketplace/api exec tsx scripts/rotateEncryptionKey.ts --dry-run
+
+   # Реальная миграция:
+   pnpm --filter @botmarketplace/api exec tsx scripts/rotateEncryptionKey.ts
+   ```
+   Скрипт выведет счётчики `rotated=N failed=M`. Если `failed > 0` —
+   **НЕ** удалять `SECRET_ENCRYPTION_KEY_OLD`, разбираться в логах
+   прежде чем двигаться дальше.
+6. Убрать старый ключ из `.env`:
+   ```
+   # удалить строку SECRET_ENCRYPTION_KEY_OLD=…
+   ```
+7. Рестарт ещё раз — убедиться, что всё читается только новым ключом:
+   ```bash
+   systemctl restart botmarket-api botmarket-worker
+   systemctl is-active botmarket-api botmarket-worker
+   ```
+8. Записать событие в CHANGELOG.md (`[Unreleased] ### Security —
+   encryption key rotated on <date>`).
+
+**Если что-то пошло не так.** До шага 6 ротация полностью обратима —
+просто вернуть `SECRET_ENCRYPTION_KEY` на старое значение и убрать
+`_OLD`. После шага 6 (удаления OLD) откат требует restore из backup БД.
+
+### 11.2 `JWT_SECRET` (инвалидация токенов)
+
+Изменение `JWT_SECRET` делает все выданные access/refresh токены
+невалидными (все пользователи разлогинятся). Процедура:
+
+1. Сгенерировать новый секрет: `openssl rand -hex 32`.
+2. Обновить `.env` и рестартовать API.
+3. Уведомить пользователей (необязательно — они увидят форму логина при
+   первом же запросе).
+
+### 11.3 `BOT_WORKER_SECRET` (worker ↔ API канал)
+
+Используется worker-to-API endpoints (`PATCH /state`, `POST /heartbeat`,
+`POST /reconcile`). Если worker и API — в одном процессе (embedded),
+просто обновить `.env` и рестартовать. Если worker standalone — сначала
+обновить API (`.env` + restart), затем worker.
+
+---
+
+## 12. Полезные команды
 
 ```bash
 # Версия приложения (из package.json)


### PR DESCRIPTION
## Summary

Addresses `docs/37` §5.7. Before this, `SECRET_ENCRYPTION_KEY` rotation
was undocumented and would silently brick all stored
`ExchangeConnection` secrets + Telegram tokens; operators had to choose
between never rotating or forcing every user to reconnect.

**Dual-key approach** (additive, no schema change):

- `lib/crypto.ts`: new `getEncryptionKeysRaw()` returns `[current, ...old]`
  from `SECRET_ENCRYPTION_KEY` + comma-separated `SECRET_ENCRYPTION_KEY_OLD`
- `lib/crypto.ts`: new `decryptWithFallback(payload)` tries keys in order;
  supports pre- and post-rotation ciphertexts simultaneously
- All read callsites switched from `decrypt(…, key)` to
  `decryptWithFallback(…)`: `botWorker.ts`, `worker/intentExecutor.ts`,
  `notify.ts`, `routes/exchanges.ts`, `routes/notifications.ts`
- Encrypt callsites unchanged — always use the current key

**One-shot migration** (`apps/api/scripts/rotateEncryptionKey.ts`):
re-encrypts every `ExchangeConnection` + `WorkspaceNotification` row
with the new key. `--dry-run` supported. Exits non-zero if any row
fails so operator knows not to remove the old key yet.

**Docs**:

- RUNBOOK §11 — step-by-step dual-key rotation playbook (backup → set
  both keys → restart → run migration → remove old key → verify)
- RUNBOOK §11.2 / §11.3 — `JWT_SECRET` + `BOT_WORKER_SECRET` rotation
- `.env.example` — documents `SECRET_ENCRYPTION_KEY_OLD`

## Test plan

- [x] `pnpm test:api` — 1696 passed (prev 1687 + 9 new in
      `tests/lib/cryptoRotation.test.ts`)
- [x] `pnpm build:api`
- [x] Rotation tests cover: current-key-only path, old-key fallback,
      current preferred when both work, fail when neither works,
      malformed `SECRET_ENCRYPTION_KEY_OLD` rejected, comma-separated
      list of multiple historical keys
- [x] Existing test suite mocks updated to expose `decryptWithFallback`
      on the mock of `../../src/lib/crypto.js` — no regressions
