### PR TITLE
feat(dlq): workspace-scoped intents list + retry + operator UI (§5.6)

### DIFF
--- a/apps/api/src/routes/intents.ts
+++ b/apps/api/src/routes/intents.ts
@@ -153,4 +153,111 @@ export async function intentRoutes(app: FastifyInstance) {
 
     return reply.send(updated);
   });
+
+  // ── GET /intents ── workspace-scoped list (DLQ / operator UI, §5.6) ──────
+  app.get<{
+    Querystring: { state?: IntentState; limit?: string; offset?: string };
+  }>("/intents", { onRequest: [app.authenticate] }, async (request, reply) => {
+    const workspace = await resolveWorkspace(request, reply);
+    if (!workspace) return;
+
+    const limit = Math.min(parseInt(request.query?.limit ?? "50", 10) || 50, 200);
+    const offset = Math.max(parseInt(request.query?.offset ?? "0", 10) || 0, 0);
+    const state = request.query?.state;
+
+    const where: Prisma.BotIntentWhereInput = {
+      botRun: { workspaceId: workspace.id },
+      ...(state ? { state } : {}),
+    };
+
+    const [items, total] = await Promise.all([
+      prisma.botIntent.findMany({
+        where,
+        orderBy: { createdAt: "desc" },
+        take: limit,
+        skip: offset,
+        include: {
+          botRun: {
+            select: {
+              id: true,
+              symbol: true,
+              state: true,
+              bot: { select: { id: true, name: true, symbol: true } },
+            },
+          },
+        },
+      }),
+      prisma.botIntent.count({ where }),
+    ]);
+
+    return reply.send({ items, total, limit, offset });
+  });
+
+  // ── POST /intents/:id/retry ── manual retry of a FAILED intent (§5.6) ────
+  app.post<{ Params: { id: string } }>(
+    "/intents/:id/retry",
+    { onRequest: [app.authenticate] },
+    async (request, reply) => {
+      const workspace = await resolveWorkspace(request, reply);
+      if (!workspace) return;
+
+      const intent = await prisma.botIntent.findUnique({
+        where: { id: request.params.id },
+        include: { botRun: { select: { id: true, workspaceId: true } } },
+      });
+
+      if (!intent || intent.botRun.workspaceId !== workspace.id) {
+        return problem(reply, 404, "Not Found", "Intent not found");
+      }
+      if (intent.state !== "FAILED") {
+        return problem(
+          reply,
+          409,
+          "Conflict",
+          `Only FAILED intents can be retried (current state: ${intent.state})`,
+        );
+      }
+
+      const prevMeta =
+        intent.metaJson && typeof intent.metaJson === "object"
+          ? (intent.metaJson as Record<string, unknown>)
+          : {};
+      const updated = await prisma.botIntent.update({
+        where: { id: intent.id },
+        data: {
+          state: "PENDING",
+          metaJson: {
+            ...prevMeta,
+            manualRetryAt: new Date().toISOString(),
+            previousState: "FAILED",
+          } as Prisma.InputJsonValue,
+        },
+        include: {
+          botRun: {
+            select: {
+              id: true,
+              symbol: true,
+              state: true,
+              bot: { select: { id: true, name: true, symbol: true } },
+            },
+          },
+        },
+      });
+
+      await prisma.botEvent.create({
+        data: {
+          botRunId: intent.botRun.id,
+          type: "intent_manually_retried",
+          payloadJson: {
+            intentId: intent.intentId,
+            orderLinkId: intent.orderLinkId,
+            retryCount: intent.retryCount,
+            at: new Date().toISOString(),
+          } as Prisma.InputJsonValue,
+        },
+      });
+
+      return reply.send(updated);
+    },
+  );
 }

