### PR TITLE
feat(lab): POST /lab/preview — DSL dry-run against last 24h candles (§5.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Entries get promoted to a versioned section on release (see
 
 ### Added
 
+- `POST /api/v1/lab/preview` — synchronous DSL dry-run against the last
+  N hours (≤168) of `MarketCandle` data. Reuses the pure `runBacktest()`
+  engine; no DB writes, no exchange call. Returns the same report shape
+  as `/lab/backtest` plus a `meta` block with `candleCount`, `fromTsMs`,
+  `toTsMs`, and `dataAgeMs` so callers can surface data-freshness lag.
+  Rate-limited to 5 req/min per IP. (§5.12)
 - `deploy/rollback.sh` with auto-detected previous tag, `--dry-run`,
   `--to`, `--yes`; warns on forward-only DB migrations. RUNBOOK §3.5.
   (§5.1, #277)

--- a/apps/api/src/routes/lab.ts
+++ b/apps/api/src/routes/lab.ts
@@ -4,6 +4,7 @@ import { problem } from "../lib/problem.js";
 import { logger } from "../lib/logger.js";
 import { resolveWorkspace } from "../lib/workspace.js";
 import { runBacktest } from "../lib/backtest.js";
+import { validateDsl } from "../lib/dslValidator.js";
 import { applyDslSweepParam } from "../lib/dslSweepParam.js";
 import { compileGraph } from "../lib/graphCompiler.js";
 import type { GraphJson } from "../lib/graphCompiler.js";
@@ -32,6 +33,9 @@ type FillAt = typeof ALLOWED_FILL_AT[number];
 /** Reasonable upper bound for fee/slippage to prevent nonsensical inputs */
 const MAX_BPS = 1000; // 10%
 
+/** Upper bound for preview lookback window (1 week @ M15 ≈ 672 candles) */
+const PREVIEW_MAX_HOURS = 168;
+
 // ---------------------------------------------------------------------------
 // Routes
 // ---------------------------------------------------------------------------
@@ -48,6 +52,17 @@ interface StartBacktestBody {
   feeBps?: number;
   slippageBps?: number;
   fillAt?: FillAt;
+}
+
+/**
+ * Preview request — synchronous DSL dry-run against the last N hours of
+ * MarketCandle data (no DB writes, no exchange call). Used by the graph
+ * builder to sanity-check a strategy before flipping it live.
+ */
+interface PreviewBody {
+  dslJson: unknown;
+  symbol: string;
+  hours?: number;
 }
 
 /** Fields returned in list/detail views (includes Stage 19b + Phase 5 additions) */
@@ -446,6 +461,93 @@ export async function labRoutes(app: FastifyInstance) {
     });
 
     return reply.status(202).send(bt);
+  });
+
+  // ── POST /lab/preview ── synchronous DSL dry-run against the last N hours ──
+  // Stateless: no BotRun, no exchange call, no DB writes. Reuses the pure
+  // runBacktest() engine against the global MarketCandle table so users can
+  // sanity-check a strategy before enabling it (§5.12 product gap).
+  app.post<{ Body: PreviewBody }>("/lab/preview", {
+    config: { rateLimit: { max: 5, timeWindow: "1 minute" } },
+    onRequest: [app.authenticate],
+  }, async (request, reply) => {
+    const workspace = await resolveWorkspace(request, reply);
+    if (!workspace) return;
+
+    const { dslJson, symbol, hours = 24 } = request.body ?? {};
+
+    const dslErrors = validateDsl(dslJson);
+    if (dslErrors) {
+      return problem(reply, 400, "Validation Error", "DSL validation failed", { errors: dslErrors });
+    }
+    if (typeof symbol !== "string" || symbol.trim().length === 0) {
+      return problem(reply, 400, "Validation Error", "symbol is required", {
+        errors: [{ field: "symbol", message: "symbol must be a non-empty string" }],
+      });
+    }
+    if (!Number.isFinite(hours) || hours <= 0 || hours > PREVIEW_MAX_HOURS) {
+      return problem(reply, 400, "Validation Error", "hours out of range", {
+        errors: [{ field: "hours", message: `hours must be > 0 and ≤ ${PREVIEW_MAX_HOURS}` }],
+      });
+    }
+
+    const market = (dslJson as Record<string, unknown>).market as Record<string, unknown>;
+    const exchange = String(market.exchange);
+    const interval: import("@prisma/client").CandleInterval = "M15";
+
+    const nowMs = Date.now();
+    const fromTsMs = BigInt(nowMs - Math.ceil(hours * 3600 * 1000));
+    const toTsMs = BigInt(nowMs);
+
+    const dbCandles = await prisma.marketCandle.findMany({
+      where: {
+        exchange,
+        symbol,
+        interval,
+        openTimeMs: { gte: fromTsMs, lte: toTsMs },
+      },
+      orderBy: { openTimeMs: "asc" },
+    });
+
+    if (dbCandles.length < 2) {
+      return problem(reply, 409, "Insufficient Data",
+        `Only ${dbCandles.length} candle(s) available for ${symbol} ${interval} in the last ${hours}h. Wait for ingestion to catch up.`);
+    }
+
+    const candles = dbCandles.map((c) => ({
+      openTime: Number(c.openTimeMs),
+      open: Number(c.open),
+      high: Number(c.high),
+      low: Number(c.low),
+      close: Number(c.close),
+      volume: Number(c.volume),
+    }));
+
+    let report;
+    try {
+      report = runBacktest(candles, dslJson, { feeBps: 0, slippageBps: 0, fillAt: "CLOSE" });
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return problem(reply, 422, "Evaluation Error", `DSL evaluation failed: ${msg}`);
+    }
+
+    const firstCandleMs = candles[0].openTime;
+    const lastCandleMs = candles[candles.length - 1].openTime;
+
+    return reply.send({
+      report,
+      meta: {
+        symbol,
+        exchange,
+        interval,
+        hours,
+        candleCount: candles.length,
+        fromTsMs: firstCandleMs,
+        toTsMs: lastCandleMs,
+        dataAgeMs: nowMs - lastCandleMs,
+        engineVersion: process.env.COMMIT_SHA ?? "unknown",
+      },
+    });
   });
 
   // ── GET /lab/backtest/:id ── get result ─────────────────────────────────────

