### PR TITLE
feat(lab): Preview 24h in Test tab + accept strategyVersionId (§5.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ Entries get promoted to a versioned section on release (see
   sparkline for the most recently compiled DSL. Enabled after a
   successful compile; surfaces RFC 9457 validation errors inline and
   reports data-freshness lag via the response's `dataAgeMs`. (§5.12)
+- Lab: "Preview 24h" button next to "Run Backtest" in the Test tab,
+  letting researchers sanity-check a saved `StrategyVersion` against
+  the last 24h before committing to a full dataset backtest — useful
+  for A/B comparisons of variants. `/lab/preview` now also accepts
+  `strategyVersionId` (workspace-scoped) as an alternative to an
+  inline `dslJson`; `symbol` defaults to the strategy's own symbol
+  when not overridden. (§5.12)
 - `deploy/rollback.sh` with auto-detected previous tag, `--dry-run`,
   `--to`, `--yes`; warns on forward-only DB migrations. RUNBOOK §3.5.
   (§5.1, #277)

--- a/apps/api/src/routes/lab.ts
+++ b/apps/api/src/routes/lab.ts
@@ -58,10 +58,15 @@ interface StartBacktestBody {
  * Preview request — synchronous DSL dry-run against the last N hours of
  * MarketCandle data (no DB writes, no exchange call). Used by the graph
  * builder to sanity-check a strategy before flipping it live.
+ *
+ * Exactly one of `dslJson` or `strategyVersionId` must be provided.
+ * When `strategyVersionId` is used, the DSL is resolved from the DB
+ * (workspace-scoped) and `symbol` defaults to the strategy's own symbol.
  */
 interface PreviewBody {
-  dslJson: unknown;
-  symbol: string;
+  dslJson?: unknown;
+  strategyVersionId?: string;
+  symbol?: string;
   hours?: number;
 }
 
@@ -467,6 +472,9 @@ export async function labRoutes(app: FastifyInstance) {
   // Stateless: no BotRun, no exchange call, no DB writes. Reuses the pure
   // runBacktest() engine against the global MarketCandle table so users can
   // sanity-check a strategy before enabling it (§5.12 product gap).
+  //
+  // Accepts either a raw `dslJson` (Build tab, pre-persist) or a
+  // `strategyVersionId` (Test tab, for comparing saved versions).
   app.post<{ Body: PreviewBody }>("/lab/preview", {
     config: { rateLimit: { max: 5, timeWindow: "1 minute" } },
     onRequest: [app.authenticate],
@@ -474,13 +482,41 @@ export async function labRoutes(app: FastifyInstance) {
     const workspace = await resolveWorkspace(request, reply);
     if (!workspace) return;
 
-    const { dslJson, symbol, hours = 24 } = request.body ?? {};
+    const { dslJson: bodyDsl, strategyVersionId, symbol: bodySymbol, hours = 24 } = request.body ?? {};
+
+    if (!bodyDsl && !strategyVersionId) {
+      return problem(reply, 400, "Validation Error", "dslJson or strategyVersionId is required", {
+        errors: [{ field: "body", message: "provide either dslJson or strategyVersionId" }],
+      });
+    }
+    if (bodyDsl && strategyVersionId) {
+      return problem(reply, 400, "Validation Error", "provide only one of dslJson or strategyVersionId", {
+        errors: [{ field: "body", message: "dslJson and strategyVersionId are mutually exclusive" }],
+      });
+    }
+
+    // Resolve DSL + default symbol from the StrategyVersion when referenced by id.
+    let dslJson: unknown = bodyDsl;
+    let defaultSymbol: string | undefined;
+    if (strategyVersionId) {
+      const sv = await prisma.strategyVersion.findUnique({
+        where: { id: strategyVersionId },
+        include: { strategy: true },
+      });
+      if (!sv || sv.strategy.workspaceId !== workspace.id) {
+        return problem(reply, 404, "Not Found", "StrategyVersion not found");
+      }
+      dslJson = sv.dslJson;
+      defaultSymbol = sv.strategy.symbol;
+    }
 
     const dslErrors = validateDsl(dslJson);
     if (dslErrors) {
       return problem(reply, 400, "Validation Error", "DSL validation failed", { errors: dslErrors });
     }
-    if (typeof symbol !== "string" || symbol.trim().length === 0) {
+
+    const symbol = (bodySymbol ?? defaultSymbol ?? "").trim();
+    if (symbol.length === 0) {
       return problem(reply, 400, "Validation Error", "symbol is required", {
         errors: [{ field: "symbol", message: "symbol must be a non-empty string" }],
       });

--- a/apps/api/tests/routes/lab.test.ts
+++ b/apps/api/tests/routes/lab.test.ts
@@ -935,4 +935,76 @@ describe("POST /api/v1/lab/preview", () => {
     expect(results.filter((s) => s === 200).length).toBeLessThanOrEqual(5);
     expect(results).toContain(429);
   });
+
+  // ── strategyVersionId path (Test-tab flow) ────────────────────────────────
+
+  it("resolves DSL from strategyVersionId and uses strategy.symbol by default", async () => {
+    mockStrategyVersions["sv-preview-1"] = {
+      id: "sv-preview-1",
+      strategyId: "strat-preview-1",
+      dslJson: dummyDsl,
+      strategy: { workspaceId: WS_ID, symbol: "ETHUSDT" },
+    };
+
+    const res = await app.inject({
+      method: "POST", url: "/api/v1/lab/preview",
+      headers: previewHeaders(),
+      payload: { strategyVersionId: "sv-preview-1" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().meta.symbol).toBe("ETHUSDT");
+  });
+
+  it("allows overriding the strategy's symbol via body", async () => {
+    mockStrategyVersions["sv-preview-2"] = {
+      id: "sv-preview-2",
+      strategyId: "strat-preview-2",
+      dslJson: dummyDsl,
+      strategy: { workspaceId: WS_ID, symbol: "ETHUSDT" },
+    };
+
+    const res = await app.inject({
+      method: "POST", url: "/api/v1/lab/preview",
+      headers: previewHeaders(),
+      payload: { strategyVersionId: "sv-preview-2", symbol: "SOLUSDT" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().meta.symbol).toBe("SOLUSDT");
+  });
+
+  it("returns 404 when strategyVersion belongs to another workspace", async () => {
+    mockStrategyVersions["sv-other"] = {
+      id: "sv-other",
+      strategyId: "strat-other",
+      dslJson: dummyDsl,
+      strategy: { workspaceId: "ws-different", symbol: "BTCUSDT" },
+    };
+
+    const res = await app.inject({
+      method: "POST", url: "/api/v1/lab/preview",
+      headers: previewHeaders(),
+      payload: { strategyVersionId: "sv-other" },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 400 when neither dslJson nor strategyVersionId provided", async () => {
+    const res = await app.inject({
+      method: "POST", url: "/api/v1/lab/preview",
+      headers: previewHeaders(),
+      payload: { symbol: "BTCUSDT" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().detail).toContain("dslJson or strategyVersionId");
+  });
+
+  it("returns 400 when both dslJson and strategyVersionId provided", async () => {
+    const res = await app.inject({
+      method: "POST", url: "/api/v1/lab/preview",
+      headers: previewHeaders(),
+      payload: { dslJson: dummyDsl, strategyVersionId: "sv-xyz", symbol: "BTCUSDT" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().errors[0].message).toContain("mutually exclusive");
+  });
 });

--- a/apps/web/src/app/lab/LabShell.tsx
+++ b/apps/web/src/app/lab/LabShell.tsx
@@ -371,9 +371,10 @@ function LabContextBar({ activeTab }: { activeTab: TabId }) {
             {compileLabel}
           </button>
           <PreviewPanel
-            dslJson={(lastCompileResult?.compiledDsl as Record<string, unknown> | undefined) ?? null}
+            source={{ dslJson: (lastCompileResult?.compiledDsl as Record<string, unknown> | undefined) ?? null }}
             symbol="BTCUSDT"
             disabled={compileState !== "success" || !lastCompileResult}
+            hint={compileState !== "success" || !lastCompileResult ? "Compile the graph first" : undefined}
           />
         </div>
       )}

--- a/apps/web/src/app/lab/PreviewPanel.tsx
+++ b/apps/web/src/app/lab/PreviewPanel.tsx
@@ -59,30 +59,54 @@ type RunState =
 
 // ---------------------------------------------------------------------------
 // Component
+//
+// Accepts either a raw `dslJson` (Build tab, freshly compiled) or a
+// `strategyVersionId` (Test tab, persisted version). Exactly one must be
+// set; the server validates the body.
 // ---------------------------------------------------------------------------
 
+export type PreviewSource =
+  | { dslJson: Record<string, unknown> | null; strategyVersionId?: undefined }
+  | { strategyVersionId: string | null; dslJson?: undefined };
+
 export function PreviewPanel({
-  dslJson,
+  source,
   symbol,
   disabled,
+  align = "right",
+  label = "Preview 24h",
+  hint,
 }: {
-  dslJson: Record<string, unknown> | null;
-  symbol: string;
+  source: PreviewSource;
+  symbol?: string;
   disabled: boolean;
+  align?: "left" | "right";
+  label?: string;
+  hint?: string;
 }) {
   const [state, setState] = useState<RunState>({ kind: "idle" });
   const [open, setOpen] = useState(false);
   const popoverRef = useRef<HTMLDivElement>(null);
 
-  const btnDisabled = disabled || !dslJson || state.kind === "loading";
+  const hasSource =
+    ("dslJson" in source && source.dslJson !== null && source.dslJson !== undefined) ||
+    ("strategyVersionId" in source && !!source.strategyVersionId);
+  const btnDisabled = disabled || !hasSource || state.kind === "loading";
 
   const runPreview = useCallback(async () => {
-    if (!dslJson) return;
+    if (!hasSource) return;
     setState({ kind: "loading" });
     setOpen(true);
+    const body: Record<string, unknown> = { hours: 24 };
+    if ("dslJson" in source && source.dslJson) body.dslJson = source.dslJson;
+    if ("strategyVersionId" in source && source.strategyVersionId) {
+      body.strategyVersionId = source.strategyVersionId;
+    }
+    if (symbol) body.symbol = symbol;
+
     const res = await apiFetch<PreviewResponse>("/lab/preview", {
       method: "POST",
-      body: JSON.stringify({ dslJson, symbol, hours: 24 }),
+      body: JSON.stringify(body),
     });
     if (res.ok) {
       setState({ kind: "done", data: res.data });
@@ -94,7 +118,7 @@ export function PreviewPanel({
         errors: res.problem.errors,
       });
     }
-  }, [dslJson, symbol]);
+  }, [source, symbol, hasSource]);
 
   // Close popover on click-outside / Escape
   useEffect(() => {
@@ -115,16 +139,21 @@ export function PreviewPanel({
     };
   }, [open]);
 
+  const buttonTitle =
+    hint ??
+    (!hasSource
+      ? "No strategy to preview"
+      : "Run a dry-run preview against the last 24h of market data");
+
+  const popoverPositionStyle: React.CSSProperties =
+    align === "left" ? { ...popoverStyle, right: "auto", left: 0 } : popoverStyle;
+
   return (
     <div style={{ position: "relative", flexShrink: 0 }} ref={popoverRef}>
       <button
         onClick={runPreview}
         disabled={btnDisabled}
-        title={
-          !dslJson
-            ? "Compile the graph first"
-            : "Run a dry-run preview against the last 24h of market data"
-        }
+        title={buttonTitle}
         style={{
           padding: "5px 14px",
           fontSize: 12,
@@ -138,11 +167,11 @@ export function PreviewPanel({
           fontFamily: "inherit",
         }}
       >
-        {state.kind === "loading" ? "Previewing…" : "Preview 24h"}
+        {state.kind === "loading" ? "Previewing…" : label}
       </button>
 
       {open && (
-        <div style={popoverStyle}>
+        <div style={popoverPositionStyle}>
           <PreviewBody state={state} onClose={() => setOpen(false)} onRetry={runPreview} />
         </div>
       )}

--- a/apps/web/src/app/lab/test/page.tsx
+++ b/apps/web/src/app/lab/test/page.tsx
@@ -14,6 +14,7 @@ import { apiFetch, getWorkspaceId } from "../../../lib/api";
 import { useLabGraphStore } from "../useLabGraphStore";
 import type { IChartApi, LineData, Time } from "lightweight-charts";
 import OptimisePanel from "./OptimisePanel";
+import { PreviewPanel } from "../PreviewPanel";
 
 // ---------------------------------------------------------------------------
 // Task 29 — AI Explainability helpers
@@ -552,17 +553,30 @@ function BacktestForm({
 
       {error && <div style={errorBoxStyle}>{error}</div>}
 
-      <button
-        style={{
-          ...runBtnStyle,
-          opacity: canSubmit ? 1 : 0.45,
-          cursor: canSubmit ? "pointer" : "not-allowed",
-        }}
-        disabled={!canSubmit}
-        onClick={() => onSubmit({ strategyVersionId: versionId, datasetId, feeBps, slippageBps })}
-      >
-        {submitting ? "Starting…" : "Run Backtest"}
-      </button>
+      <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+        <button
+          style={{
+            ...runBtnStyle,
+            opacity: canSubmit ? 1 : 0.45,
+            cursor: canSubmit ? "pointer" : "not-allowed",
+          }}
+          disabled={!canSubmit}
+          onClick={() => onSubmit({ strategyVersionId: versionId, datasetId, feeBps, slippageBps })}
+        >
+          {submitting ? "Starting…" : "Run Backtest"}
+        </button>
+        <PreviewPanel
+          source={{ strategyVersionId: versionId || null }}
+          symbol={selectedVersion?.strategy.symbol}
+          disabled={!versionId || submitting}
+          align="left"
+          hint={
+            !versionId
+              ? "Select a compiled version first"
+              : "Sanity-check this version against the last 24h before committing to a full backtest"
+          }
+        />
+      </div>
 
       <div style={{ fontSize: 11, color: "rgba(255,255,255,0.25)", marginTop: 8 }}>
         Fill price: CLOSE (fixed per spec). Same inputs produce identical results.


### PR DESCRIPTION
## Summary

**Stacked on top of #287** (targets `claude/dsl-preview-ui`; GitHub will
auto-retarget to `main` once #287 merges). Completes the §5.12 work by
bringing the same preview affordance into the researcher flow.

Puts the existing "Preview 24h" button next to **Run Backtest** in the
Test tab so researchers can sanity-check a saved `StrategyVersion`
against the last 24h before committing to a full dataset backtest —
specifically useful when A/B-comparing variants.

### Backend — extends `/lab/preview`

The endpoint now accepts two mutually-exclusive body shapes:

```jsonc
// Build-tab flow (unchanged)
{ "dslJson": {...}, "symbol": "BTCUSDT", "hours": 24 }

// Test-tab flow (new)
{ "strategyVersionId": "sv-abc123", "symbol": "ETHUSDT", "hours": 24 }
```

When `strategyVersionId` is given:
- Server resolves the DSL from the DB with **workspace isolation** —
  cross-tenant ids return 404.
- `symbol` defaults to `strategy.symbol` if not overridden.
- Validation / 409 / 422 / 429 branches unchanged.

Both / neither → 400 with a clear error.

### Frontend

- `PreviewPanel`: now accepts a discriminated `source` prop
  (`dslJson | strategyVersionId`) plus optional `align`, `label`, `hint`
  so one component serves both contexts — no duplicate popover markup.
- `LabShell`: migrated to the new `source` API (no UX change).
- `/lab/test`: Preview button sits inline next to Run Backtest,
  disabled until a compiled version is selected. Popover opens
  leftward so it doesn't clip the form's right edge.

### Why extend the endpoint instead of a second round-trip

Could have added `GET /lab/strategy-versions/:id/dsl` and called that
first, but that's two round-trips for one user action and requires
transporting the compiled DSL to the client unnecessarily. Keeping the
preview resolution server-side is shorter, more secure (no workspace
leak surface), and mirrors how `/lab/backtest` handles the same concern.

## Test plan

- [x] `pnpm test` (apps/api) — **1720/1720** pass (+5 new: DSL
      resolution from `strategyVersionId`, symbol override,
      cross-workspace 404, both/neither 400)
- [x] `pnpm build` (apps/api) — clean tsc
- [x] `pnpm build` (apps/web) — clean; `/lab/test` 11.4 kB → 13.2 kB
- [ ] Manual: select version → Preview → popover shows report scoped to
      that strategy's symbol
- [ ] Manual: stale ingestion → 409 surfaces "Insufficient Data"

## Merge order

1. #286 (backend endpoint)
2. #287 (Build-tab UI)
3. This PR (retarget to `main` automatically after #287 merges)

https://claude.ai/code/session_012xd2RMLEEUgzbRPC9kov9J