--- a/apps/api/tests/routes/intentsDlq.test.ts
+++ b/apps/api/tests/routes/intentsDlq.test.ts
@@ -1,0 +1,334 @@
+/**
+ * Route tests: DLQ / operator UI endpoints on intents.ts (§5.6).
+ *
+ * Covers: GET /intents  (workspace-scoped list, filterable by state, paginated)
+ *         POST /intents/:id/retry  (manual retry of a FAILED intent)
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from "vitest";
+
+// ── Mock state ──────────────────────────────────────────────────────────────
+
+interface MockIntent {
+  id: string;
+  intentId: string;
+  orderLinkId: string;
+  state: "PENDING" | "PLACED" | "FILLED" | "FAILED" | "CANCELLED";
+  type: "ENTRY" | "EXIT";
+  side: "BUY" | "SELL";
+  qty: number;
+  price: number | null;
+  retryCount: number;
+  metaJson: Record<string, unknown> | null;
+  orderId: string | null;
+  cumExecQty: number | null;
+  avgFillPrice: number | null;
+  createdAt: Date;
+  updatedAt: Date;
+  botRunId: string;
+}
+
+const mockIntents: MockIntent[] = [];
+const mockBotRuns: Record<string, { id: string; workspaceId: string; symbol: string; state: string; botId: string }> = {};
+const mockBotEvents: Array<Record<string, unknown>> = [];
+const mockWorkspaceMemberships: Array<Record<string, unknown>> = [];
+
+// ── Mock Prisma ─────────────────────────────────────────────────────────────
+
+vi.mock("@prisma/client", () => ({
+  PrismaClient: vi.fn().mockImplementation(() => ({})),
+  Prisma: { sql: vi.fn(), join: vi.fn(), JsonNull: "DbNull", InputJsonValue: {} as never },
+}));
+
+function includeBotRun(intent: MockIntent) {
+  const run = mockBotRuns[intent.botRunId];
+  return {
+    ...intent,
+    botRun: run
+      ? {
+          id: run.id,
+          symbol: run.symbol,
+          state: run.state,
+          bot: { id: run.botId, name: `bot-${run.botId}`, symbol: run.symbol },
+        }
+      : null,
+  };
+}
+
+vi.mock("../../src/lib/prisma.js", () => ({
+  prisma: {
+    botRun: {
+      findUnique: vi.fn().mockImplementation(({ where }: { where: { id: string } }) =>
+        Promise.resolve(mockBotRuns[where.id] ?? null),
+      ),
+    },
+    botIntent: {
+      findUnique: vi.fn().mockImplementation(({ where, include }: {
+        where: { id?: string };
+        include?: { botRun?: unknown };
+      }) => {
+        if (!where.id) return Promise.resolve(null);
+        const intent = mockIntents.find((i) => i.id === where.id);
+        if (!intent) return Promise.resolve(null);
+        if (include?.botRun) {
+          const run = mockBotRuns[intent.botRunId];
+          return Promise.resolve({
+            ...intent,
+            botRun: run
+              ? { id: run.id, workspaceId: run.workspaceId }
+              : { id: intent.botRunId, workspaceId: "" },
+          });
+        }
+        return Promise.resolve(intent);
+      }),
+      findMany: vi.fn().mockImplementation(({ where, take, skip }: {
+        where: { botRun?: { workspaceId?: string }; state?: string };
+        take?: number;
+        skip?: number;
+      }) => {
+        let items = [...mockIntents];
+        if (where.botRun?.workspaceId) {
+          items = items.filter((i) => mockBotRuns[i.botRunId]?.workspaceId === where.botRun!.workspaceId);
+        }
+        if (where.state) {
+          items = items.filter((i) => i.state === where.state);
+        }
+        items.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+        const sliced = items.slice(skip ?? 0, (skip ?? 0) + (take ?? items.length));
+        return Promise.resolve(sliced.map(includeBotRun));
+      }),
+      count: vi.fn().mockImplementation(({ where }: { where: { botRun?: { workspaceId?: string }; state?: string } }) => {
+        let items = [...mockIntents];
+        if (where.botRun?.workspaceId) {
+          items = items.filter((i) => mockBotRuns[i.botRunId]?.workspaceId === where.botRun!.workspaceId);
+        }
+        if (where.state) items = items.filter((i) => i.state === where.state);
+        return Promise.resolve(items.length);
+      }),
+      update: vi.fn().mockImplementation(({ where, data, include }: {
+        where: { id: string };
+        data: Partial<MockIntent>;
+        include?: { botRun?: unknown };
+      }) => {
+        const intent = mockIntents.find((i) => i.id === where.id);
+        if (!intent) return Promise.resolve(null);
+        Object.assign(intent, data, { updatedAt: new Date() });
+        return Promise.resolve(include?.botRun ? includeBotRun(intent) : intent);
+      }),
+    },
+    botEvent: {
+      create: vi.fn().mockImplementation(({ data }: { data: Record<string, unknown> }) => {
+        mockBotEvents.push(data);
+        return Promise.resolve({ id: `event-${mockBotEvents.length}`, ...data });
+      }),
+    },
+    workspaceMember: {
+      findUnique: vi.fn().mockImplementation(({ where }: {
+        where: { workspaceId_userId?: { userId: string; workspaceId: string } };
+      }) => {
+        const filter = where.workspaceId_userId;
+        if (!filter) return Promise.resolve(null);
+        const m = mockWorkspaceMemberships.find(
+          (x) => x.userId === filter.userId && x.workspaceId === filter.workspaceId,
+        );
+        if (!m) return Promise.resolve(null);
+        return Promise.resolve({ ...m, workspace: { id: m.workspaceId, name: "Test WS" } });
+      }),
+    },
+    $queryRaw: vi.fn().mockResolvedValue([]),
+    $connect: vi.fn(),
+    $disconnect: vi.fn(),
+  },
+}));
+
+import { buildApp } from "../../src/app.js";
+import type { FastifyInstance } from "fastify";
+
+// ── Setup ───────────────────────────────────────────────────────────────────
+
+let app: FastifyInstance;
+let token: string;
+let otherToken: string;
+const WS_ID = "ws-dlq-test";
+const OTHER_WS_ID = "ws-dlq-other";
+const USER_ID = "user-dlq-1";
+
+beforeAll(async () => {
+  app = await buildApp();
+  token = app.jwt.sign({ sub: USER_ID, email: "dlq@test.com" });
+  otherToken = app.jwt.sign({ sub: "user-other", email: "other@test.com" });
+});
+
+afterAll(async () => { await app.close(); });
+
+function mkIntent(overrides: Partial<MockIntent> = {}): MockIntent {
+  const id = overrides.id ?? `i-${mockIntents.length + 1}`;
+  return {
+    id,
+    intentId: overrides.intentId ?? `intent-${id}`,
+    orderLinkId: overrides.orderLinkId ?? `link-${id}`,
+    state: overrides.state ?? "FAILED",
+    type: overrides.type ?? "ENTRY",
+    side: overrides.side ?? "BUY",
+    qty: overrides.qty ?? 0.01,
+    price: overrides.price ?? null,
+    retryCount: overrides.retryCount ?? 1,
+    metaJson: overrides.metaJson ?? { error: "HTTP 500", errorClass: "transient" },
+    orderId: overrides.orderId ?? null,
+    cumExecQty: overrides.cumExecQty ?? null,
+    avgFillPrice: overrides.avgFillPrice ?? null,
+    createdAt: overrides.createdAt ?? new Date(),
+    updatedAt: overrides.updatedAt ?? new Date(),
+    botRunId: overrides.botRunId ?? "run-1",
+  };
+}
+
+beforeEach(() => {
+  mockIntents.length = 0;
+  mockBotEvents.length = 0;
+  mockWorkspaceMemberships.length = 0;
+  Object.keys(mockBotRuns).forEach((k) => delete mockBotRuns[k]);
+
+  mockWorkspaceMemberships.push({ userId: USER_ID, workspaceId: WS_ID, role: "OWNER" });
+  mockBotRuns["run-1"]  = { id: "run-1",  workspaceId: WS_ID,       symbol: "BTCUSDT", state: "RUNNING", botId: "bot-a" };
+  mockBotRuns["run-2"]  = { id: "run-2",  workspaceId: OTHER_WS_ID, symbol: "ETHUSDT", state: "RUNNING", botId: "bot-b" };
+});
+
+function headers(wsId = WS_ID) {
+  return { authorization: `Bearer ${token}`, "x-workspace-id": wsId };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("GET /api/v1/intents (workspace-scoped list, §5.6)", () => {
+  it("returns items + total for the current workspace only", async () => {
+    mockIntents.push(mkIntent({ id: "i-ws", botRunId: "run-1" }));
+    mockIntents.push(mkIntent({ id: "i-other", botRunId: "run-2" }));
+
+    const res = await app.inject({ method: "GET", url: "/api/v1/intents", headers: headers() });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.total).toBe(1);
+    expect(body.items).toHaveLength(1);
+    expect(body.items[0].id).toBe("i-ws");
+    expect(body.items[0].botRun.bot.id).toBe("bot-a");
+  });
+
+  it("filters by state=FAILED", async () => {
+    mockIntents.push(mkIntent({ id: "i-failed", state: "FAILED",   botRunId: "run-1" }));
+    mockIntents.push(mkIntent({ id: "i-filled", state: "FILLED",   botRunId: "run-1" }));
+    mockIntents.push(mkIntent({ id: "i-pend",   state: "PENDING",  botRunId: "run-1" }));
+
+    const res = await app.inject({ method: "GET", url: "/api/v1/intents?state=FAILED", headers: headers() });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.total).toBe(1);
+    expect(body.items[0].id).toBe("i-failed");
+  });
+
+  it("respects limit + offset pagination", async () => {
+    for (let i = 0; i < 5; i++) {
+      const createdAt = new Date(Date.now() + i * 1000);
+      mockIntents.push(mkIntent({ id: `i-${i}`, botRunId: "run-1", createdAt }));
+    }
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/intents?limit=2&offset=1",
+      headers: headers(),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.total).toBe(5);
+    expect(body.items).toHaveLength(2);
+    expect(body.limit).toBe(2);
+    expect(body.offset).toBe(1);
+  });
+
+  it("caps limit at 200 to prevent runaway queries", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/intents?limit=10000",
+      headers: headers(),
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().limit).toBe(200);
+  });
+
+  it("returns 401 without auth", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/v1/intents" });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns empty list when user does not belong to the requested workspace", async () => {
+    mockIntents.push(mkIntent({ id: "i-other", botRunId: "run-2" }));
+    mockWorkspaceMemberships.length = 0;
+    mockWorkspaceMemberships.push({ userId: USER_ID, workspaceId: WS_ID, role: "OWNER" });
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/intents",
+      headers: { authorization: `Bearer ${otherToken}`, "x-workspace-id": WS_ID },
+    });
+    expect([401, 403, 404]).toContain(res.statusCode);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("POST /api/v1/intents/:id/retry (§5.6)", () => {
+  it("resets a FAILED intent to PENDING and emits a BotEvent", async () => {
+    mockIntents.push(mkIntent({ id: "i-retry", state: "FAILED", botRunId: "run-1" }));
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/intents/i-retry/retry",
+      headers: headers(),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.state).toBe("PENDING");
+    expect(body.metaJson.manualRetryAt).toBeTruthy();
+    expect(body.metaJson.previousState).toBe("FAILED");
+
+    expect(mockBotEvents).toHaveLength(1);
+    expect((mockBotEvents[0] as { type: string }).type).toBe("intent_manually_retried");
+  });
+
+  it("rejects retry on a non-FAILED intent (409)", async () => {
+    mockIntents.push(mkIntent({ id: "i-pend", state: "PENDING", botRunId: "run-1" }));
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/intents/i-pend/retry",
+      headers: headers(),
+    });
+    expect(res.statusCode).toBe(409);
+    expect(mockBotEvents).toHaveLength(0);
+  });
+
+  it("returns 404 for an intent in a different workspace", async () => {
+    mockIntents.push(mkIntent({ id: "i-other", state: "FAILED", botRunId: "run-2" }));
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/intents/i-other/retry",
+      headers: headers(),
+    });
+    expect(res.statusCode).toBe(404);
+    expect(mockBotEvents).toHaveLength(0);
+  });
+
+  it("returns 404 for a nonexistent intent id", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/intents/does-not-exist/retry",
+      headers: headers(),
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 401 without auth", async () => {
+    const res = await app.inject({ method: "POST", url: "/api/v1/intents/x/retry" });
+    expect(res.statusCode).toBe(401);
+  });
+});

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -828,6 +828,126 @@
     "node_modules/zustand": {
       "resolved": "../../node_modules/.pnpm/zustand@5.0.11_@types+react@19.2.14_react@19.2.4/node_modules/zustand",
       "link": true
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.15.tgz",
+      "integrity": "sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.15.tgz",
+      "integrity": "sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.15.tgz",
+      "integrity": "sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.15.tgz",
+      "integrity": "sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.15.tgz",
+      "integrity": "sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.15.tgz",
+      "integrity": "sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.15.tgz",
+      "integrity": "sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.15.tgz",
+      "integrity": "sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/apps/web/src/app/operator/dlq/page.tsx
+++ b/apps/web/src/app/operator/dlq/page.tsx
@@ -1,0 +1,350 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { apiFetch, getToken } from "../../../lib/api";
+
+// ---------------------------------------------------------------------------
+// Types — mirror the API shape from GET /api/v1/intents
+// ---------------------------------------------------------------------------
+
+type IntentState =
+  | "PENDING" | "PLACED" | "PARTIALLY_FILLED" | "FILLED" | "CANCELLED" | "FAILED";
+
+interface BotRef { id: string; name: string; symbol: string }
+interface BotRunRef { id: string; symbol: string; state: string; bot: BotRef }
+
+interface Intent {
+  id: string;
+  intentId: string;
+  orderLinkId: string;
+  type: string;
+  side: string;
+  qty: string;
+  price: string | null;
+  state: IntentState;
+  retryCount: number;
+  orderId: string | null;
+  metaJson: Record<string, unknown> | null;
+  createdAt: string;
+  updatedAt: string;
+  botRun: BotRunRef;
+}
+
+interface ListResponse {
+  items: Intent[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+const STATES: IntentState[] = ["FAILED", "PENDING", "PLACED", "PARTIALLY_FILLED", "FILLED", "CANCELLED"];
+const PAGE_SIZE = 25;
+
+// ---------------------------------------------------------------------------
+
+export default function DlqPage() {
+  const router = useRouter();
+
+  const [state, setState] = useState<IntentState | "">("FAILED");
+  const [items, setItems] = useState<Intent[]>([]);
+  const [total, setTotal] = useState(0);
+  const [offset, setOffset] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [retrying, setRetrying] = useState<Record<string, boolean>>({});
+  const [retryMsg, setRetryMsg] = useState<Record<string, string | null>>({});
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const qs = new URLSearchParams({
+      limit: String(PAGE_SIZE),
+      offset: String(offset),
+      ...(state ? { state } : {}),
+    });
+    const res = await apiFetch<ListResponse>(`/intents?${qs.toString()}`);
+    setLoading(false);
+    if (!res.ok) {
+      setError(`${res.problem.title}: ${res.problem.detail}`);
+      setItems([]);
+      setTotal(0);
+      return;
+    }
+    setItems(res.data.items);
+    setTotal(res.data.total);
+  }, [state, offset]);
+
+  useEffect(() => {
+    if (!getToken()) {
+      router.push("/login");
+      return;
+    }
+    load();
+  }, [load, router]);
+
+  async function handleRetry(intent: Intent) {
+    setRetrying((r) => ({ ...r, [intent.id]: true }));
+    setRetryMsg((m) => ({ ...m, [intent.id]: null }));
+    const res = await apiFetch<Intent>(`/intents/${intent.id}/retry`, { method: "POST" });
+    setRetrying((r) => ({ ...r, [intent.id]: false }));
+    if (!res.ok) {
+      setRetryMsg((m) => ({ ...m, [intent.id]: `✗ ${res.problem.title}: ${res.problem.detail}` }));
+      return;
+    }
+    setRetryMsg((m) => ({ ...m, [intent.id]: "✓ Retried — state reset to PENDING" }));
+    // Refresh list in place so the retried row disappears from FAILED view
+    setTimeout(load, 500);
+  }
+
+  const page = Math.floor(offset / PAGE_SIZE) + 1;
+  const pages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  return (
+    <div style={wrap}>
+      <div style={header}>
+        <h1 style={title}>Dead-letter queue</h1>
+        <p style={subtitle}>
+          Failed bot intents, workspace-scoped. Retry puts an intent back into PENDING
+          so the worker re-processes it on the next tick.
+        </p>
+      </div>
+
+      <div style={card}>
+        <div style={filterRow}>
+          <label style={fieldLabel}>State</label>
+          <select
+            style={selectStyle}
+            value={state}
+            onChange={(e) => { setOffset(0); setState(e.target.value as IntentState | ""); }}
+          >
+            <option value="">(any)</option>
+            {STATES.map((s) => <option key={s} value={s}>{s}</option>)}
+          </select>
+          <button style={smallBtn} onClick={() => load()} disabled={loading}>
+            {loading ? "Loading…" : "Refresh"}
+          </button>
+          <span style={{ ...hint, marginLeft: "auto" }}>
+            {total > 0 ? `${total} total, page ${page}/${pages}` : "0 total"}
+          </span>
+        </div>
+
+        {error && <div style={errorBanner}>{error}</div>}
+        {!error && items.length === 0 && !loading && (
+          <div style={emptyMsg}>No intents match the current filter.</div>
+        )}
+
+        {items.length > 0 && (
+          <table style={table}>
+            <thead>
+              <tr>
+                <Th w={30} />
+                <Th>intentId</Th>
+                <Th>bot / symbol</Th>
+                <Th>type</Th>
+                <Th>side</Th>
+                <Th>qty</Th>
+                <Th>state</Th>
+                <Th>retry</Th>
+                <Th>created</Th>
+                <Th w={120} align="right">actions</Th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((it) => (
+                <IntentRow
+                  key={it.id}
+                  intent={it}
+                  expanded={expanded === it.id}
+                  toggle={() => setExpanded(expanded === it.id ? null : it.id)}
+                  retrying={!!retrying[it.id]}
+                  retryMsg={retryMsg[it.id] ?? null}
+                  onRetry={() => handleRetry(it)}
+                />
+              ))}
+            </tbody>
+          </table>
+        )}
+
+        {total > PAGE_SIZE && (
+          <div style={paginationRow}>
+            <button
+              style={smallBtn}
+              disabled={offset === 0}
+              onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+            >
+              ← Prev
+            </button>
+            <span style={hint}>page {page} / {pages}</span>
+            <button
+              style={smallBtn}
+              disabled={offset + PAGE_SIZE >= total}
+              onClick={() => setOffset(offset + PAGE_SIZE)}
+            >
+              Next →
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Row — collapsible, with detail + action buttons
+// ---------------------------------------------------------------------------
+
+function IntentRow({
+  intent, expanded, toggle, retrying, retryMsg, onRetry,
+}: {
+  intent: Intent;
+  expanded: boolean;
+  toggle: () => void;
+  retrying: boolean;
+  retryMsg: string | null;
+  onRetry: () => void;
+}) {
+  const createdAgo = useMemo(() => formatAgo(intent.createdAt), [intent.createdAt]);
+  const meta = intent.metaJson ?? {};
+  const errorReason = String(meta.error ?? meta.classificationReason ?? meta.deadLetterReason ?? "—");
+  const errorClass = String(meta.errorClass ?? "");
+
+  return (
+    <>
+      <tr onClick={toggle} style={trClickable}>
+        <td style={td}>{expanded ? "▾" : "▸"}</td>
+        <td style={{ ...td, fontFamily: "var(--font-mono, monospace)", fontSize: 12 }}>{intent.intentId}</td>
+        <td style={td}>
+          <div style={{ fontWeight: 500 }}>{intent.botRun.bot.name}</div>
+          <div style={hint}>{intent.botRun.bot.symbol}</div>
+        </td>
+        <td style={td}>{intent.type}</td>
+        <td style={td}>{intent.side}</td>
+        <td style={td}>{intent.qty}</td>
+        <td style={td}><StateBadge state={intent.state} /></td>
+        <td style={td}>{intent.retryCount}</td>
+        <td style={{ ...td, ...hint }}>{createdAgo}</td>
+        <td style={{ ...td, textAlign: "right" }}>
+          {intent.state === "FAILED" && (
+            <button
+              style={retryBtn}
+              onClick={(e) => { e.stopPropagation(); onRetry(); }}
+              disabled={retrying}
+            >
+              {retrying ? "…" : "Retry"}
+            </button>
+          )}
+        </td>
+      </tr>
+      {expanded && (
+        <tr>
+          <td colSpan={10} style={detailCell}>
+            <div style={detailGrid}>
+              <DetailField label="id" value={intent.id} />
+              <DetailField label="orderLinkId" value={intent.orderLinkId} />
+              <DetailField label="orderId" value={intent.orderId ?? "—"} />
+              <DetailField label="run" value={`${intent.botRun.id} (${intent.botRun.state})`} />
+              <DetailField label="error" value={errorReason} />
+              <DetailField label="errorClass" value={errorClass || "—"} />
+              <DetailField label="price" value={intent.price ?? "—"} />
+              <DetailField label="updatedAt" value={new Date(intent.updatedAt).toISOString()} />
+            </div>
+            <pre style={metaPre}>{JSON.stringify(meta, null, 2)}</pre>
+            {retryMsg && <div style={retryStatus}>{retryMsg}</div>}
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}
+
+function DetailField({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div style={hint}>{label}</div>
+      <div style={{ fontFamily: "var(--font-mono, monospace)", fontSize: 12, wordBreak: "break-all" }}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function StateBadge({ state }: { state: IntentState }) {
+  const bg = STATE_COLORS[state] ?? "#6e7681";
+  return (
+    <span style={{
+      display: "inline-block", padding: "2px 8px", borderRadius: 4,
+      background: bg, color: "#fff", fontSize: 11, fontWeight: 600, letterSpacing: 0.2,
+    }}>
+      {state}
+    </span>
+  );
+}
+
+function Th({ children, w, align }: { children?: React.ReactNode; w?: number; align?: "left" | "right" }) {
+  return (
+    <th style={{
+      textAlign: align ?? "left",
+      padding: "8px 10px",
+      color: "var(--text-secondary)",
+      fontWeight: 500,
+      fontSize: 12,
+      borderBottom: "1px solid var(--border)",
+      width: w,
+    }}>
+      {children}
+    </th>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatAgo(iso: string): string {
+  const delta = Date.now() - new Date(iso).getTime();
+  const s = Math.floor(delta / 1000);
+  if (s < 60)     return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60)     return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24)     return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  return `${d}d ago`;
+}
+
+// ---------------------------------------------------------------------------
+// Styles — match the token vocabulary used on /settings
+// ---------------------------------------------------------------------------
+
+const STATE_COLORS: Record<IntentState, string> = {
+  PENDING:           "#6e7681",
+  PLACED:            "#1f6feb",
+  PARTIALLY_FILLED:  "#bb8009",
+  FILLED:            "#3fb950",
+  CANCELLED:         "#8250df",
+  FAILED:            "#f85149",
+};
+
+const wrap:          React.CSSProperties = { maxWidth: 1200, margin: "0 auto", padding: "32px 24px" };
+const header:        React.CSSProperties = { marginBottom: 20 };
+const title:         React.CSSProperties = { fontSize: 22, fontWeight: 600, margin: 0, color: "var(--text-primary)" };
+const subtitle:      React.CSSProperties = { color: "var(--text-secondary)", fontSize: 13, marginTop: 6 };
+const card:          React.CSSProperties = { background: "var(--bg-card)", border: "1px solid var(--border)", borderRadius: 8, padding: "16px 20px" };
+const filterRow:     React.CSSProperties = { display: "flex", alignItems: "center", gap: 12, paddingBottom: 12, borderBottom: "1px solid var(--border)", marginBottom: 8 };
+const fieldLabel:    React.CSSProperties = { color: "var(--text-secondary)", fontSize: 13 };
+const selectStyle:   React.CSSProperties = { background: "var(--bg-secondary)", border: "1px solid var(--border)", borderRadius: 6, color: "var(--text-primary)", fontSize: 13, padding: "6px 10px" };
+const smallBtn:      React.CSSProperties = { padding: "4px 12px", background: "transparent", border: "1px solid var(--border)", borderRadius: 5, color: "var(--text-secondary)", cursor: "pointer", fontSize: 12 };
+const retryBtn:      React.CSSProperties = { padding: "4px 12px", background: "var(--accent)", border: "none", borderRadius: 5, color: "#fff", cursor: "pointer", fontSize: 12, fontWeight: 600 };
+const hint:          React.CSSProperties = { color: "var(--text-secondary)", fontSize: 12 };
+const emptyMsg:      React.CSSProperties = { padding: "32px 0", textAlign: "center", color: "var(--text-secondary)", fontSize: 13 };
+const errorBanner:   React.CSSProperties = { background: "#f85149", color: "#fff", padding: "10px 14px", borderRadius: 6, fontSize: 13, margin: "8px 0" };
+const table:         React.CSSProperties = { width: "100%", borderCollapse: "collapse", fontSize: 13 };
+const trClickable:   React.CSSProperties = { cursor: "pointer", borderBottom: "1px solid var(--border)" };
+const td:            React.CSSProperties = { padding: "8px 10px", color: "var(--text-primary)", verticalAlign: "middle" };
+const detailCell:    React.CSSProperties = { padding: "12px 16px", background: "var(--bg-secondary)", borderBottom: "1px solid var(--border)" };
+const detailGrid:    React.CSSProperties = { display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 12, marginBottom: 12 };
+const metaPre:       React.CSSProperties = { background: "var(--bg-card)", padding: 10, borderRadius: 6, border: "1px solid var(--border)", fontSize: 11, overflowX: "auto", color: "var(--text-primary)", margin: 0 };
+const retryStatus:   React.CSSProperties = { marginTop: 10, fontSize: 12, color: "var(--text-secondary)" };
+const paginationRow: React.CSSProperties = { display: "flex", alignItems: "center", justifyContent: "center", gap: 14, padding: "12px 0 4px" };

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -410,6 +410,21 @@ export default function SettingsPage() {
           </div>
         </div>
       </section>
+
+      {/* Operator tools */}
+      <section style={card}>
+        <h2 style={sectionTitle}>Operator tools</h2>
+        <div style={field}>
+          <span style={fieldValue}>Dead-letter queue</span>
+          <a href="/operator/dlq" style={{ ...hint, marginLeft: "auto", textDecoration: "underline" }}>
+            /operator/dlq →
+          </a>
+        </div>
+        <div style={{ ...hint, marginTop: 6 }}>
+          Inspect FAILED bot intents across the workspace and retry them manually
+          (see RUNBOOK §6.8).
+        </div>
+      </section>
     </div>
   );
 }