--- a/apps/api/tests/routes/lab.test.ts
+++ b/apps/api/tests/routes/lab.test.ts
@@ -209,6 +209,10 @@ vi.mock("../../src/lib/backtest.js", () => ({
   runBacktest: vi.fn().mockReturnValue({ trades: 0, totalPnlPct: 0 }),
 }));
 
+vi.mock("../../src/lib/dslValidator.js", () => ({
+  validateDsl: vi.fn().mockReturnValue(null),
+}));
+
 import { buildApp } from "../../src/app.js";
 import type { FastifyInstance } from "fastify";
 
@@ -798,5 +802,137 @@ describe("DELETE /api/v1/lab/journal/:id", () => {
     mockJournalEntries["je-3"] = { id: "je-3", workspaceId: WS_ID, strategyGraphVersionId: "gv-1", hypothesis: "H", whatChanged: "W", expectedResult: "E", status: "KEEP_TESTING", createdAt: new Date(), updatedAt: new Date() };
     const res = await app.inject({ method: "DELETE", url: "/api/v1/lab/journal/je-3", headers: authHeaders() });
     expect(res.statusCode).toBe(204);
+  });
+});
+
+// ── POST /lab/preview ── DSL dry-run preview ─────────────────────────────────
+
+import { prisma as previewPrisma } from "../../src/lib/prisma.js";
+import { runBacktest as previewRunBacktest } from "../../src/lib/backtest.js";
+import { validateDsl as previewValidateDsl } from "../../src/lib/dslValidator.js";
+
+describe("POST /api/v1/lab/preview", () => {
+  const prismaMock = previewPrisma as unknown as {
+    marketCandle: { findMany: ReturnType<typeof vi.fn> };
+  };
+  const backtestMock = previewRunBacktest as unknown as ReturnType<typeof vi.fn>;
+  const validatorMock = previewValidateDsl as unknown as ReturnType<typeof vi.fn>;
+
+  const dummyDsl = { market: { exchange: "bybit", symbol: "BTCUSDT" } };
+  let ipCounter = 0;
+
+  function makeCandles(n: number) {
+    const nowMs = Date.now();
+    return Array.from({ length: n }, (_, i) => ({
+      openTimeMs: BigInt(nowMs - (n - i) * 15 * 60_000),
+      open: 100, high: 101, low: 99, close: 100.5, volume: 10,
+    }));
+  }
+
+  // Each test gets a unique client IP so the per-route rate-limit bucket is fresh
+  // (app.ts sets trustProxy="127.0.0.1" → X-Forwarded-For is honored in tests).
+  function previewHeaders() {
+    ipCounter += 1;
+    const oct = 10 + (ipCounter % 240);
+    return { ...authHeaders(), "x-forwarded-for": `10.0.0.${oct}` };
+  }
+
+  beforeEach(() => {
+    validatorMock.mockReset().mockReturnValue(null);
+    backtestMock.mockReset().mockReturnValue({
+      trades: 3, wins: 2, winrate: 0.667,
+      totalPnlPct: 1.23, maxDrawdownPct: 0.5, candles: 96, tradeLog: [],
+    });
+    prismaMock.marketCandle.findMany.mockReset().mockResolvedValue(makeCandles(96));
+  });
+
+  it("returns 401 without auth", async () => {
+    const res = await app.inject({
+      method: "POST", url: "/api/v1/lab/preview",
+      headers: { "x-forwarded-for": "10.0.1.1" },
+      payload: { dslJson: dummyDsl, symbol: "BTCUSDT" },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns 200 with report + meta for valid DSL and sufficient candles", async () => {
+    const res = await app.inject({
+      method: "POST", url: "/api/v1/lab/preview",
+      headers: previewHeaders(),
+      payload: { dslJson: dummyDsl, symbol: "BTCUSDT", hours: 24 },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.report).toMatchObject({ trades: 3, winrate: 0.667, totalPnlPct: 1.23 });
+    expect(body.meta).toMatchObject({ symbol: "BTCUSDT", exchange: "bybit", interval: "M15", hours: 24, candleCount: 96 });
+    expect(typeof body.meta.dataAgeMs).toBe("number");
+  });
+
+  it("returns 400 when DSL validation fails", async () => {
+    validatorMock.mockReturnValueOnce([{ field: "entry", message: "missing" }]);
+    const res = await app.inject({
+      method: "POST", url: "/api/v1/lab/preview",
+      headers: previewHeaders(),
+      payload: { dslJson: {}, symbol: "BTCUSDT" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().errors).toEqual([{ field: "entry", message: "missing" }]);
+  });
+
+  it("returns 400 when symbol is missing", async () => {
+    const res = await app.inject({
+      method: "POST", url: "/api/v1/lab/preview",
+      headers: previewHeaders(),
+      payload: { dslJson: dummyDsl },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().errors[0].field).toBe("symbol");
+  });
+
+  it("returns 400 when hours exceeds the cap", async () => {
+    const res = await app.inject({
+      method: "POST", url: "/api/v1/lab/preview",
+      headers: previewHeaders(),
+      payload: { dslJson: dummyDsl, symbol: "BTCUSDT", hours: 9999 },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().errors[0].field).toBe("hours");
+  });
+
+  it("returns 409 when candles < 2", async () => {
+    prismaMock.marketCandle.findMany.mockResolvedValueOnce([]);
+    const res = await app.inject({
+      method: "POST", url: "/api/v1/lab/preview",
+      headers: previewHeaders(),
+      payload: { dslJson: dummyDsl, symbol: "BTCUSDT" },
+    });
+    expect(res.statusCode).toBe(409);
+    expect(res.json().title).toBe("Insufficient Data");
+  });
+
+  it("returns 422 when backtest engine throws", async () => {
+    backtestMock.mockImplementationOnce(() => { throw new Error("bad indicator"); });
+    const res = await app.inject({
+      method: "POST", url: "/api/v1/lab/preview",
+      headers: previewHeaders(),
+      payload: { dslJson: dummyDsl, symbol: "BTCUSDT" },
+    });
+    expect(res.statusCode).toBe(422);
+    expect(res.json().detail).toContain("bad indicator");
+  });
+
+  it("applies rate limit after 5 requests/minute from the same IP", async () => {
+    const headers = { ...authHeaders(), "x-forwarded-for": "10.9.9.9" };
+    const payload = { dslJson: dummyDsl, symbol: "BTCUSDT" };
+    const results: number[] = [];
+    for (let i = 0; i < 6; i++) {
+      const res = await app.inject({
+        method: "POST", url: "/api/v1/lab/preview",
+        headers, payload,
+      });
+      results.push(res.statusCode);
+    }
+    expect(results.filter((s) => s === 200).length).toBeLessThanOrEqual(5);
+    expect(results).toContain(429);
   });
 });


### PR DESCRIPTION
## Summary

Closes the last open item in `docs/37-production-readiness-audit.md`
(§5.12 — "Нет DSL dry-run preview"). Gives users a way to sanity-check a
strategy against the last 24h of real market data **before** flipping it
live, which is the point at which trust in a new strategy matters most.

- New `POST /api/v1/lab/preview` — synchronous, stateless dry-run.
- Reuses the existing pure `runBacktest()` engine against `MarketCandle`
  — no new exchange adapter, no BotRun, no DB writes, no migration.
- Rate-limited to 5 req/min per IP (same budget as `/lab/backtest`).
- Returns the same report shape as `/lab/backtest` plus a `meta` block
  (`candleCount`, `fromTsMs`, `toTsMs`, `dataAgeMs`) so the UI can
  surface ingestion-lag without a second round-trip.

### Error contract

| Status | Condition |
|--------|-----------|
| 400 | DSL validation errors (delegated to existing `dslValidator`) |
| 400 | Missing/empty `symbol`, or `hours` outside `(0, 168]` |
| 409 | Fewer than 2 candles in the requested window (stale ingestion) |
| 422 | DSL evaluator throws (bad indicator ref, etc.) |
| 429 | Rate limit exceeded |

### Scope notes

- Timeframe is fixed to `M15` — matches the default elsewhere in lab,
  keeps the API narrow; can be widened later if needed.
- Symbol whitelist is deferred to `dslValidator` + Bybit API
  (consistent with how `/lab/backtest` handles it today — see
  exploration notes).
- Candle staleness is surfaced via `meta.dataAgeMs`; UI will display
  "data up to \<timestamp>" rather than triggering ad-hoc ingest.

## Test plan

- [x] `pnpm test` (apps/api) — 1715/1715 pass (was 1707; +8 new)
- [x] `pnpm build` (apps/api) — clean tsc
- [x] New tests cover: 200 shape, 400 (DSL / symbol / hours), 409
      insufficient data, 422 engine throw, 401 no auth, 429 rate limit
- [ ] UI preview panel — follow-up PR (`claude/dsl-preview-ui`)

https://claude.ai/code/session_012xd2RMLEEUgzbRPC9kov9J