### PR TITLE
feat(load): add k6 load-test scenarios + README (§5.2)

### DIFF
--- a/load/README.md
+++ b/load/README.md
@@ -1,0 +1,75 @@
+# Load tests (k6)
+
+Addresses `docs/37` §5.2. Small set of [k6](https://k6.io/) scenarios so
+we can measure latency + capacity rather than guess. Not wired into CI
+by default — the audit suggests "optional, only on main push"; run
+locally or on a dedicated load-gen VPS when capacity planning or before
+a major release.
+
+## Install k6
+
+macOS: `brew install k6`. Linux: see
+[k6.io/docs/getting-started/installation](https://k6.io/docs/getting-started/installation/).
+
+## Scenarios
+
+| File                | Endpoint                | Purpose                                                     |
+|---------------------|-------------------------|-------------------------------------------------------------|
+| `healthz.js`        | `GET /healthz`          | Baseline — p99 floor, pure Fastify handler, no DB           |
+| `auth-login.js`     | `POST /api/v1/auth/login` | Bcrypt-heavy path; invalid path validates rate-limit 429s  |
+| `bots-list.js`      | `GET /api/v1/bots`      | Auth'd read — JWT verify + Prisma findMany, typical dashboard |
+
+## Run
+
+```bash
+# Baseline
+BASE_URL=http://localhost:4000 k6 run load/healthz.js
+
+# Auth — seed a test user first
+curl -s http://localhost:4000/api/v1/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"email":"seed@example.com","password":"Seed1234!"}'
+
+BASE_URL=http://localhost:4000 \
+  LOAD_EMAIL=seed@example.com LOAD_PASS=Seed1234! \
+  k6 run load/auth-login.js
+
+# Dashboard polling
+BASE_URL=http://localhost:4000 \
+  LOAD_EMAIL=seed@example.com LOAD_PASS=Seed1234! \
+  k6 run load/bots-list.js
+```
+
+## Thresholds
+
+Each scenario defines its own `options.thresholds`. Summary of baselines
+we've committed to:
+
+- `/healthz`: p95 < 100 ms, p99 < 250 ms at 50 rps
+- `/auth/login` (valid): p95 < 1000 ms, p99 < 2000 ms (bcrypt is
+  deliberately slow; this is a soft ceiling under ~10 rps)
+- `/api/v1/bots`: p95 < 300 ms, p99 < 500 ms up to 50 concurrent VUs
+
+If a threshold fails, k6 exits non-zero and prints the failing
+metric — use the failure as a signal to investigate before release, not
+as a hard merge gate.
+
+## Interpreting output
+
+- `http_req_duration` — total latency including network; best single
+  metric for user-facing responsiveness.
+- `http_req_failed` — share of non-2xx responses. Rate-limit scenarios
+  expect some 429s and filter them via tags.
+- `custom Trend metrics` — per-endpoint view (e.g. `bots_list_latency_ms`)
+  so you can compare regressions over time.
+
+## Capacity planning
+
+Current rate-limit baseline (API):
+
+- `/auth/login`: 5 req / 15 min per IP
+- global default: 100 req / min per IP
+- `/terminal/*`, `/funding/*`, `/hedges/*`: 30 req / min
+- `/client-errors`: 3 req / min
+
+Use the scenarios to confirm headroom after tuning any of these.

--- a/load/auth-login.js
+++ b/load/auth-login.js
@@ -1,0 +1,88 @@
+// @ts-nocheck -- k6 runtime, not Node.
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { Trend, Rate } from "k6/metrics";
+
+// /auth/login load scenario (§5.2 / docs/37).
+//
+// Two interleaved profiles:
+//   - valid credentials   — exercises bcrypt.compare + refresh token issuance
+//   - invalid credentials — exercises rate-limit path (5 req / 15 min) and
+//     should see 429s kick in quickly, validating the limiter
+//
+// Usage:
+//   BASE_URL=http://localhost:4000 LOAD_EMAIL=seed@example.com LOAD_PASS=Seed1234! \
+//     k6 run load/auth-login.js
+//
+// Seed the account first:
+//   curl -s http://localhost:4000/api/v1/auth/register \
+//     -H "Content-Type: application/json" \
+//     -d '{"email":"seed@example.com","password":"Seed1234!"}'
+
+const BASE_URL  = __ENV.BASE_URL  || "http://localhost:4000";
+const EMAIL     = __ENV.LOAD_EMAIL || "seed@example.com";
+const PASSWORD  = __ENV.LOAD_PASS  || "Seed1234!";
+
+const loginLatency  = new Trend("auth_login_latency_ms", true);
+const rateLimitRate = new Rate("auth_login_rate_limited");
+
+export const options = {
+  scenarios: {
+    valid_creds: {
+      executor: "ramping-arrival-rate",
+      startRate: 1,
+      timeUnit: "1s",
+      preAllocatedVUs: 5,
+      maxVUs: 20,
+      stages: [
+        { target: 5,  duration: "30s" },
+        { target: 10, duration: "30s" },
+        { target: 0,  duration: "10s" },
+      ],
+      exec: "validLogin",
+    },
+    invalid_creds: {
+      executor: "constant-arrival-rate",
+      rate: 2,
+      timeUnit: "1s",
+      duration: "60s",
+      preAllocatedVUs: 2,
+      maxVUs: 5,
+      exec: "invalidLogin",
+      startTime: "10s",
+    },
+  },
+  thresholds: {
+    // bcrypt is intentionally slow; keep p99 under 2s at this load.
+    "http_req_duration{scenario:valid_creds}": ["p(95)<1000", "p(99)<2000"],
+    // invalid path should be fast after limiter kicks in — either quick
+    // 401 or instant 429. Keep failure rate accounting expected 429s.
+    "http_req_failed{scenario:valid_creds}": ["rate<0.01"],
+  },
+};
+
+export function validLogin() {
+  const res = http.post(
+    `${BASE_URL}/api/v1/auth/login`,
+    JSON.stringify({ email: EMAIL, password: PASSWORD }),
+    { headers: { "Content-Type": "application/json" }, tags: { scenario: "valid_creds" } },
+  );
+  loginLatency.add(res.timings.duration);
+  check(res, {
+    "status is 200":   (r) => r.status === 200,
+    "has accessToken": (r) => !!r.json("accessToken"),
+  });
+}
+
+export function invalidLogin() {
+  const res = http.post(
+    `${BASE_URL}/api/v1/auth/login`,
+    JSON.stringify({ email: EMAIL, password: "wrong-password" }),
+    { headers: { "Content-Type": "application/json" }, tags: { scenario: "invalid_creds" } },
+  );
+  rateLimitRate.add(res.status === 429);
+  check(res, {
+    "401 or 429": (r) => r.status === 401 || r.status === 429,
+  });
+  sleep(0.5);
+}

--- a/load/bots-list.js
+++ b/load/bots-list.js
@@ -1,0 +1,72 @@
+// @ts-nocheck -- k6 runtime, not Node.
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { Trend } from "k6/metrics";
+
+// /api/v1/bots load scenario (§5.2 / docs/37).
+//
+// Authenticated read path — representative of dashboard traffic where a
+// logged-in user polls their bot list. Exercises JWT verify + Prisma
+// findMany + workspace resolution.
+//
+// Usage:
+//   BASE_URL=http://localhost:4000 \
+//     LOAD_EMAIL=seed@example.com LOAD_PASS=Seed1234! \
+//     k6 run load/bots-list.js
+//
+// The script logs in once in setup() and reuses the access token for VUs.
+
+const BASE_URL = __ENV.BASE_URL  || "http://localhost:4000";
+const EMAIL    = __ENV.LOAD_EMAIL || "seed@example.com";
+const PASSWORD = __ENV.LOAD_PASS  || "Seed1234!";
+
+const listLatency = new Trend("bots_list_latency_ms", true);
+
+export const options = {
+  scenarios: {
+    dashboard_poll: {
+      executor: "ramping-vus",
+      startVUs: 5,
+      stages: [
+        { target: 10, duration: "30s" },
+        { target: 25, duration: "30s" },
+        { target: 50, duration: "30s" },
+        { target: 0,  duration: "10s" },
+      ],
+    },
+  },
+  thresholds: {
+    // Authenticated JSON list should stay under 500ms p99 up to 50 VUs.
+    http_req_duration: ["p(95)<300", "p(99)<500"],
+    http_req_failed:   ["rate<0.005"],
+  },
+};
+
+export function setup() {
+  const res = http.post(
+    `${BASE_URL}/api/v1/auth/login`,
+    JSON.stringify({ email: EMAIL, password: PASSWORD }),
+    { headers: { "Content-Type": "application/json" } },
+  );
+  if (res.status !== 200) {
+    throw new Error(`setup: login failed status=${res.status} body=${res.body}`);
+  }
+  return {
+    accessToken: res.json("accessToken"),
+    workspaceId: res.json("workspaceId"),
+  };
+}
+
+export default function (data) {
+  const headers = {
+    Authorization:   `Bearer ${data.accessToken}`,
+    "X-Workspace-Id": data.workspaceId,
+  };
+  const res = http.get(`${BASE_URL}/api/v1/bots`, { headers });
+  listLatency.add(res.timings.duration);
+  check(res, {
+    "status is 200":    (r) => r.status === 200,
+    "body is array":    (r) => Array.isArray(r.json()) || Array.isArray(r.json("items")),
+  });
+  sleep(1); // model a dashboard polling once per second per user
+}

--- a/load/healthz.js
+++ b/load/healthz.js
@@ -1,0 +1,48 @@
+// @ts-nocheck -- this file is run by the k6 runtime (Go), not Node/tsc.
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { Trend } from "k6/metrics";
+
+// Baseline health-endpoint probe (§5.2 / docs/37).
+// Purpose: confirm base HTTP stack capacity + establish a p99 floor
+// that other scenarios can be compared against.
+//
+// Usage:
+//   BASE_URL=http://localhost:4000 k6 run load/healthz.js
+//   BASE_URL=https://staging.botmarketplace.store k6 run load/healthz.js
+//
+// Output: JSON summary goes to stdout; p95/p99 latencies + error rate in
+// the trend metrics.
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:4000";
+
+const healthzLatency = new Trend("healthz_latency_ms", true);
+
+export const options = {
+  scenarios: {
+    baseline: {
+      executor: "constant-arrival-rate",
+      rate: 50,                // 50 req/s
+      timeUnit: "1s",
+      duration: "30s",
+      preAllocatedVUs: 10,
+      maxVUs: 50,
+    },
+  },
+  thresholds: {
+    // p99 on /healthz should be < 250ms even under 50 rps — it's just a
+    // DB-less handler returning a constant object.
+    http_req_duration: ["p(95)<100", "p(99)<250"],
+    http_req_failed:   ["rate<0.001"],
+  },
+};
+
+export default function () {
+  const res = http.get(`${BASE_URL}/healthz`);
+  healthzLatency.add(res.timings.duration);
+  check(res, {
+    "status is 200": (r) => r.status === 200,
+    "body has status=ok": (r) => r.json("status") === "ok",
+  });
+  sleep(0.02); // target ~50 rps per VU with constant-arrival-rate
+}


### PR DESCRIPTION
## Summary

Addresses `docs/37` §5.2. Before: rate limits, pool sizes, and endpoint
latencies were picked without measurement. This PR gives us a way to
actually measure them.

Three scenarios, each with explicit thresholds:

- `load/healthz.js` — `GET /healthz` at 50 rps, 30s, p95<100ms
  p99<250ms. Baseline for the Fastify handler with no DB — any
  regression here means the HTTP stack itself is slower.
- `load/auth-login.js` — `POST /api/v1/auth/login` with two interleaved
  profiles: valid creds (ramping 5→10 rps, p99<2s under bcrypt load)
  and invalid creds (2 rps sustained, verifies the 429 rate-limit
  kicks in correctly).
- `load/bots-list.js` — `GET /api/v1/bots` authed, ramping 5→50 VUs
  over 90s. Models a dashboard polling every 1s; p95<300ms p99<500ms.

`load/README.md` documents install, seed-user setup, run commands,
threshold interpretation, and the current rate-limit baselines so
future tuning is informed by data instead of guesswork.

Per audit §5.2: not wired into CI by default ("optional, only on main
push") — scripts run locally or on a dedicated load-gen host.

## Test plan

- [x] `pnpm test:api` — 1696 still passes (no `apps/api` changes)
- [x] `pnpm check:stray` — clean, no stray JS artefacts flagged
- [x] k6 syntax of each script reviewed (uses documented k6 APIs only —
      http, check, sleep, Trend, Rate); thresholds defined per scenario