--- a/docs/runbooks/RUNBOOK.md
+++ b/docs/runbooks/RUNBOOK.md
@@ -331,6 +331,22 @@ journalctl -u botmarket-worker --since "5 minutes ago" | tail -5
      -H "X-Workspace-Id: $WS_ID"
    ```
 
+**DLQ UI (§5.6).** Для ручного разбора FAILED intents — страница `/operator/dlq`
+в web-UI (ссылка также доступна из Settings → Operator tools). Показывает
+список с фильтром по state, деталями `metaJson` (включая `error`, `errorClass`,
+`deadLetterReason`), pagination; кнопка **Retry** переводит FAILED → PENDING,
+воркер подхватит на следующем тике. Эквиваленты через API:
+
+```bash
+# Список FAILED в воркспейсе
+curl -s -H "Authorization: Bearer $TOKEN" -H "X-Workspace-Id: $WS_ID" \
+  "http://localhost:4000/api/v1/intents?state=FAILED&limit=50"
+
+# Manual retry
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "X-Workspace-Id: $WS_ID" \
+  "http://localhost:4000/api/v1/intents/$INTENT_ID/retry"
+```
+
 ### 6.9 Exchange API вернул 5xx / недоступен
 
 **Симптом.** Счётчик `botmarket_intent_failed_total` резко растёт; в логах — `errorClass=transient` или `classification.retryable=true`; `/readyz` остаётся `ok` (проблема снаружи, не у нас).


### PR DESCRIPTION
## Summary

Addresses `docs/37` §5.6 — **the last open production-readiness audit
item**. Before this, an operator needed `psql` to inspect FAILED intents
and there was no in-app way to retry one without exporting/re-importing data.

**API (`apps/api`)**:

- `GET /api/v1/intents?state=<STATE>&limit=<n>&offset=<n>`
  - workspace-scoped via `resolveWorkspace` + `BotRun.workspaceId` filter
  - returns `{ items, total, limit, offset }`; `limit` capped at 200
  - each item includes joined `botRun` + `bot` (id, name, symbol) so the
    UI doesn't need a second round-trip per row
- `POST /api/v1/intents/:id/retry`
  - only accepts intents currently in `FAILED` (409 otherwise)
  - resets `state → PENDING`, merges `metaJson` with `manualRetryAt` +
    `previousState: "FAILED"`
  - emits `BotEvent` `intent_manually_retried` so the per-run audit trail
    keeps showing up
- Workspace isolation enforced: cross-workspace `:id` returns 404

**Web (`apps/web`)**:

- New page `/operator/dlq`
  - Auth guard (redirects to `/login` if no token)
  - State filter (default `FAILED`), paginated (25/page)
  - Table: state badge, bot/symbol, type/side/qty, retryCount, relative
    timestamp, per-row **Retry** button
  - Click a row to expand: `orderLinkId`, `orderId`, run id, error,
    errorClass, full `metaJson` pretty-printed
  - Styles match `/settings` vocabulary (CSS var tokens, no new design system)
- `/settings`: new "Operator tools" card links to `/operator/dlq` so the
  page is discoverable without knowing the URL

**Docs**:

- RUNBOOK §6.8 now references `/operator/dlq` as the preferred way to
  inspect + retry FAILED intents; equivalent `curl` examples included
  so scripts / external automation still work.

## Test plan

- [x] `pnpm test:api` — 1707 passed (prev 1696 + 11 new in
      `tests/routes/intentsDlq.test.ts`)
- [x] `pnpm build:api`
- [x] `pnpm build:web` — page rendered as static, no runtime errors
- [x] New tests cover:
  - workspace isolation on list + retry
  - `state=FAILED` filter
  - pagination (`limit` + `offset`), limit cap at 200
  - 401 unauthenticated
  - retry happy path (FAILED → PENDING, BotEvent emitted)
  - retry rejection on non-FAILED (409), nonexistent id (404),
    cross-workspace id (404)
