### PR TITLE
docs: add research-track roadmap (docs/46–49)

### DIFF
--- a/docs/46-backtest-realism-plan.md
+++ b/docs/46-backtest-realism-plan.md
@@ -1,0 +1,324 @@
+# 46. Backtest Realism Plan
+
+Статус: draft  
+Владелец: core trading / lab  
+Последнее обновление: 2026-04-27  
+Родительский документ: `docs/44-strategy-engine-overview.md`  
+Дорожка: A (research workflow)
+
+## Контекст
+
+Текущее состояние (проверено по коду):
+
+- Тонкая обёртка `runBacktest(candleData, dslJson, opts: Partial<ExecOpts>, mtfContext?)` (`apps/api/src/lib/backtest.ts:39`) делегирует в `runDslBacktest`.
+- `ExecOpts` декларирует **только одно допустимое значение** `fillAt`: `{ feeBps: number; slippageBps: number; fillAt: "CLOSE" }` (`apps/api/src/lib/backtest.ts:24–28`). Docstring явно фиксирует ограничение: "fillAt = "CLOSE" — fill at candle close price (only supported value)" (`apps/api/src/lib/backtest.ts:11`).
+- В ядре `DslExecOpts` поле `fillAt` **отсутствует** — оно живёт только на уровне обёртки и не пробрасывается ниже: `export interface DslExecOpts { feeBps: number; slippageBps: number }` (`apps/api/src/lib/dslEvaluator.ts:78–81`).
+- Внутри `runDslBacktest` (`apps/api/src/lib/dslEvaluator.ts:822`) на entry хардкод close-fill: `effectiveEntry = c.close * entryMult` (`apps/api/src/lib/dslEvaluator.ts:1134`). На exit аналогично через `last.close * exitMult` (`apps/api/src/lib/dslEvaluator.ts:1185`).
+- Slippage применяется **асимметрично**: `entryMult = 1 + (feeBps + slippageBps) / 10_000`, `exitMult = 1 - feeBps / 10_000` (`apps/api/src/lib/dslEvaluator.ts:893–894`). На exit slippage не вычитается — это занижает реальный издержки round-trip-а.
+- Fees единым `feeBps` без разделения taker/maker. На текущем этапе все ордера market (taker-only), но раздельные ставки понадобятся при добавлении лимитных входов/выходов.
+- Routes-слой: `ALLOWED_FILL_AT = ["CLOSE"] as const`, `type FillAt = typeof ALLOWED_FILL_AT[number]` (`apps/api/src/routes/lab.ts:30–31`); тело запроса `StartBacktestBody.fillAt?: FillAt` (`apps/api/src/routes/lab.ts:54`); валидация по этому списку (`apps/api/src/routes/lab.ts:410–411`); хардкоды `"CLOSE"` в sweep (`apps/api/src/routes/lab.ts:1339, 1349`) и в одиночном backtest (`apps/api/src/routes/lab.ts:1485`); preview (`apps/api/src/routes/lab.ts:564`).
+- Frontend: `fillAt` типизирован как `string` и всегда отправляется `"CLOSE"` (`apps/web/src/app/lab/ClassicMode.tsx:80, 541`; `apps/web/src/app/lab/test/page.tsx:54, 1308`); отображается в snapshot-таблице (`apps/web/src/app/lab/ClassicMode.tsx:904`; `apps/web/src/app/lab/test/page.tsx:202`).
+- Prisma: поля под realism уже есть, **миграции не требуются**: `BacktestResult.feeBps Int`, `slippageBps Int`, `fillAt String @default("CLOSE")`, `engineVersion String @default("unknown")` (`apps/api/prisma/schema.prisma:598–602`); `BacktestSweep.feeBps Int`, `slippageBps Int` (`apps/api/prisma/schema.prisma:693–694`).
+- `engineVersion` уже пишется как `process.env.COMMIT_SHA ?? "unknown"` (`apps/api/src/routes/lab.ts:439, 584, 1307`; `apps/api/src/routes/datasets.ts:143`) — отдельная воспроизводимость уже работает; этот документ её не затрагивает.
+- Тесты: основные фикстуры в `apps/api/tests/lib/backtest.test.ts`, `apps/api/tests/lib/dslEvaluator.test.ts`, `apps/api/tests/lib/dcaBacktest.test.ts`, `apps/api/tests/lib/exitEngine.test.ts`. Sweep e2e — `apps/api/tests/routes/lab.test.ts:442–515`.
+- `apps/api/src/lib/funding/` существует (`basis.ts`, `fetcher.ts`, `hedgePlanner.ts`, `ingestion.ts`, ...) для live-слоя, но в `runDslBacktest` funding-расходы не учитываются. Это известный gap, **за рамками этого документа** — см. раздел "Не входит в задачу".
+
+## Цель
+
+- Закрыть три самых грубых источника нереалистичности в текущем backtest: (1) только close-fill, (2) асимметричный slippage, (3) объединённый fee без taker/maker.
+- Все правки additive: дефолты сохраняют текущее поведение точно бит-в-бит, чтобы существующие записи `BacktestResult` оставались сравнимыми.
+- Поднять `fillAt` с уровня обёртки в ядро `DslExecOpts` — это разблокирует docs/47-T3 и docs/48-T5, которые сейчас вынуждены передавать `"CLOSE"` хардкодом.
+
+## Решение по форме fill-policy
+
+Поддерживаемые значения `fillAt`:
+
+- `"CLOSE"` — fill по close сигнальной свечи. Текущее поведение, остаётся default.
+- `"OPEN"` — fill по open сигнальной свечи. Полезно для confirmation-style стратегий, где сигнал валиден на открытии следующего периода.
+- `"NEXT_OPEN"` — fill по open **следующей** свечи. Это устраняет lookahead на close: сигнал, посчитанный по closed bar, исполняется на open ближайшей будущей свечи. Для стратегий с indicator-сигналами это самый честный режим.
+
+`"NEXT_OPEN"` для exit-сигналов (indicator_exit) аналогично — exit на open следующей свечи. Для SL/TP/trailing stop fillAt **не применяется** — они срабатывают по intra-bar high/low (как сейчас); это явно документируется в комментарии. Funding и partial fills — out of scope (см. ниже).
+
+## Не входит в задачу
+
+- Funding accrual для perpetual датасетов. `apps/api/src/lib/funding/` уже агрегирует rate-историю для live-слоя; интеграция в `runDslBacktest` — отдельный план (`docs/50` или follow-up к этому документу). Причина выноса: требует синхронизации funding-таймсерии с candle-таймсерией, нового `DslBacktestReport.fundingPnlPct`, отдельного UI-блока и e2e фикстур funding-rate. Объём сравним с этим документом целиком.
+- Partial fills, queue position, latency model. Out of scope первой версии.
+- Order book impact / volume-aware slippage. Текущая модель — фиксированный bps; volume-aware — отдельная задача после стабилизации funding.
+- Maker-only / limit-order backtest. После 46-T3 структура полей готова к maker-режиму, но сама логика лимитных входов с очередью/таймаутами — отдельный план.
+- Изменение `engineVersion`-логики или ввод `reportVersion` (правило отложено в `docs/49`).
+- Изменение поведения SL/TP/trailing — они продолжают срабатывать по intra-bar high/low.
+- Изменение MTF-слоя.
+
+---
+
+## Задачи
+
+### 46-T1: Поднять `fillAt` в ядро + поддержать `OPEN` и `NEXT_OPEN`
+
+**Цель:** перенести параметр `fillAt` из обёртки в `DslExecOpts`, расширить enum до трёх значений и реализовать новые режимы fill в `runDslBacktest`.
+
+**Файлы для изменения:**
+- `apps/api/src/lib/dslEvaluator.ts` — расширить `DslExecOpts` (`строка 78`), переписать entry-fill (`строка 1134`), exit-fill для `indicator_exit` и `end_of_data` (`строка 1185`).
+- `apps/api/src/lib/backtest.ts` — расширить `ExecOpts` (`строка 24`), пробросить `fillAt` в `runDslBacktest` (`строка 45`), обновить docstring (`строки 10–14`).
+- `apps/api/tests/lib/dslEvaluator.test.ts` и `apps/api/tests/lib/backtest.test.ts` — добавить кейсы.
+
+**Шаги реализации:**
+1. В `dslEvaluator.ts`:
+   ```ts
+   export type DslFillAt = "OPEN" | "CLOSE" | "NEXT_OPEN";
+   export interface DslExecOpts {
+     feeBps: number;
+     slippageBps: number;
+     fillAt: DslFillAt;
+   }
+   ```
+2. В `runDslBacktest` дефолтить `fillAt = "CLOSE"` при чтении из `opts` (так же, как `feeBps = 0`). Это сохраняет backward compat: старые вызовы без `fillAt` ведут себя ровно как сейчас.
+3. Entry-fill (`строка 1134`): заменить хардкод `c.close * entryMult` на:
+   - `"CLOSE"` → `c.close * entryMult` (как сейчас).
+   - `"OPEN"` → `c.open * entryMult`.
+   - `"NEXT_OPEN"` → если `i + 1 < candles.length` → `candles[i+1].open * entryMult` и сдвинуть `entryTime = candles[i+1].openTime`, `entryBarIndex = i+1`. Если `i + 1 >= candles.length` (сигнал на последней свече) → entry **не открывается** (нет следующей свечи для исполнения), `inPosition` остаётся `false`. Записать в `tradeLog` ничего не нужно — entry просто пропускается. Документировать это поведение в комментарии.
+4. Exit-fill для `indicator_exit`: при срабатывании сигнала выхода на свече `i` — для `"NEXT_OPEN"` exit исполняется по `candles[i+1].open`, иначе по той же свече (open или close по `fillAt`). Если `i + 1 >= candles.length` для `"NEXT_OPEN"` — exit на close текущей свечи (degraded fallback, чтобы позиция не повисла; задокументировать в комментарии).
+5. Exit-fill для `end_of_data` (`строка 1185`): остаётся `last.close` независимо от `fillAt` — это синтетическое закрытие, не реальный exit-сигнал. Зафиксировать в комментарии.
+6. SL/TP/trailing срабатывания — НЕ затрагивать. Они идут по intra-bar high/low, `fillAt` к ним не относится. Добавить комментарий перед блоком SL/TP-проверок: "SL/TP/trailing trigger on intra-bar extremes; fillAt applies only to entry and indicator_exit/end_of_data exits."
+7. В `backtest.ts`:
+   ```ts
+   export type FillAt = "OPEN" | "CLOSE" | "NEXT_OPEN";
+   export interface ExecOpts { feeBps: number; slippageBps: number; fillAt: FillAt }
+   ```
+   Пробросить `fillAt: opts.fillAt ?? "CLOSE"` в `runDslBacktest`. Обновить JSDoc и шапку файла (`строки 10–14`) — отразить три значения.
+
+**Тест-план:**
+- Существующие тесты `dslEvaluator.test.ts` и `backtest.test.ts` зелёные без правок (default `"CLOSE"` сохраняет поведение).
+- Новый кейс на `"OPEN"`: фикстура из 5 свечей с известными `open != close`, простая стратегия с сигналом на свече i. Проверить, что `entryPrice = candles[i].open * entryMult`.
+- Новый кейс на `"NEXT_OPEN"`: тот же сигнал на свече i — entry на `candles[i+1].open`, `entryTime = candles[i+1].openTime`.
+- Edge: сигнал на последней свече при `"NEXT_OPEN"` → trade не открыт, `tradeLog` без новой записи.
+- Edge: indicator_exit на последней свече при `"NEXT_OPEN"` → exit по close (fallback).
+
+**Критерии готовности:**
+- `tsc --noEmit` проходит.
+- Все существующие тесты зелёные.
+- Новые тест-кейсы зелёные.
+- В `backtest.ts` docstring отражает три значения `fillAt`.
+
+---
+
+### 46-T2: Симметричный slippage — учёт на exit
+
+**Цель:** применить slippage и при выходе из позиции, а не только при входе. Сделать это так, чтобы default-поведение для существующих записей не сломалось (`slippageBps = 0` → результат идентичен текущему).
+
+**Файлы для изменения:**
+- `apps/api/src/lib/dslEvaluator.ts` — `entryMult`/`exitMult` (`строки 893–894`).
+- `apps/api/tests/lib/dslEvaluator.test.ts` — расширить тест-кейсы.
+
+**Шаги реализации:**
+1. Текущая формула:
+   ```ts
+   const entryMult = 1 + (feeBps + slippageBps) / 10_000;
+   const exitMult  = 1 - feeBps / 10_000;
+   ```
+   Заменить на:
+   ```ts
+   const entryMult = 1 + (feeBps + slippageBps) / 10_000;
+   const exitMult  = 1 - (feeBps + slippageBps) / 10_000;
+   ```
+   То есть slippage вычитается из proceeds на exit ровно так же, как добавлялся к cost на entry. Для long это означает: и купили дороже, и продали дешевле — двойной slippage cost за round-trip. Для short — симметрично.
+2. Backward compatibility: при `slippageBps = 0` формулы идентичны старым — все существующие тесты проходят без правок. При `slippageBps > 0` `pnlPct` уменьшается; это **сознательное** изменение, отражающее реальный round-trip cost.
+3. В шапке файла (или над декларацией мультипликаторов) обновить комментарий: "Symmetric slippage: applied at both entry (cost up) and exit (proceeds down)."
+4. Обновить шапку `backtest.ts` (`строки 10–14`):
+   ```
+   *   effectiveEntry = fillPrice * (1 + (feeBps + slippageBps) / 10_000)
+   *   effectiveExit  = rawExit  * (1 - (feeBps + slippageBps) / 10_000)
+   ```
+5. **Важно:** старые `BacktestResult` записи становятся не сравнимы с новыми по абсолютному `pnlPct` при `slippageBps > 0`. Это допустимо — `engineVersion` уже фиксирует версию, существующие записи остаются интерпретируемыми по своему `engineVersion`. Документировать в PR-описании.
+
+**Тест-план:**
+- Существующие тесты с `slippageBps = 0` — зелёные без правок.
+- Новый кейс: `slippageBps = 50, feeBps = 0`, простая стратегия с одним выигрышным trade (long). Проверить, что новый `pnlPct` меньше старого ровно на величину `2 * slippageBps / 10_000 * 100` процентов от номинала (с поправкой на маленькие расхождения из-за компаундинга по `entryMult`/`exitMult`).
+- Кейс short: симметричное снижение pnlPct.
+- Кейс с большим количеством сделок: новый `totalPnlPct` должен быть строго ≤ старого при `slippageBps > 0`.
+
+**Критерии готовности:**
+- `tsc --noEmit` проходит.
+- Все существующие тесты зелёные.
+- Новые тесты зелёные.
+- Шапка `backtest.ts` и `dslEvaluator.ts` отражают симметричную формулу.
+
+---
+
+### 46-T3: Раздельные `takerFeeBps` / `makerFeeBps` с alias на `feeBps`
+
+**Цель:** подготовить структуру под maker-режим (limit orders), не меняя текущее поведение. Все fills сейчас market → используется taker. Maker fee пишется в опции, но в формулах ещё не участвует — это явный задел.
+
+**Файлы для изменения:**
+- `apps/api/src/lib/dslEvaluator.ts` — `DslExecOpts` (`строка 78`), нормализация в начале `runDslBacktest` (`строка 828`).
+- `apps/api/src/lib/backtest.ts` — `ExecOpts` (`строка 24`), проброс полей.
+- `apps/api/tests/lib/backtest.test.ts` — тесты на нормализацию.
+
+**Шаги реализации:**
+1. В `DslExecOpts` добавить два опциональных поля:
+   ```ts
+   export interface DslExecOpts {
+     feeBps?: number;          // alias for takerFeeBps (backward-compat)
+     takerFeeBps?: number;
+     makerFeeBps?: number;
+     slippageBps: number;
+     fillAt: DslFillAt;
+   }
+   ```
+   `feeBps` становится optional (был required) — но это не ломает вызывающие, потому что в самой реализации всегда был fallback `feeBps = 0`.
+2. Нормализация при чтении опций:
+   ```ts
+   const takerFeeBps = opts.takerFeeBps ?? opts.feeBps ?? 0;
+   const makerFeeBps = opts.makerFeeBps ?? takerFeeBps; // default: maker = taker (consistent)
+   const slippageBps = opts.slippageBps ?? 0;
+   const fillAt      = opts.fillAt ?? "CLOSE";
+   ```
+3. В существующих формулах (`entryMult`, `exitMult`) использовать `takerFeeBps` — все текущие fills market. Поле `makerFeeBps` сохраняется в `opts`, но в расчётах не участвует. Это явно отметить комментарием: "makerFeeBps reserved for limit-order backtest (deferred); current evaluator uses takerFeeBps for all fills".
+4. В `backtest.ts` `ExecOpts` отзеркалить:
+   ```ts
+   export interface ExecOpts {
+     feeBps?: number;
+     takerFeeBps?: number;
+     makerFeeBps?: number;
+     slippageBps: number;
+     fillAt: FillAt;
+   }
+   ```
+   Пробросить все поля в `runDslBacktest`.
+5. Обновить шапку `backtest.ts` — упомянуть alias-поведение.
+6. Тип `DslExecOpts.feeBps` помечен deprecated в JSDoc, но остаётся `optional`. Удалять его в этом этапе **не** надо — есть внешние вызывающие в routes/tests, миграция отдельной follow-up задачей.
+
+**Тест-план:**
+- `feeBps: 30` → `takerFeeBps = 30, makerFeeBps = 30` (внутренняя нормализация). Существующие тесты — зелёные.
+- `takerFeeBps: 30` без `feeBps` → то же самое.
+- Оба заданы (`feeBps: 10, takerFeeBps: 30`) → `takerFeeBps = 30` (новое поле приоритетнее).
+- `takerFeeBps: 30, makerFeeBps: 10` → `makerFeeBps = 10`, но в формулах используется только `takerFeeBps`. Проверить через специально сконструированный кейс — `pnlPct` тот же, что при `takerFeeBps: 30` без maker.
+
+**Критерии готовности:**
+- `tsc --noEmit` проходит.
+- Все существующие вызовы `runDslBacktest({feeBps, slippageBps})` работают без правок.
+- Новые поля доступны для опционального использования.
+- В JSDoc `feeBps` помечен deprecated с указанием на `takerFeeBps`.
+
+---
+
+### 46-T4: API + UI экспонирование новых полей
+
+**Цель:** позволить пользователю выбрать `fillAt ∈ {OPEN, CLOSE, NEXT_OPEN}` и (опционально) задать `takerFeeBps`/`makerFeeBps` через Lab UI; пробросить значения в `runBacktest` во всех местах, где он сейчас вызывается с хардкодом `"CLOSE"`.
+
+**Файлы для изменения:**
+- `apps/api/src/routes/lab.ts` — `ALLOWED_FILL_AT` (`строка 30`), `StartBacktestBody` (`строка 49`), валидация (`строки 410–411`), вызовы `runBacktest` (`строки 564, 1339, 1349, 1485`).
+- `apps/web/src/app/lab/ClassicMode.tsx` — типизация `fillAt` (`строка 80`), отправка POST (`строка 541`), снапшот (`строка 904`).
+- `apps/web/src/app/lab/test/page.tsx` — `fillAt` (`строки 54, 1308`), снапшот (`строка 202`).
+- `apps/api/tests/routes/lab.test.ts` — расширить валидационные тесты.
+
+**Шаги реализации:**
+1. Routes: `ALLOWED_FILL_AT = ["OPEN", "CLOSE", "NEXT_OPEN"] as const`. Тип `FillAt` обновится автоматически. Сообщение валидации `"fillAt must be one of: ${ALLOWED_FILL_AT.join(", ")}"` — без правок (формулировка корректна).
+2. `StartBacktestBody` — добавить optional `takerFeeBps?: number` и `makerFeeBps?: number`. Сохранить `feeBps?: number` как backward-compat alias (та же стратегия, что в 46-T3). Серверная нормализация: если пришёл `feeBps` без `takerFeeBps` → `takerFeeBps = feeBps`. Записывать в `BacktestResult` поля `feeBps` (для обратной совместимости с существующей колонкой) и при наличии новых — записывать `takerFeeBps`/`makerFeeBps` в `reportJson`-блоке (additive, без миграции).
+3. **Решение по схеме Prisma:** новые колонки `takerFeeBps`/`makerFeeBps` **не добавляются** в модель `BacktestResult` в этом этапе. Причина: текущая колонка `feeBps Int @default(0)` адекватна для taker-only режима, новые поля живут в `reportJson` до момента, когда maker-fees станут реально использоваться формулами (то есть до limit-order backtest, который вне scope этого документа). Это явное scope-discipline решение из `docs/44 §Scope discipline`. Документировать в PR-описании.
+4. Заменить хардкоды:
+   - `apps/api/src/routes/lab.ts:564` (preview) — оставить `fillAt: "CLOSE"` (preview = sanity-check, неизменно). Документировать.
+   - `apps/api/src/routes/lab.ts:1339, 1349` (sweep) — пробрасывать `body.fillAt ?? "CLOSE"`.
+   - `apps/api/src/routes/lab.ts:1485` (одиночный backtest fire-and-forget) — пробрасывать `body.fillAt ?? "CLOSE"`.
+5. UI:
+   - `ClassicMode.tsx:80` — тип `fillAt: "OPEN" | "CLOSE" | "NEXT_OPEN"`.
+   - `ClassicMode.tsx:541` — заменить хардкод `fillAt: "CLOSE"` на значение из state (новый `<select>` рядом с fee/slippage инпутами); default state value = `"CLOSE"`.
+   - `test/page.tsx:1308` — аналогично, добавить `<select>` в форму запуска backtest и пробрасывать значение.
+   - Snapshot-таблица (`ClassicMode.tsx:904`, `test/page.tsx:202`) уже отображает `bt.fillAt` — без правок, она просто покажет новые значения.
+   - `<select>` подписи: `"On candle close" / "On candle open" / "Next candle open"` для пользовательской ясности.
+6. Не вводить отдельный UI для `takerFeeBps`/`makerFeeBps` в этом этапе — текущее единое поле "fee bps" продолжает мапиться в `feeBps` (server нормализует в `takerFeeBps`). UI для двух полей — отдельная задача после внедрения maker-режима.
+
+**Тест-план:**
+- e2e: POST с `fillAt: "OPEN"` — принимается, `BacktestResult.fillAt = "OPEN"`.
+- e2e: POST с `fillAt: "NEXT_OPEN"` — принимается.
+- e2e: POST с `fillAt: "INVALID"` — 400.
+- e2e: POST без `fillAt` — default `"CLOSE"` (как сейчас).
+- e2e: sweep с `fillAt: "OPEN"` — все runs внутри sweep используют это значение (проверить через `BacktestResult.fillAt` для одной из runs).
+- Ручной smoke в Lab → Test:
+  - Запуск с `"On candle close"` — pnlPct совпадает с pre-46-T1 значением (golden).
+  - Запуск с `"Next candle open"` — pnlPct отличается, snapshot показывает `NEXT_OPEN`.
+- preview-эндпоинт продолжает использовать `"CLOSE"` независимо от выбранного значения.
+
+**Критерии готовности:**
+- `tsc --noEmit` проходит и в api, и в web.
+- Все существующие тесты зелёные.
+- Новые e2e тесты зелёные.
+- Lab UI golden-path работает в браузере для всех трёх значений `fillAt`.
+- Хардкоды `"CLOSE"` в `lab.ts` остались только в preview (обоснованно).
+
+---
+
+### 46-T5: Тесты — golden fixtures и регрессии
+
+**Цель:** убедиться, что нововведения 46-T1..T4 не задевают существующие зелёные тесты, добавить покрытие новых режимов и зафиксировать golden-значения для каждого `fillAt`.
+
+**Файлы для изменения:**
+- `apps/api/tests/lib/dslEvaluator.test.ts` — расширить (если задачи T1..T3 не покрыли все сценарии).
+- `apps/api/tests/lib/backtest.test.ts` — golden-таблица.
+- `apps/api/tests/routes/lab.test.ts` — e2e (если T4 не покрыл).
+- (опционально) `apps/api/tests/lib/realism.test.ts` — новый файл, если хочется собрать realism-сценарии в одном месте.
+
+**Шаги реализации:**
+1. Зафиксировать golden-фикстуру: 50 свечей с явно заданными OHLC (предпочтительно ramp + sin для разнообразия), один простой DSL-стратегия (например, `crossover SMA(5) / SMA(20)`).
+2. Прогнать backtest со всеми комбинациями: `fillAt ∈ {OPEN, CLOSE, NEXT_OPEN}` × `slippageBps ∈ {0, 50}` × `feeBps ∈ {0, 30}`. Получаем 12 запусков. Записать `(trades, totalPnlPct)` в табличный assert. Эти числа фиксируют контракт engine после 46-T1..T3 — изменение любого числа в будущем должно требовать явного обновления golden-таблицы и причины в PR.
+3. Граничные кейсы:
+   - Сигнал на последней свече при `"NEXT_OPEN"` → trade пропущен (assert `trades` на 1 меньше, чем при `"CLOSE"`).
+   - `slippageBps = 0` → новые формулы 46-T2 идентичны старым (assert by golden из pre-46 версии).
+   - `takerFeeBps ≠ feeBps` → используется `takerFeeBps` (assert через golden).
+4. Не вводить тестов на funding, partial fills, maker fees в формулах — это out of scope.
+5. Все тесты детерминированы: фикстуры зашиты, никаких `Date.now()`, никаких PRNG без seed.
+
+**Тест-план:**
+- 12-комбинационная golden table проходит зелёной.
+- Граничные кейсы проходят.
+- e2e блок `lab.test.ts` для `fillAt` (если есть из 46-T4) — зелёный.
+- Suite `apps/api` целиком — зелёный.
+
+**Критерии готовности:**
+- `npm test` (apps/api) зелёный.
+- Golden-таблица зафиксирована в коде с комментарием "do not edit without justification".
+- Покрытие новых формул (entryMult/exitMult, fillAt branches) ≥ 90% по строкам (ориентир, не блокирующий).
+
+---
+
+## Порядок выполнения задач
+
+```
+46-T1 → 46-T2 → 46-T3 → 46-T4 → 46-T5
+```
+
+Каждая задача — отдельный PR.
+
+- T1 первой: вводит fillAt в ядро, разблокирует docs/47-T3 и docs/48-T5.
+- T2 после T1: симметричный slippage может затронуть новые fillAt-режимы, удобнее сначала закрепить fill, потом править slippage.
+- T3 после T2: alias-нормализация полей независима, но логичнее ввести её, когда формулы уже стабильны.
+- T4 после T1..T3: API/UI пробрасывают всё новое.
+- T5 — последняя задача или встроена инкрементально.
+
+## Зависимости от других документов
+
+- **`docs/47`** (Strategy Optimizer) — после закрытия 46-T1 нужно вернуться в `docs/47-T3` (sweep) и заменить хардкод `fillAt: "CLOSE"` на проброс из `SweepRequestBody.fillAt`. Это уже учтено в комментарии 47-T3 как условная зависимость.
+- **`docs/48`** (Walk-Forward) — после закрытия 46-T1 в `WalkForwardRequestBody` появляется `fillAt?: FillAt` (это уже описано в 48-T5 как условное расширение).
+- **`docs/49`** (Backtest Metrics) — независим. 46 и 49 могут идти параллельно.
+- **`docs/45`** (Indicator Engine Extraction) — независим.
+
+## Backward compatibility checklist
+
+- Все вызовы `runBacktest({feeBps, slippageBps})` без `fillAt` продолжают работать (default `"CLOSE"`).
+- Все вызовы `runBacktest({feeBps, slippageBps, fillAt: "CLOSE"})` дают идентичный результат (бит-в-бит).
+- При `slippageBps = 0` формула 46-T2 идентична старой → существующие тесты с дефолтным slippage не падают.
+- Поле `feeBps` в `DslExecOpts`/`ExecOpts` остаётся доступным как alias для `takerFeeBps`.
+- Prisma схема не меняется — `BacktestResult.feeBps Int`, `slippageBps Int`, `fillAt String @default("CLOSE")` уже совместимы (`apps/api/prisma/schema.prisma:598–602`).
+- `engineVersion` уже фиксируется в каждом `BacktestResult` — старые записи интерпретируются по своему `engineVersion`, новые — по новому. Сравнимость абсолютных pnlPct между ними не гарантируется (это ожидаемо при `slippageBps > 0`).
+- `reportVersion` не вводится (правило отложено в `docs/49`).
+- preview-эндпоинт сохраняет `fillAt: "CLOSE"` — не ломает существующие preview-вызовы.
+
+## Ожидаемый результат
+
+После завершения всех задач:
+- Backtest поддерживает три режима fill: `OPEN`, `CLOSE`, `NEXT_OPEN`.
+- `NEXT_OPEN` устраняет lookahead-bias на close для indicator-based стратегий — становится рекомендованным режимом для серьёзного research-а.
+- Slippage учитывается симметрично на entry и exit — round-trip cost отражает реальность.
+- Структура полей готова к maker/taker разделению; формулы пока используют taker (market-only fills).
+- Existing UI Lab → Test предлагает выбор `fillAt`; sweep и walk-forward (после 47/48) пробрасывают значение в каждый run.
+- Funding и partial fills остаются в follow-up плане; явно зафиксировано в "Не входит в задачу".

--- a/docs/46-backtest-realism-plan.md
+++ b/docs/46-backtest-realism-plan.md
@@ -216,10 +216,17 @@
 1. Routes: `ALLOWED_FILL_AT = ["OPEN", "CLOSE", "NEXT_OPEN"] as const`. Тип `FillAt` обновится автоматически. Сообщение валидации `"fillAt must be one of: ${ALLOWED_FILL_AT.join(", ")}"` — без правок (формулировка корректна).
 2. `StartBacktestBody` — добавить optional `takerFeeBps?: number` и `makerFeeBps?: number`. Сохранить `feeBps?: number` как backward-compat alias (та же стратегия, что в 46-T3). Серверная нормализация: если пришёл `feeBps` без `takerFeeBps` → `takerFeeBps = feeBps`. Записывать в `BacktestResult` поля `feeBps` (для обратной совместимости с существующей колонкой) и при наличии новых — записывать `takerFeeBps`/`makerFeeBps` в `reportJson`-блоке (additive, без миграции).
 3. **Решение по схеме Prisma:** новые колонки `takerFeeBps`/`makerFeeBps` **не добавляются** в модель `BacktestResult` в этом этапе. Причина: текущая колонка `feeBps Int @default(0)` адекватна для taker-only режима, новые поля живут в `reportJson` до момента, когда maker-fees станут реально использоваться формулами (то есть до limit-order backtest, который вне scope этого документа). Это явное scope-discipline решение из `docs/44 §Scope discipline`. Документировать в PR-описании.
+3.1. **Prisma migration для `BacktestSweep.fillAt`** — необходима. `runSweepAsync(sweepId)` принимает только `sweepId` (`apps/api/src/routes/lab.ts:1258`) и читает все опции из БД (`sweep.feeBps`, `sweep.slippageBps`). Текущая модель `BacktestSweep` (`apps/api/prisma/schema.prisma:686-708`) **не имеет колонки `fillAt`** (она есть только у `BacktestResult`, line 601). Без миграции sweep не сможет персистировать пользовательский `fillAt` для replay/inspection.
+   - Migration: `ALTER TABLE "BacktestSweep" ADD COLUMN "fillAt" TEXT NOT NULL DEFAULT 'CLOSE'` (additive, безопасна — старые записи получают дефолт `"CLOSE"`, что соответствует их фактическому поведению до 46-T1).
+   - В Prisma: `fillAt String @default("CLOSE")` рядом с `feeBps`/`slippageBps` (`schema.prisma:693-694`).
+   - В `POST /lab/backtest/sweep` сохранять `body.fillAt ?? "CLOSE"` в новую колонку.
+   - В `runSweepAsync` читать `sweep.fillAt` и пробрасывать в `runBacktest` + в `BacktestResult.create({ fillAt: sweep.fillAt })`.
+3.2. **Обновить docstring `BacktestResult.fillAt`** в `apps/api/prisma/schema.prisma:600`. Текущий комментарий `/// Fill price reference; Stage 19 v2.2 fixes to "CLOSE"` после 46-T1 неактуален. Заменить на `/// Fill price reference; supports OPEN | CLOSE | NEXT_OPEN per docs/46`.
 4. Заменить хардкоды:
    - `apps/api/src/routes/lab.ts:564` (preview) — оставить `fillAt: "CLOSE"` (preview = sanity-check, неизменно). Документировать.
-   - `apps/api/src/routes/lab.ts:1339, 1349` (sweep) — пробрасывать `body.fillAt ?? "CLOSE"`.
-   - `apps/api/src/routes/lab.ts:1485` (одиночный backtest fire-and-forget) — пробрасывать `body.fillAt ?? "CLOSE"`.
+   - `apps/api/src/routes/lab.ts:1339` (BacktestResult.create внутри sweep loop) — `fillAt: sweep.fillAt` (после миграции 3.1).
+   - `apps/api/src/routes/lab.ts:1349` (`runBacktest` вызов внутри sweep loop) — `fillAt: sweep.fillAt`.
+   - `apps/api/src/routes/lab.ts:1485` (одиночный backtest fire-and-forget) — пробрасывать `btRecord?.fillAt ?? "CLOSE"`.
 5. UI:
    - `ClassicMode.tsx:80` — тип `fillAt: "OPEN" | "CLOSE" | "NEXT_OPEN"`.
    - `ClassicMode.tsx:541` — заменить хардкод `fillAt: "CLOSE"` на значение из state (новый `<select>` рядом с fee/slippage инпутами); default state value = `"CLOSE"`.

--- a/docs/47-strategy-optimizer-plan.md
+++ b/docs/47-strategy-optimizer-plan.md
@@ -1,0 +1,285 @@
+# 47. Strategy Optimizer Plan
+
+Статус: draft  
+Владелец: core trading / lab  
+Последнее обновление: 2026-04-26  
+Родительский документ: `docs/44-strategy-engine-overview.md`  
+Дорожка: A (research workflow)
+
+## Контекст
+
+Текущее состояние (проверено по коду):
+
+- Phase C1 sweep уже реализован: `POST /lab/backtest/sweep` (`apps/api/src/routes/lab.ts:838`), `GET /lab/backtest/sweep/:id` (`apps/api/src/routes/lab.ts:935`), `GET /lab/backtest/sweeps` (`apps/api/src/routes/lab.ts:962`).
+- Sweep — это **1-D linear sweep** одного параметра: `SweepRequestBody.sweepParam: { blockId, paramName, from, to, step }` (`apps/api/src/routes/lab.ts:1230`), runCount = `floor((to - from) / step) + 1`, max 20 (`apps/api/src/routes/lab.ts:873`).
+- `runSweepAsync(sweepId)` — fire-and-forget loop (`apps/api/src/routes/lab.ts:1258`), candle load один раз на sweep (`apps/api/src/routes/lab.ts:1281`), линейный цикл `for (let paramValue = from; paramValue <= to; paramValue += step)` (`apps/api/src/routes/lab.ts:1312`).
+- На каждой итерации: `runBacktest(candles, mutatedDsl, { feeBps, slippageBps, fillAt: "CLOSE" })` (`apps/api/src/routes/lab.ts:1346`).
+- Sharpe считается локально: `computeSharpe(report.tradeLog.map(t => t.pnlPct))` (`apps/api/src/routes/lab.ts:1357`) — будет удалён после `docs/49-T3` (`report.sharpe` придёт из ядра).
+- Best row выбирается жёстко по `pnlPct`: `results.reduce((best, r) => r.pnlPct > best.pnlPct ? r : best)` (`apps/api/src/routes/lab.ts:1398`) — нет настраиваемого `rankBy`.
+- Мутация DSL: `applyDslSweepParam(dsl, blockId, paramName, paramValue)` (`apps/api/src/lib/dslSweepParam.ts:12`) — один параметр.
+- Prisma модель: `BacktestSweep` со `sweepParamJson Json` (один объект) и `bestParamValue Float?` (`apps/api/prisma/schema.prisma:686`); `SweepStatus: PENDING|RUNNING|DONE|FAILED` (`apps/api/prisma/schema.prisma:677`).
+- Хранение строк: `SweepRow { paramValue: number, backtestResultId, pnlPct, winRate, maxDrawdownPct, tradeCount, sharpe }` (`apps/api/src/routes/lab.ts:1244`) — plain `paramValue`, не словарь.
+- Frontend: `OptimisePanel.tsx` — `SweepParam` тип (`apps/web/src/app/lab/test/OptimisePanel.tsx:18`), UI sort (`SortKey`, строка 67), `OptimiseMetric = "pnl" | "winRate" | "sharpe" | "maxDrawdown"` объявлен (`apps/web/src/app/lab/test/OptimisePanel.tsx:70`, использован в `setMetric` строка 122 и `<select>` строка 504), но **не передаётся в API** — это чисто клиентская сортировка.
+- POLL/MAX: `POLL_INTERVAL_MS=2000`, `MAX_RUNS=20` (`apps/web/src/app/lab/test/OptimisePanel.tsx:75`).
+- Sweepable parameters берутся из `BLOCK_DEF_MAP` через `getNumericParams` (`apps/web/src/app/lab/test/OptimisePanel.tsx:87`) и определены для SMA/EMA/RSI/MACD/Bollinger/ATR/ADX/SuperTrend (`apps/web/src/app/lab/build/blockDefs.ts:137`–`286`).
+- Тесты: `apps/api/tests/routes/lab.test.ts:442`–`515`.
+- Phase C1 spec: `docs/steps/25c1-lab-phase-c1-grid-search.md`.
+
+## Цель
+
+- Расширить sweep до **multi-parameter grid** (1..N параметров, N ≤ 3 чтобы декартово произведение помещалось в текущий лимит 20 runs).
+- Ввести серверный `rankBy` для выбора best row по выбранной метрике.
+- Сохранить полную backward compatibility: старый `sweepParam` (singular) и старый ответ с `paramValue: number` продолжают работать.
+- Минимальные правки UI: добавление/удаление строк параметров, селектор rank-by.
+
+## Решение по форме параметров
+
+В `SweepRequestBody` вводится новое поле `sweepParams: SweepParam[]` (массив, 1..3 элемента). Старое поле `sweepParam` (одиночное) сохраняется как backward-compat alias: если пришло `sweepParam` без `sweepParams`, бэкенд оборачивает его в массив длиной 1. Если пришли оба — `sweepParams` приоритетнее, `sweepParam` игнорируется. Это additive расширение в духе `docs/44 §Backward compatibility`.
+
+В `SweepRow` добавляется `paramValues: Record<string, number>` где ключ — `${blockId}.${paramName}`. Для 1-параметрического запуска поле `paramValue: number` остаётся заполненным (равно единственному значению в `paramValues`), чтобы старые клиенты (текущий `OptimisePanel.tsx`) продолжили работать без правок.
+
+## Не входит в задачу
+
+- Random search, Bayesian optimization, любая non-grid стратегия выбора точек.
+- Distributed optimization, worker pool, BullMQ — изменения сугубо in-process в `runSweepAsync`.
+- Изменение лимита 20 runs или rate limit (5/min, 2 concurrent per workspace).
+- Изменения `runBacktest`, `dslEvaluator` или ядра execution.
+- Введение `reportVersion` (правило отложено в `docs/49`).
+- Сохранение полной матрицы для визуализации heatmap — в данном этапе достаточно линейной таблицы строк.
+- Замена `applyDslSweepParam` без обёртки — старая сигнатура остаётся.
+
+---
+
+## Задачи
+
+### 47-T1: Расширить `SweepRequestBody` до массива параметров
+
+**Цель:** принимать `sweepParams: SweepParam[]` (1..3) с backward-compat alias на `sweepParam`.
+
+**Файлы для изменения:**
+- `apps/api/src/routes/lab.ts` — тип `SweepRequestBody` (строка 1230), валидация в `POST /lab/backtest/sweep` (строка 838).
+- `apps/api/tests/routes/lab.test.ts` — расширить тесты валидации.
+
+**Шаги реализации:**
+1. В `SweepRequestBody` добавить `sweepParams?: SweepParam[]` рядом с существующим `sweepParam?: SweepParam`. Оба поля делать optional на уровне типа; валидация обеспечит, что хотя бы одно присутствует.
+2. В обработчике `POST /lab/backtest/sweep` после парсинга body нормализовать вход: если `sweepParams` отсутствует, но есть `sweepParam` → `sweepParams = [sweepParam]`; если есть оба — использовать `sweepParams`, `sweepParam` игнорируется (логировать warning).
+3. Валидация: `1 ≤ sweepParams.length ≤ 3`; для каждого элемента — `from < to`, `step > 0`, `(to - from) / step + 1 ≥ 2`. Декартов размер `Π (runs_i)` — проверять отдельно в 47-T3.
+4. Сохранять весь массив в `BacktestSweep.sweepParamJson` как массив объектов (поле уже `Json`, миграция не требуется). Для 1-параметрического случая — массив длины 1, формат сохраняется как объект-в-массиве.
+5. Обновить response типов `GET /lab/backtest/sweep/:id` — добавить `sweepParams: SweepParam[]` (читать из JSON), при этом для backward compat сохранить `sweepParam: SweepParam` как первый элемент массива.
+
+**Тест-план:**
+- Отправка только `sweepParam` → принимается, нормализуется в `sweepParams: [...]`.
+- Отправка только `sweepParams` (1 элемент) → принимается.
+- Отправка `sweepParams` (2 и 3 элемента) → принимается.
+- Отправка `sweepParams` (4 элемента) → 400.
+- Отправка обоих — `sweepParams` побеждает, в логах warning.
+- Отсутствие обоих → 400.
+- GET-эндпоинт возвращает оба поля для 1-парам случая.
+
+**Критерии готовности:**
+- `tsc --noEmit` проходит.
+- Существующие тесты sweep зелёные без правок.
+- Новые тесты валидации зелёные.
+- Миграция Prisma не требуется (поле уже `Json`).
+
+---
+
+### 47-T2: Multi-param мутация DSL — `applyDslSweepParams`
+
+**Цель:** ввести функцию для мутации сразу нескольких параметров DSL за один проход, сохранив `applyDslSweepParam` как тонкую обёртку.
+
+**Файлы для изменения:**
+- `apps/api/src/lib/dslSweepParam.ts` — добавить `applyDslSweepParams`, оставить `applyDslSweepParam`.
+- `apps/api/tests/lib/dslSweepParam.test.ts` (создать или дополнить, если уже есть) — unit-тесты.
+
+**Шаги реализации:**
+1. Добавить функцию `applyDslSweepParams(dsl: DslJson, params: Array<{ blockId: string; paramName: string; value: number }>): DslJson`.
+2. Реализация: глубокий клон DSL один раз (`structuredClone`), затем in-place мутация по каждому элементу `params` — ровно та же логика поиска блока по `blockId` и присвоения `paramName`, что в существующем `applyDslSweepParam` (строки 12–35). Если блок не найден или `paramName` не существует — выбросить ту же ошибку, что и в одиночной версии (сохранить текст ошибки).
+3. Переписать `applyDslSweepParam(dsl, blockId, paramName, value)` как `return applyDslSweepParams(dsl, [{ blockId, paramName, value }])`. Старая сигнатура остаётся, импортёры не меняются.
+4. Обеспечить детерминизм: порядок применения мутаций = порядок элементов массива. Документировать это в JSDoc.
+5. Если два элемента массива указывают на один и тот же `(blockId, paramName)` — последний выигрывает (но валидация в 47-T1 должна это предотвращать — добавить проверку уникальности на уровне роутера).
+
+**Тест-план:**
+- Unit: 1 параметр через `applyDslSweepParams` — результат идентичен `applyDslSweepParam`.
+- Unit: 2 параметра в разных блоках — оба применены.
+- Unit: 2 параметра в одном блоке — оба применены.
+- Unit: несуществующий `blockId` — та же ошибка, что в одиночной версии.
+- Unit: исходный DSL не мутируется (immutability проверка через deep equality до/после).
+- Существующие тесты `applyDslSweepParam` зелёные без правок.
+
+**Критерии готовности:**
+- `tsc --noEmit` проходит.
+- Все существующие импортёры `applyDslSweepParam` работают без изменений.
+- `applyDslSweepParams` экспортируется из `dslSweepParam.ts`.
+- Покрытие тестами включает single-param, multi-param и ошибочные сценарии.
+
+---
+
+### 47-T3: N-D grid generation в `runSweepAsync` + расширение `SweepRow`
+
+**Цель:** в существующем fire-and-forget sweep-loop заменить линейный 1-D цикл на декартов перебор по `sweepParams`; сохранить лимит 20 runs; расширить `SweepRow` дополнительным полем `paramValues`.
+
+**Файлы для изменения:**
+- `apps/api/src/routes/lab.ts` — `runSweepAsync` (`строка 1258`), типизация `SweepRow` (`строка 1244`), валидация общего числа runs (`строка 873`).
+- `apps/api/tests/routes/lab.test.ts` — расширить существующие e2e тесты sweep.
+
+**Шаги реализации:**
+1. Перенести вычисление `runCount` per-param: для каждого `p ∈ sweepParams` `runs_p = floor((p.to - p.from) / p.step) + 1`. Полное число итераций = `Π runs_p`. Если `Π runs_p > 20` → 400 на эндпоинте (валидация до запуска `runSweepAsync`).
+2. В `runSweepAsync` сгенерировать массив комбинаций. Реализация: чистый детерминированный декартов перебор (например, n-вложенный `for` через рекурсию или iterative с массивом индексов). Порядок комбинаций — лексикографический по индексам параметров `[0..0..0], [0..0..1], ...` — фиксируется в комментарии для воспроизводимости.
+3. Для каждой комбинации: построить `params: Array<{ blockId, paramName, value }>`, вызвать `applyDslSweepParams(dsl, params)` (из 47-T2), затем `runBacktest(candles, mutatedDsl, { feeBps, slippageBps, fillAt: "CLOSE" })`. Параметр `fillAt` остаётся `"CLOSE"` пока `docs/46` не закрыт; после `docs/46-T1` сюда передаётся пользовательский `fillAt`.
+4. В `SweepRow` добавить новое поле `paramValues: Record<string, number>` где ключ = `${blockId}.${paramName}`. Поле `paramValue: number` сохраняется и для случая `sweepParams.length === 1` равно единственному значению из `paramValues` (для backward compat). Для `sweepParams.length > 1` — `paramValue` равно значению **первого** параметра из массива (документировать в комментарии; клиенты, которые поддерживают multi-param, должны читать `paramValues`).
+5. Хранение в БД: расширить структуру `SweepRow`-аналога в JSON (если она хранится в JSON) либо обновить колонки таблицы `BacktestSweepRow` (если такая есть). Уточнение по схеме: посмотреть `prisma/schema.prisma` для модели рядом с `BacktestSweep` — добавить `paramValuesJson Json` additive колонкой; миграция additive, безопасна.
+6. Прогресс: текущий `progress: number` в `BacktestSweep` сохраняется как `iterationsDone / totalIterations` — формула не меняется, корректно работает для N-D.
+
+**Тест-план:**
+- e2e: 1-параметрический sweep — старый формат запроса работает, ответ содержит и `paramValue`, и `paramValues`.
+- e2e: 2-параметрический sweep с малыми диапазонами (например, 2×3 = 6 runs) — все 6 комбинаций пробежали, `paramValues` корректен на каждой строке.
+- e2e: 3×3×3 = 27 runs → 400 (превышен лимит 20).
+- e2e: 3×3 = 9 runs — успех.
+- Юнит: декартов генератор детерминирован (одинаковый input → одинаковый порядок комбинаций).
+- Существующие тесты sweep продолжают проходить.
+
+**Критерии готовности:**
+- `tsc --noEmit` проходит.
+- Лимит 20 runs соблюдается.
+- Старый клиент получает ровно тот же набор полей, что и раньше (`paramValue`, `pnlPct`, `winRate`, ...).
+- Новый клиент получает дополнительно `paramValues`.
+- Миграция Prisma additive, безопасна для существующих записей.
+
+---
+
+### 47-T4: Серверный `rankBy` для выбора best row
+
+**Цель:** ввести параметр `rankBy: "pnlPct" | "sharpe" | "profitFactor" | "expectancy"` в `SweepRequestBody`; жёсткий выбор по `pnlPct` заменить на выбор по указанной метрике; сохранить полную backward compatibility.
+
+**Файлы для изменения:**
+- `apps/api/src/routes/lab.ts` — `SweepRequestBody` (`строка 1230`), best-row selection (`строка 1398`).
+- `apps/api/tests/routes/lab.test.ts` — добавить тест-кейсы.
+
+**Шаги реализации:**
+1. В `SweepRequestBody` добавить optional `rankBy?: "pnlPct" | "sharpe" | "profitFactor" | "expectancy"`. Default: `"pnlPct"` (сохраняет текущее поведение).
+2. Поля `sharpe`, `profitFactor`, `expectancy` приходят из `DslBacktestReport` после `docs/49-T2`. До тех пор реализуется только `pnlPct`-ветка; для остальных значений до завершения `docs/49-T2` бросать 400 с пояснением "rankBy=<x> requires docs/49-T2 metrics; only 'pnlPct' is available". Это явная gating-зависимость, документировать в PR-описании.
+3. В `runSweepAsync` после сбора всех `results` заменить жёсткий `r.pnlPct > best.pnlPct` на `compareByMetric(r, best, rankBy) > 0`. Реализация `compareByMetric`:
+   - `pnlPct`: больше = лучше.
+   - `sharpe`: больше = лучше; `null` трактуется как `-Infinity`.
+   - `profitFactor`: больше = лучше; `Infinity` (нет убытков) сортируется выше любого конечного.
+   - `expectancy`: больше = лучше.
+4. Tie-breaking (per `docs/44 §Детерминизм`): при равенстве метрики использовать индекс комбинации (меньший индекс = победитель). Это даёт детерминированный результат для одинаковых сценариев.
+5. Сохранить `bestParamValue Float?` в `BacktestSweep` для 1-параметрического случая (значение первого параметра комбинации-победителя). Добавить `bestParamValuesJson Json?` для multi-param. Оба поля additive.
+6. В response `GET /lab/backtest/sweep/:id` вернуть оба поля, плюс `rankBy` (эхо запроса).
+
+**Тест-план:**
+- `rankBy` не указан → default `pnlPct`, поведение совпадает с текущим.
+- `rankBy: "pnlPct"` явно → поведение совпадает с default.
+- `rankBy: "sharpe"` без `docs/49-T2` → 400.
+- (после `docs/49-T2`) `rankBy: "sharpe"` — best row выбран по sharpe; tie-break проверен фикстурой с равными значениями.
+- `rankBy` не из allowed enum → 400.
+
+**Критерии готовности:**
+- `tsc --noEmit` проходит.
+- Default-поведение идентично текущему — старые клиенты не сломаны.
+- `bestParamValue` для 1-param случая совпадает со старым полем при `rankBy="pnlPct"`.
+- 400 для метрик, требующих `docs/49-T2`, с понятным сообщением.
+
+---
+
+### 47-T5: UI — multi-param строки и rank-by селектор в `OptimisePanel.tsx`
+
+**Цель:** позволить пользователю добавить до 3 параметров для grid-search и выбрать серверную метрику ранжирования; минимальные правки таблицы для отображения нескольких param-колонок.
+
+**Файлы для изменения:**
+- `apps/web/src/app/lab/test/OptimisePanel.tsx`.
+
+**Шаги реализации:**
+1. Заменить state одиночного `sweepParam` на массив `sweepParams: SweepParam[]` (1..3). UI: список строк, в каждой — селектор блока + селектор параметра + поля `from/to/step`. Кнопка `+ Add parameter` (disabled при достижении 3); кнопка удаления на каждой строке (disabled когда строк ровно 1).
+2. Перед отправкой POST: считать суммарный размер grid-а `Π runs_p` локально и блокировать кнопку запуска (с подсказкой "макс 20 итераций"), если превышено. Та же валидация остаётся на сервере (47-T3).
+3. Существующий локальный `OptimiseMetric` (`строка 70`) — перевести в передаваемый на сервер `rankBy` параметр запроса. Маппинг: `"pnl"→"pnlPct"`, `"winRate"→` (НЕ передавать, т.к. в server-side enum его нет — оставить как UI-only sort), `"sharpe"→"sharpe"`, `"maxDrawdown"→` (UI-only sort). То есть `rankBy` присылается только для `pnl`/`sharpe`/(после `docs/49-T2`) `profitFactor`/`expectancy`. Для `winRate`/`maxDrawdown` — `rankBy` не присылается, делается клиентский sort (как сейчас).
+4. Таблица результатов: вместо одной колонки `paramValue` — серия колонок по `sweepParams`, читать из `paramValues`. Для backward-compat: если ответ содержит только `paramValue` (старый сервер), отрисовать одну колонку.
+5. `MAX_RUNS = 20` остаётся; обновить подсказку рядом с кнопкой запуска: "Макс 20 итераций (произведение run-counts всех параметров)".
+6. Не вводить новые публичные компоненты: всё inline в `OptimisePanel.tsx`.
+
+**Тест-план:**
+- Ручной smoke в Lab → Test → Optimise:
+  - 1 параметр — старый сценарий, всё работает.
+  - 2 параметра 2×3 = 6 runs — таблица содержит 2 param-колонки и 6 строк.
+  - 3 параметра 2×2×3 = 12 — успех.
+  - 3 параметра 3×3×3 = 27 — кнопка disabled, подсказка показана.
+- `rankBy=pnl` → серверный best совпадает с лучшим pnl в таблице.
+- `rankBy=sharpe` (после `docs/49-T2`) — серверный best совпадает с лучшим sharpe.
+- `rankBy=winRate` или `maxDrawdown` — `rankBy` не отправляется, серверный best остаётся по `pnlPct`, клиентский sort работает.
+
+**Критерии готовности:**
+- TypeScript-проверка фронтенда проходит.
+- Lab UI запускается, golden-path 1-param + multi-param работает в браузере.
+- Нет регрессий в существующем sort/filter поведении.
+
+---
+
+### 47-T6: Тесты — unit и e2e расширения
+
+**Цель:** довести покрытие до уровня, при котором регрессии sweep-функционала ловятся на CI.
+
+**Файлы для изменения:**
+- `apps/api/tests/lib/dslSweepParam.test.ts` (создать или дополнить).
+- `apps/api/tests/routes/lab.test.ts` — расширить блок тестов `/lab/backtest/sweep` (`строки 442–515`).
+- (опционально) `apps/api/tests/lib/sweepGrid.test.ts` — unit для декартова генератора, если он вынесен в отдельную функцию в 47-T3.
+
+**Шаги реализации:**
+1. Добавить unit-тесты для `applyDslSweepParams` (см. 47-T2 тест-план), если не были добавлены в самой задаче 47-T2.
+2. Добавить unit-тест для генератора комбинаций: вход `[{from:1,to:2,step:1},{from:10,to:20,step:5}]` → выход `[[1,10],[1,15],[1,20],[2,10],[2,15],[2,20]]` — проверить порядок и полноту.
+3. Расширить `lab.test.ts`:
+   - happy-path 2-param sweep: проверить `paramValues` на каждой строке, проверить `bestParamValuesJson` после завершения.
+   - rejection при `Π runs > 20`.
+   - rejection при `sweepParams.length === 0` или `> 3`.
+   - rejection при дубликате `(blockId, paramName)` в `sweepParams`.
+   - backward-compat: старый запрос с `sweepParam` (singular) проходит.
+4. Все новые тесты должны быть детерминированы: фикстуры свечей зашиты в файл, рандом не используется (если бы использовался — явный seed).
+
+**Тест-план:**
+- `npm test` (или соответствующий тестовый раннер apps/api) проходит.
+- Time-skewed/flaky тесты отсутствуют (новые тесты не зависят от текущего времени).
+
+**Критерии готовности:**
+- Все новые тесты зелёные на CI.
+- Существующие тесты sweep остаются зелёными.
+- Покрытие `dslSweepParam.ts` и grid-генератора ≥ 90% по строкам (метрика опциональна, ориентир).
+
+---
+
+## Порядок выполнения задач
+
+```
+47-T1 → 47-T2 → 47-T3 → 47-T4 → 47-T5 → 47-T6
+```
+
+Каждая задача — отдельный PR.
+
+- 47-T1 и 47-T2 можно параллелить, но T3 требует обоих.
+- 47-T4 зависит от `docs/49-T2` для `rankBy ∈ {sharpe, profitFactor, expectancy}`. Если `docs/49-T2` ещё не закрыт на момент T4 — реализовать только `pnlPct`-ветку, оставив 400 для остальных, и закрыть остальные ветки follow-up PR-ом после `docs/49-T2`.
+- 47-T5 идёт после T3 и T4 (UI читает новый формат ответа и отправляет `rankBy`).
+- 47-T6 — последний шаг или встроен в каждую предыдущую задачу инкрементально.
+
+## Зависимости от других документов
+
+- `docs/49-T2` — расширение `DslBacktestReport` полями `sharpe`, `profitFactor`, `expectancy`. Обязательно для полноценного 47-T4. Без него реализуется только `rankBy="pnlPct"`.
+- `docs/46-T1` — параметр `fillAt` в `DslExecOpts`. Косвенная: после закрытия `docs/46-T1` `runSweepAsync` должен передавать пользовательский `fillAt` в `runBacktest`, а не жёстко `"CLOSE"` (`apps/api/src/routes/lab.ts:1346`).
+- `docs/45` — независимо. Никаких блокирующих связей.
+
+## Backward compatibility checklist
+
+- `SweepRequestBody.sweepParam` (singular) продолжает работать.
+- `SweepRow.paramValue: number` сохраняется в ответе для всех случаев.
+- `BacktestSweep.bestParamValue` сохраняется для 1-param случая.
+- `rankBy` отсутствует → default `"pnlPct"` → поведение идентично текущему.
+- Миграции Prisma — только additive колонки (`paramValuesJson`, `bestParamValuesJson`).
+- Старый клиент (`OptimisePanel.tsx` до 47-T5) с новым сервером — работает: читает `paramValue`, игнорирует `paramValues`.
+- Старый сервер с новым клиентом (47-T5) — работает: клиент видит `paramValue` без `paramValues` и отрисовывает одну колонку.
+- `reportVersion` не вводится (правило отложено в `docs/49`).
+
+## Ожидаемый результат
+
+После завершения всех задач:
+- Lab Optimise позволяет запускать grid-search по 1..3 параметрам в пределах лимита 20 runs.
+- Best row выбирается на сервере по настраиваемой метрике с детерминированным tie-break.
+- `runBacktest` и ядро DSL-evaluator не модифицированы (правки только на уровне sweep-loop и DSL-мутации).
+- Вся существующая Phase C1 функциональность работает без правок клиентского кода вне `OptimisePanel.tsx`.

--- a/docs/47-strategy-optimizer-plan.md
+++ b/docs/47-strategy-optimizer-plan.md
@@ -65,7 +65,13 @@
 2. В обработчике `POST /lab/backtest/sweep` после парсинга body нормализовать вход: если `sweepParams` отсутствует, но есть `sweepParam` → `sweepParams = [sweepParam]`; если есть оба — использовать `sweepParams`, `sweepParam` игнорируется (логировать warning).
 3. Валидация: `1 ≤ sweepParams.length ≤ 3`; для каждого элемента — `from < to`, `step > 0`, `(to - from) / step + 1 ≥ 2`. Декартов размер `Π (runs_i)` — проверять отдельно в 47-T3.
 4. Сохранять весь массив в `BacktestSweep.sweepParamJson` как массив объектов (поле уже `Json`, миграция не требуется). Для 1-параметрического случая — массив длины 1, формат сохраняется как объект-в-массиве.
-5. Обновить response типов `GET /lab/backtest/sweep/:id` — добавить `sweepParams: SweepParam[]` (читать из JSON), при этом для backward compat сохранить `sweepParam: SweepParam` как первый элемент массива.
+5. **Backward-compat при чтении** `sweepParamJson`: существующие записи в БД до 47-T1 содержат единичный объект `{ blockId, paramName, from, to, step }`, новые — массив `[{...}]`. Везде, где читается это поле (`runSweepAsync`, `GET /lab/backtest/sweep/:id`, `GET /lab/backtest/sweeps`), нормализовать через единый helper:
+   ```ts
+   const normalizeSweepParams = (json: unknown): SweepParam[] =>
+     Array.isArray(json) ? json as SweepParam[] : [json as SweepParam];
+   ```
+   Helper применять перед любой работой со значением. Никаких backfill-миграций — старые записи остаются в исходном формате.
+6. Обновить response типов `GET /lab/backtest/sweep/:id` — добавить `sweepParams: SweepParam[]` (через `normalizeSweepParams`), при этом для backward compat сохранить `sweepParam: SweepParam` как первый элемент массива.
 
 **Тест-план:**
 - Отправка только `sweepParam` → принимается, нормализуется в `sweepParams: [...]`.
@@ -128,7 +134,7 @@
 2. В `runSweepAsync` сгенерировать массив комбинаций. Реализация: чистый детерминированный декартов перебор (например, n-вложенный `for` через рекурсию или iterative с массивом индексов). Порядок комбинаций — лексикографический по индексам параметров `[0..0..0], [0..0..1], ...` — фиксируется в комментарии для воспроизводимости.
 3. Для каждой комбинации: построить `params: Array<{ blockId, paramName, value }>`, вызвать `applyDslSweepParams(dsl, params)` (из 47-T2), затем `runBacktest(candles, mutatedDsl, { feeBps, slippageBps, fillAt: "CLOSE" })`. Параметр `fillAt` остаётся `"CLOSE"` пока `docs/46` не закрыт; после `docs/46-T1` сюда передаётся пользовательский `fillAt`.
 4. В `SweepRow` добавить новое поле `paramValues: Record<string, number>` где ключ = `${blockId}.${paramName}`. Поле `paramValue: number` сохраняется и для случая `sweepParams.length === 1` равно единственному значению из `paramValues` (для backward compat). Для `sweepParams.length > 1` — `paramValue` равно значению **первого** параметра из массива (документировать в комментарии; клиенты, которые поддерживают multi-param, должны читать `paramValues`).
-5. Хранение в БД: расширить структуру `SweepRow`-аналога в JSON (если она хранится в JSON) либо обновить колонки таблицы `BacktestSweepRow` (если такая есть). Уточнение по схеме: посмотреть `prisma/schema.prisma` для модели рядом с `BacktestSweep` — добавить `paramValuesJson Json` additive колонкой; миграция additive, безопасна.
+5. Хранение в БД: **отдельной таблицы `BacktestSweepRow` НЕТ**. `SweepRow[]` сериализуется внутри `BacktestSweep.resultsJson Json?` (`apps/api/prisma/schema.prisma:699`). Соответственно — **никакой Prisma-миграции не требуется**: новое поле `paramValues` добавляется внутрь существующего JSON-массива. Шаги: (а) обновить TS-тип `SweepRow`, (б) при записи в `resultsJson` сериализовать новое поле, (в) при чтении из `resultsJson` принимать оба формата (старые записи без `paramValues` корректно обрабатываются как `paramValues = { [`${blockId}.${paramName}`]: paramValue }` через fallback-helper).
 6. Прогресс: текущий `progress: number` в `BacktestSweep` сохраняется как `iterationsDone / totalIterations` — формула не меняется, корректно работает для N-D.
 
 **Тест-план:**
@@ -150,22 +156,25 @@
 
 ### 47-T4: Серверный `rankBy` для выбора best row
 
-**Цель:** ввести параметр `rankBy: "pnlPct" | "sharpe" | "profitFactor" | "expectancy"` в `SweepRequestBody`; жёсткий выбор по `pnlPct` заменить на выбор по указанной метрике; сохранить полную backward compatibility.
+**Цель:** ввести параметр `rankBy: "pnlPct" | "winRate" | "sharpe" | "profitFactor" | "expectancy"` в `SweepRequestBody`; жёсткий выбор по `pnlPct` заменить на выбор по указанной метрике; сохранить полную backward compatibility.
 
 **Файлы для изменения:**
 - `apps/api/src/routes/lab.ts` — `SweepRequestBody` (`строка 1230`), best-row selection (`строка 1398`).
 - `apps/api/tests/routes/lab.test.ts` — добавить тест-кейсы.
 
 **Шаги реализации:**
-1. В `SweepRequestBody` добавить optional `rankBy?: "pnlPct" | "sharpe" | "profitFactor" | "expectancy"`. Default: `"pnlPct"` (сохраняет текущее поведение).
-2. Поля `sharpe`, `profitFactor`, `expectancy` приходят из `DslBacktestReport` после `docs/49-T2`. До тех пор реализуется только `pnlPct`-ветка; для остальных значений до завершения `docs/49-T2` бросать 400 с пояснением "rankBy=<x> requires docs/49-T2 metrics; only 'pnlPct' is available". Это явная gating-зависимость, документировать в PR-описании.
+1. В `SweepRequestBody` добавить optional `rankBy?: "pnlPct" | "winRate" | "sharpe" | "profitFactor" | "expectancy"`. Default: `"pnlPct"` (сохраняет текущее поведение). `winRate` включён несмотря на свою методологическую слабость (легко обманывается мелкими wins при крупных losses): пользователь имеет на это право, и оставить его UI-only при наличии серверных `sharpe/PF/expectancy` было бы непоследовательно.
+2. Поля `sharpe`, `profitFactor`, `expectancy` приходят из `DslBacktestReport` после `docs/49-T2`. До тех пор реализуются только ветки `pnlPct` и `winRate` (оба доступны из текущего `report` без зависимостей); для `sharpe`/`profitFactor`/`expectancy` до завершения `docs/49-T2` бросать 400 с пояснением "rankBy=<x> requires docs/49-T2 metrics; available now: 'pnlPct', 'winRate'". Это явная gating-зависимость, документировать в PR-описании.
 3. В `runSweepAsync` после сбора всех `results` заменить жёсткий `r.pnlPct > best.pnlPct` на `compareByMetric(r, best, rankBy) > 0`. Реализация `compareByMetric`:
    - `pnlPct`: больше = лучше.
+   - `winRate`: больше = лучше.
    - `sharpe`: больше = лучше; `null` трактуется как `-Infinity`.
    - `profitFactor`: больше = лучше; `Infinity` (нет убытков) сортируется выше любого конечного.
    - `expectancy`: больше = лучше.
 4. Tie-breaking (per `docs/44 §Детерминизм`): при равенстве метрики использовать индекс комбинации (меньший индекс = победитель). Это даёт детерминированный результат для одинаковых сценариев.
-5. Сохранить `bestParamValue Float?` в `BacktestSweep` для 1-параметрического случая (значение первого параметра комбинации-победителя). Добавить `bestParamValuesJson Json?` для multi-param. Оба поля additive.
+5. Сохранить `bestParamValue Float?` в `BacktestSweep` для 1-параметрического случая (значение первого параметра комбинации-победителя). Добавить `bestParamValuesJson Json?` для multi-param.
+   - **Prisma migration**: `ALTER TABLE "BacktestSweep" ADD COLUMN "bestParamValuesJson" JSONB` (additive, nullable). В `schema.prisma` рядом с `bestParamValue Float?` (line 700): `bestParamValuesJson Json?`.
+   - Также additive колонка `rankBy String @default("pnlPct")` в той же миграции — для эхо-ответа и аудита (без неё `GET /lab/backtest/sweep/:id` не сможет восстановить, по какой метрике выбран best).
 6. В response `GET /lab/backtest/sweep/:id` вернуть оба поля, плюс `rankBy` (эхо запроса).
 
 **Тест-план:**
@@ -195,6 +204,13 @@
 2. Перед отправкой POST: считать суммарный размер grid-а `Π runs_p` локально и блокировать кнопку запуска (с подсказкой "макс 20 итераций"), если превышено. Та же валидация остаётся на сервере (47-T3).
 3. Существующий локальный `OptimiseMetric` (`строка 70`) — перевести в передаваемый на сервер `rankBy` параметр запроса. Маппинг: `"pnl"→"pnlPct"`, `"winRate"→` (НЕ передавать, т.к. в server-side enum его нет — оставить как UI-only sort), `"sharpe"→"sharpe"`, `"maxDrawdown"→` (UI-only sort). То есть `rankBy` присылается только для `pnl`/`sharpe`/(после `docs/49-T2`) `profitFactor`/`expectancy`. Для `winRate`/`maxDrawdown` — `rankBy` не присылается, делается клиентский sort (как сейчас).
 4. Таблица результатов: вместо одной колонки `paramValue` — серия колонок по `sweepParams`, читать из `paramValues`. Для backward-compat: если ответ содержит только `paramValue` (старый сервер), отрисовать одну колонку.
+4.1. **Расширение `SortKey`** (`apps/web/src/app/lab/test/OptimisePanel.tsx:67`). Текущий enum жёстко содержит литерал `"paramValue"`. После multi-param param-колонки динамические — каждая идентифицируется ключом `${blockId}.${paramName}`. Решение: расширить `SortKey` через type-union:
+   ```ts
+   type FixedSortKey = "pnlPct" | "winRate" | "maxDrawdownPct" | "tradeCount" | "sharpe";
+   type ParamSortKey = `param:${string}`;       // например, "param:block_42.length"
+   type SortKey = FixedSortKey | ParamSortKey | "paramValue"; // "paramValue" — legacy 1-param fallback
+   ```
+   В `handleSort` для `ParamSortKey` распаковывать ключ → получать `(blockId, paramName)` → сортировать `rows` по `row.paramValues[`${blockId}.${paramName}`]`. Для `"paramValue"` — старая ветка (если сервер прислал только legacy-поле).
 5. `MAX_RUNS = 20` остаётся; обновить подсказку рядом с кнопкой запуска: "Макс 20 итераций (произведение run-counts всех параметров)".
 6. Не вводить новые публичные компоненты: всё inline в `OptimisePanel.tsx`.
 

--- a/docs/48-walk-forward-plan.md
+++ b/docs/48-walk-forward-plan.md
@@ -1,0 +1,413 @@
+# 48. Walk-Forward Validation Plan
+
+Статус: draft  
+Владелец: core trading / lab  
+Последнее обновление: 2026-04-26  
+Родительский документ: `docs/44-strategy-engine-overview.md`  
+Дорожка: A (research workflow)
+
+## Контекст
+
+Текущее состояние (проверено по коду):
+
+- Walk-forward в кодовой базе **отсутствует** (`grep -r "walkForward\|walk-forward\|fold\|isBars" apps/api/src apps/web/src` пусто). Этот документ — план первой реализации.
+- Точка входа в backtest: `runDslBacktest(candles, dslJson, opts: Partial<DslExecOpts>, mtfContext?)` (`apps/api/src/lib/dslEvaluator.ts:822`); тонкая обёртка `runBacktest(candleData, dslJson, opts, mtfContext?)` (`apps/api/src/lib/backtest.ts:39`).
+- Тип отчёта: `DslBacktestReport` (`apps/api/src/lib/dslEvaluator.ts:68`); тип сделки: `DslTradeRecord` (`apps/api/src/lib/dslEvaluator.ts:50`).
+- Опции исполнения: `DslExecOpts: { feeBps, slippageBps }` (`apps/api/src/lib/dslEvaluator.ts:78`); после `docs/46-T1` к ним добавится `fillAt`. Маппинг на `ExecOpts` в `apps/api/src/lib/backtest.ts:24`.
+- Паттерн загрузки candles из БД, который повторно используем: `prisma.marketCandle.findMany({ where: { ..., openTimeMs: { gte, lte } }, orderBy: { openTimeMs: "asc" } })` — один раз на запуск (`apps/api/src/routes/lab.ts:1281`); конвертация `hours → fromTsMs/toTsMs` (`apps/api/src/routes/lab.ts:534`).
+- Шаблон fire-and-forget run-эндпоинта со статусной БД-моделью: sweep — `runSweepAsync` (`apps/api/src/routes/lab.ts:1258`), статусы `PENDING|RUNNING|DONE|FAILED` (`apps/api/prisma/schema.prisma:677`). Walk-forward повторяет этот паттерн.
+- Структурный шаблон Prisma модели: `BacktestSweep` (`apps/api/prisma/schema.prisma:686–708`) — поля `id`, `workspaceId`, `strategyVersionId`, `datasetId`, `status`, `progress`, `*Json`. Walk-forward Prisma модель повторяет ту же структуру.
+- Хранилище per-fold отчётов: можно использовать существующую `BacktestResult` (`apps/api/prisma/schema.prisma:578–619`) как референс структуры; в первом этапе храним fold-отчёты как JSON внутри родительской записи, без отдельной таблицы.
+- Метрики: `apps/api/src/lib/metrics.ts` сейчас содержит только Prometheus (`Registry`, `collectDefaultMetrics`, `Counter`, `Histogram`). Папка `apps/api/src/lib/metrics/` ещё **не создана** — она появится в `docs/49-T1` и принесёт `sharpe`, `profitFactor`, `expectancy`, `maxDrawdownPct` и т.п. Walk-forward aggregate использует именно эти функции после `docs/49`.
+- В `apps/web/src/app/lab/` walk-forward UI отсутствует.
+
+## Цель
+
+- Реализовать walk-forward validation как новый research-режим: набор fold-ов с разделением на in-sample (IS) / out-of-sample (OOS), per-fold backtest, агрегация метрик.
+- Поддержать оба режима окна: **rolling** (двигается и начало, и конец) и **anchored** (начало = 0, двигается только конец).
+- Минимальная UI: панель в Lab → Test рядом с `OptimisePanel`.
+- Без изменений ядра execution: `runBacktest` / `dslEvaluator` остаются как есть.
+
+## Решение по форме fold-конфигурации
+
+Конфигурация fold-ов задаётся в условиях **bars** (числу свечей), а не времени, потому что текущий research-стек оперирует датасетами в свечах (см. sweep candle load — `findMany({ orderBy: openTimeMs })`). Это даёт детерминизм независимо от gap-ов в данных.
+
+```ts
+type FoldConfig = {
+  isBars: number;       // длина IS окна
+  oosBars: number;      // длина OOS окна
+  step: number;         // шаг сдвига (обычно = oosBars для непересекающихся OOS)
+  anchored: boolean;    // true: IS всегда от 0; false: rolling
+};
+```
+
+`split(candles, foldCfg)` — pure функция: для `i = 0,1,2,...` возвращает массив fold-ов до тех пор, пока следующий OOS-блок целиком помещается в данные. Лимит: `foldCount ≤ 20` (тот же порядок, что у sweep, чтобы не переусложнять in-process executor).
+
+## Не входит в задачу
+
+- Параметрическая оптимизация внутри IS окна (выбор лучшего параметра по IS, проверка на OOS) — это **walk-forward optimization**, отдельная задача после интеграции с `docs/47`.
+- Multi-asset / portfolio-level walk-forward.
+- Persisted per-fold candle slices в отдельной таблице — храним fold-результаты как JSON.
+- Distributed execution, worker pool, BullMQ — fire-and-forget in-process.
+- Введение `reportVersion` (правило отложено в `docs/49`).
+- Изменения `runBacktest` / `dslEvaluator` ядра.
+- UI для визуализации equity-кривой fold-by-fold (только табличный вывод в первой версии).
+- Кросс-валидация на shuffled-блоках, purging, embargo (advanced techniques) — out of scope.
+
+---
+
+## Задачи
+
+### 48-T1: Pure функция `split` — генерация fold-ов
+
+**Цель:** реализовать чистую детерминированную функцию разбиения массива свечей на IS/OOS fold-ы по `FoldConfig`. Без вызова backtest, без I/O.
+
+**Файлы для изменения:**
+- Создать `apps/api/src/lib/walkForward/split.ts`.
+- Создать `apps/api/src/lib/walkForward/types.ts` — общие типы (`FoldConfig`, `Fold`).
+- Создать `apps/api/tests/lib/walkForward/split.test.ts`.
+
+**Шаги реализации:**
+1. В `types.ts` определить:
+   ```ts
+   export type FoldConfig = { isBars: number; oosBars: number; step: number; anchored: boolean };
+   export type FoldRange = { fromIndex: number; toIndex: number; fromTsMs: number; toTsMs: number };
+   export type Fold = {
+     foldIndex: number;
+     isSlice: Candle[];
+     oosSlice: Candle[];
+     isRange: FoldRange;
+     oosRange: FoldRange;
+   };
+   ```
+2. Реализовать `split(candles: Candle[], cfg: FoldConfig): Fold[]`:
+   - Валидация: `isBars > 0`, `oosBars > 0`, `step > 0`, `candles.length ≥ isBars + oosBars`. Иначе бросать `Error` с понятным сообщением.
+   - Для `i = 0, 1, 2, ...`:
+     - `oosStart = isBars + i * step` (для anchored) ИЛИ `oosStart = isBars + i * step` с `isStart = i * step` (для rolling).
+     - `isStart = anchored ? 0 : i * step`.
+     - `oosEnd = oosStart + oosBars`.
+     - Если `oosEnd > candles.length` → break.
+     - Создать срезы (использовать `Array.prototype.slice`, не мутировать исходный массив).
+     - Заполнить `isRange.fromTsMs/toTsMs` из `candles[isStart].openTimeMs` и `candles[oosEnd-1].openTimeMs` (то же для OOS).
+3. Обеспечить, что для anchored все fold-ы имеют общий начальный индекс 0; для rolling — одинаковую длину IS.
+4. Документировать в JSDoc формулу для каждого режима — это критично для воспроизводимости.
+
+**Тест-план:**
+- 100 свечей, `isBars=50, oosBars=10, step=10, anchored=false` → 5 fold-ов: `[0..50)+[50..60)`, `[10..60)+[60..70)`, ..., `[40..90)+[90..100)`.
+- Тот же набор с `anchored=true` → 5 fold-ов: `[0..50)+[50..60)`, `[0..60)+[60..70)`, ..., `[0..90)+[90..100)` (IS растёт, OOS длиной 10).
+- 100 свечей, `isBars=80, oosBars=30, step=10` → 0 fold-ов (`isBars+oosBars = 110 > 100`) — выбросить ошибку.
+- Граничный: `isBars+oosBars = candles.length` ровно → 1 fold.
+- Иммутабельность: `candles` после `split` не изменён (deep equality).
+- Детерминизм: одинаковый input → одинаковый output (повторный запуск).
+
+**Критерии готовности:**
+- `tsc --noEmit` проходит.
+- Все unit-тесты зелёные.
+- Никаких импортов из `dslEvaluator`, `runBacktest`, БД, Express — pure функция.
+
+---
+
+### 48-T2: `runWalkForward` — per-fold backtest без агрегации
+
+**Цель:** реализовать pure-ish функцию, которая для каждого fold-а из 48-T1 запускает `runBacktest` на IS и на OOS, возвращая полный набор отчётов. Без БД, без HTTP — только in-memory.
+
+**Файлы для изменения:**
+- Создать `apps/api/src/lib/walkForward/run.ts`.
+- Дополнить `apps/api/src/lib/walkForward/types.ts` (`FoldReport`, `WalkForwardReport`).
+- Создать `apps/api/tests/lib/walkForward/run.test.ts`.
+
+**Шаги реализации:**
+1. В `types.ts` добавить:
+   ```ts
+   export type FoldReport = {
+     foldIndex: number;
+     isReport: DslBacktestReport;
+     oosReport: DslBacktestReport;
+     isRange: FoldRange;
+     oosRange: FoldRange;
+   };
+   export type WalkForwardReport = {
+     folds: FoldReport[];
+     // aggregate добавляется в 48-T3
+   };
+   ```
+2. Реализовать `runWalkForward(candles, dslJson, opts: Partial<DslExecOpts>, foldCfg: FoldConfig, onProgress?: (done: number, total: number) => void): WalkForwardReport`:
+   - Получить `folds = split(candles, foldCfg)` (через 48-T1).
+   - Для каждого fold-а: `isReport = runBacktest(fold.isSlice, dslJson, opts, undefined)`, затем `oosReport = runBacktest(fold.oosSlice, dslJson, opts, undefined)` — два независимых вызова.
+   - `mtfContext` оставляем `undefined` в первой версии. Поддержка MTF в walk-forward — отдельная follow-up задача (требует нарезки MTF-контекста синхронно с базовыми свечами).
+   - После каждого fold-а вызывать `onProgress?.(foldIndex + 1, folds.length)` для прогресса в БД-обёртке (48-T5).
+3. `opts.fillAt` пробрасывается как есть; до закрытия `docs/46-T1` поле может отсутствовать в типе и не передаваться.
+4. Обеспечить детерминизм: порядок fold-ов фиксирован (48-T1), `runBacktest` сам по себе детерминирован (по `docs/44`).
+
+**Тест-план:**
+- Smoke: 100 свечей, `isBars=50, oosBars=10, step=10, rolling`, простой DSL-стратегия (например, "buy на каждой N-й свече") → 5 fold-ов в `report.folds`, каждый содержит непустой `isReport.tradeLog` и `oosReport.tradeLog`.
+- Иммутабельность входов: `candles` и `dslJson` после `runWalkForward` не изменены.
+- Прогресс: `onProgress` вызван `folds.length` раз с правильными аргументами.
+- Сравнение: `runBacktest(folds[0].isSlice, dsl, opts)` = `report.folds[0].isReport` (per-fold вызов независим).
+
+**Критерии готовности:**
+- `tsc --noEmit` проходит.
+- Unit-тесты зелёные.
+- Никаких side-effects кроме вызовов `runBacktest`.
+- Импорты: `split` (48-T1), `runBacktest`, типы из `dslEvaluator`. Без БД, без Express.
+
+---
+
+### 48-T3: Aggregate metrics для `WalkForwardReport`
+
+**Цель:** добавить в `WalkForwardReport` поле `aggregate` со сводными метриками по fold-ам, используя метрические утилиты из `docs/49`.
+
+**Файлы для изменения:**
+- `apps/api/src/lib/walkForward/aggregate.ts` (создать).
+- `apps/api/src/lib/walkForward/run.ts` — заполнять `aggregate` после прохода всех fold-ов.
+- Дополнить `apps/api/src/lib/walkForward/types.ts` (`WalkForwardAggregate`).
+- `apps/api/tests/lib/walkForward/aggregate.test.ts` (создать).
+
+**Шаги реализации:**
+1. В `types.ts` добавить:
+   ```ts
+   export type WalkForwardAggregate = {
+     foldCount: number;
+     avgIsPnlPct: number;
+     avgOosPnlPct: number;
+     totalOosPnlPct: number;     // суммарный PnL по OOS-блокам, как индикатор реальной выживаемости
+     avgIsSharpe: number | null;
+     avgOosSharpe: number | null;
+     isOosPnlRatio: number | null;  // avgOosPnlPct / avgIsPnlPct, null если знаменатель 0
+     oosWinFoldShare: number;    // доля fold-ов с OOS pnlPct > 0
+   };
+   ```
+2. Реализовать `aggregate(folds: FoldReport[]): WalkForwardAggregate` как чистую функцию:
+   - `avgIsPnlPct = mean(folds.map(f => f.isReport.pnlPct))`.
+   - `avgOosPnlPct = mean(folds.map(f => f.oosReport.pnlPct))`.
+   - `totalOosPnlPct = sum(folds.map(f => f.oosReport.pnlPct))` (простая сумма; в первой версии не реинвестируем — отметить в комментарии как ограничение).
+   - `avgIsSharpe / avgOosSharpe` — берём `report.sharpe` (после `docs/49-T2`); пропускаем `null`-значения; если все `null` → `null`.
+   - `oosWinFoldShare = count(f => f.oosReport.pnlPct > 0) / folds.length`.
+3. До завершения `docs/49-T2` (когда `report.sharpe` ещё не существует на уровне ядра): использовать локальный fallback — копировать функцию из текущего `computeSharpe` (`apps/api/src/routes/lab.ts:1357`) во временный helper `apps/api/src/lib/walkForward/_localSharpe.ts`. Этот helper удаляется в follow-up PR после `docs/49-T2` — задокументировать TODO в файле.
+4. В `run.ts` в конце `runWalkForward` вызывать `aggregate(folds)` и присвоить результату.
+
+**Тест-план:**
+- Фиксированные фикстуры `FoldReport[]`: 3 fold-а с известными `pnlPct` → проверить все поля aggregate.
+- Все `oosReport.pnlPct = 0` → `oosWinFoldShare = 0`.
+- Все sharpe null → `avgOosSharpe = null`.
+- `avgIsPnlPct = 0` → `isOosPnlRatio = null` (избежать деления на 0).
+
+**Критерии готовности:**
+- `tsc --noEmit` проходит.
+- Unit-тесты зелёные.
+- TODO про `_localSharpe.ts` зафиксирован в файле и в PR-описании.
+- Aggregate чисто функционален (нет I/O).
+
+---
+
+### 48-T4: Prisma модель `WalkForwardRun`
+
+**Цель:** добавить таблицу для хранения запусков walk-forward по структурному шаблону `BacktestSweep`.
+
+**Файлы для изменения:**
+- `apps/api/prisma/schema.prisma`.
+- Новая миграция в `apps/api/prisma/migrations/<timestamp>_add_walk_forward_run/`.
+
+**Шаги реализации:**
+1. В `schema.prisma` добавить enum рядом с `SweepStatus`:
+   ```prisma
+   enum WalkForwardStatus {
+     PENDING
+     RUNNING
+     DONE
+     FAILED
+   }
+   ```
+2. Добавить модель (структурный аналог `BacktestSweep`):
+   ```prisma
+   model WalkForwardRun {
+     id                 String              @id @default(cuid())
+     workspaceId        String
+     strategyVersionId  String
+     datasetId          String
+     status             WalkForwardStatus   @default(PENDING)
+     foldConfigJson     Json
+     foldCount          Int                 @default(0)
+     progress           Float               @default(0) // 0..1
+     foldsJson          Json?               // массив FoldReport (без полных tradeLog'ов — см. шаг 4)
+     aggregateJson      Json?
+     error              String?
+     createdAt          DateTime            @default(now())
+     updatedAt          DateTime            @updatedAt
+     // Индексы по аналогии с BacktestSweep
+     @@index([workspaceId, createdAt])
+     @@index([strategyVersionId])
+   }
+   ```
+3. Связи (`workspace`, `strategyVersion`, `dataset`) — определить так же, как в `BacktestSweep`. Если у этих моделей есть `relation`-поля на родительские стороны — добавить аналогичные (например, `WorkspaceRelation` `walkForwardRuns WalkForwardRun[]`).
+4. Размер `foldsJson`: per-fold отчёт включает `tradeLog`. Для 20 fold-ов с сотнями сделок JSON-объект может стать большим. **Решение для первой версии:** хранить в `foldsJson` усечённую форму — без `tradeLog` каждого fold-а, только метрики (`pnlPct`, `winRate`, `maxDrawdownPct`, `tradeCount`, `sharpe`, ranges, foldIndex). Полный `tradeLog` доступен только в момент исполнения и не сохраняется. Если в будущем понадобится — отдельная задача.
+5. Сгенерировать миграцию (`prisma migrate dev --name add_walk_forward_run`), убедиться, что она additive: только `CREATE TABLE` и `CREATE INDEX`, никаких изменений существующих таблиц.
+
+**Тест-план:**
+- Миграция применяется на чистой БД и на БД со всеми существующими данными — без ошибок.
+- `prisma generate` без warnings.
+- Smoke insert: создание `WalkForwardRun` через `prisma.walkForwardRun.create({ data: {...} })` работает.
+
+**Критерии готовности:**
+- Миграция additive.
+- Schema проходит lint Prisma.
+- Структура повторяет `BacktestSweep` для консистентности.
+
+---
+
+### 48-T5: HTTP эндпоинты — `POST /lab/backtest/walk-forward` и `GET /lab/backtest/walk-forward/:id`
+
+**Цель:** обернуть `runWalkForward` в fire-and-forget эндпоинт по аналогии со sweep, плюс эндпоинт опроса статуса.
+
+**Файлы для изменения:**
+- `apps/api/src/routes/lab.ts` — добавить два новых хэндлера и одну `runWalkForwardAsync`-обёртку.
+- `apps/api/tests/routes/lab.test.ts` — e2e тесты.
+
+**Шаги реализации:**
+1. Определить тело запроса:
+   ```ts
+   type WalkForwardRequestBody = {
+     datasetId: string;
+     strategyVersionId: string;
+     fold: { isBars: number; oosBars: number; step: number; anchored: boolean };
+     feeBps?: number;
+     slippageBps?: number;
+     fillAt?: "OPEN" | "CLOSE";   // только если docs/46-T1 закрыт
+   };
+   ```
+2. `POST /lab/backtest/walk-forward`:
+   - Те же rate limits и concurrency, что у sweep (5/min, max 2 concurrent per workspace) — переиспользовать тот же middleware/счётчик.
+   - Валидировать `fold`: позитивные числа, `isBars + oosBars ≤ candles.length` (после загрузки candles).
+   - **Pre-flight foldCount check:** загрузить candles один раз (то же `findMany` что и у sweep, `apps/api/src/routes/lab.ts:1281–1298`), вызвать `split(candles, fold)`, проверить `folds.length ≤ 20`. Если больше или меньше 1 — 400 с понятным сообщением.
+   - Создать `WalkForwardRun` со `status: PENDING`, `foldCount = folds.length`, `foldConfigJson = fold`, `progress = 0`. Вернуть `{ id }`.
+   - Запустить `runWalkForwardAsync(id, candles, ...)` через `setImmediate` или эквивалент (как `runSweepAsync`, `apps/api/src/routes/lab.ts:1258`) — fire-and-forget, без `await` в обработчике.
+3. `runWalkForwardAsync(id, candles, dslJson, opts, fold)`:
+   - Установить `status: RUNNING`.
+   - Вызвать `runWalkForward(candles, dslJson, opts, fold, onProgress)` где `onProgress(done, total)` обновляет `progress = done / total` в БД (батч-обновление — раз в N fold-ов, чтобы не флудить транзакциями).
+   - После завершения: усечённую форму `folds` (см. 48-T4 шаг 4) сохранить в `foldsJson`, `aggregate` — в `aggregateJson`, `status: DONE`.
+   - При исключении: `status: FAILED`, `error = e.message`. Не пробрасывать ошибку выше (fire-and-forget).
+4. `GET /lab/backtest/walk-forward/:id`:
+   - Те же auth-проверки, что у `GET /lab/backtest/sweep/:id` (`apps/api/src/routes/lab.ts:935`) — workspace ownership.
+   - Возвращать полный объект записи: `{ id, status, progress, foldCount, fold, folds, aggregate, error, createdAt, updatedAt }`.
+5. (Опционально) `GET /lab/backtest/walk-forwards` — list endpoint по аналогии со sweep, если есть запрос со стороны UI; иначе отложить.
+
+**Тест-план:**
+- e2e: POST с валидным fold-конфигом → 201 с `id`; повторный GET через короткий интервал → `status: RUNNING|DONE`; финально `DONE` с непустым `aggregate`.
+- e2e: POST с `isBars + oosBars > candles.length` → 400.
+- e2e: POST с конфигом, дающим `foldCount > 20` → 400.
+- e2e: POST другим workspace + GET с этим workspace → 403/404.
+- e2e: при синтетической ошибке внутри `runBacktest` (моком) → запись имеет `status: FAILED, error: "..."`.
+
+**Критерии готовности:**
+- `tsc --noEmit` проходит.
+- e2e тесты зелёные.
+- Rate limit и concurrency делятся со sweep корректно.
+- Хэндлер не блокирует event loop (fire-and-forget).
+
+---
+
+### 48-T6: Минимальный UI — `WalkForwardPanel`
+
+**Цель:** добавить в Lab → Test панель walk-forward рядом с `OptimisePanel`. Запуск, polling, табличный вывод fold-by-fold + сводка.
+
+**Файлы для изменения:**
+- Создать `apps/web/src/app/lab/test/WalkForwardPanel.tsx`.
+- `apps/web/src/app/lab/test/page.tsx` (или текущий контейнер Test-вкладки) — подключить новую панель.
+
+**Шаги реализации:**
+1. Поля формы: `isBars`, `oosBars`, `step`, `anchored` (toggle), `feeBps`, `slippageBps`, (после `docs/46-T1`) `fillAt`. Дефолты подобрать так, чтобы для типичного датасета на 1000 свечей получалось 4–8 fold-ов (например, `isBars=400, oosBars=100, step=100, anchored=false`).
+2. Превью: до отправки показывать "примерное число fold-ов" — для этого UI не вызывает `split` (она серверная), а считает по той же формуле локально: `floor((N - isBars - oosBars) / step) + 1`. Если значение `> 20` — кнопка disabled с подсказкой.
+3. Запуск: `POST /lab/backtest/walk-forward` → получаем `id` → polling `GET /lab/backtest/walk-forward/:id` каждые `POLL_INTERVAL_MS = 2000` ms (та же константа, что у `OptimisePanel`).
+4. Состояния: `idle | running | done | failed`. Прогрессбар = `progress * 100%`.
+5. Таблица fold-by-fold (после `done`): колонки `Fold #`, `IS range`, `OOS range`, `IS pnl%`, `OOS pnl%`, `OOS winRate`, `OOS maxDD%`, `OOS sharpe` (если есть). Источник — поля из `foldsJson`.
+6. Aggregate-блок: показывать `avgIsPnlPct`, `avgOosPnlPct`, `totalOosPnlPct`, `oosWinFoldShare`, `isOosPnlRatio` со всех fold-ов.
+7. Без графика equity (явно out of scope первой версии).
+
+**Тест-план:**
+- Ручной smoke в браузере:
+  - Корректный конфиг → запуск → polling → таблица + aggregate.
+  - `(N - isBars - oosBars) / step + 1 > 20` → кнопка disabled, подсказка показана.
+  - `isBars + oosBars > N` (видим из preview) → кнопка disabled.
+  - Failed run (синтетический) → видим `error` в UI.
+- Не вводит регрессий в `OptimisePanel` (общая страница рендерится).
+
+**Критерии готовности:**
+- TypeScript-проверка фронтенда проходит.
+- Lab UI рендерится, golden-path запуска и polling работает в браузере.
+- Никаких изменений `OptimisePanel.tsx` или общих компонентов.
+
+---
+
+### 48-T7: Тесты — split, run, aggregate, e2e
+
+**Цель:** покрыть слой walk-forward тестами на трёх уровнях: pure split, pure runner, e2e endpoint.
+
+**Файлы для изменения:**
+- `apps/api/tests/lib/walkForward/split.test.ts` (создать в 48-T1, расширить тут при необходимости).
+- `apps/api/tests/lib/walkForward/run.test.ts` (создать в 48-T2).
+- `apps/api/tests/lib/walkForward/aggregate.test.ts` (создать в 48-T3).
+- `apps/api/tests/routes/lab.test.ts` — добавить блок тестов `/lab/backtest/walk-forward` рядом с существующим блоком sweep (`строки 442–515`).
+
+**Шаги реализации:**
+1. Свести unit-тесты split/run/aggregate в единый зелёный набор. Убедиться, что фикстуры свечей (например, синтетический ramp/sin) одинаковые между файлами — вынести в `apps/api/tests/lib/walkForward/_fixtures.ts`.
+2. e2e блок в `lab.test.ts` (паттерн копировать со sweep, `строки 442–515`):
+   - happy-path POST + polling до `DONE` + проверка `aggregateJson`.
+   - validation 400 (см. 48-T5 тест-план).
+   - workspace isolation 403.
+   - failed-run: подменить `runBacktest` мок-ошибкой, проверить `status=FAILED`.
+3. Все тесты детерминированы: фикстуры зашиты, никаких `Date.now()` без явного контроля, никаких PRNG без seed.
+4. Если walk-forward использует `_localSharpe.ts` (см. 48-T3 шаг 3) — отдельный unit на него; после удаления helper-а в follow-up удалить и этот тест.
+
+**Тест-план:**
+- `npm test` в `apps/api` зелёный.
+- Все тесты walk-forward проходят локально и на CI.
+- Smoke time: e2e тест walk-forward не превышает разумного времени (ориентир: <5s на маленькой фикстуре свечей; жёсткого порога не выставляем).
+
+**Критерии готовности:**
+- Все новые тесты зелёные.
+- Существующие тесты sweep остаются зелёными (изменений в их коде нет).
+- Walk-forward слой имеет покрытие unit-тестами на каждом уровне (split, run, aggregate) + e2e на эндпоинте.
+
+---
+
+## Порядок выполнения задач
+
+```
+48-T1 → 48-T2 → 48-T3 → 48-T4 → 48-T5 → 48-T6 → 48-T7
+```
+
+- 48-T1 первым: pure функция, без зависимостей.
+- 48-T2 после T1: использует `split`.
+- 48-T3 после T2: использует `FoldReport` тип.
+- 48-T4 параллельно с T2/T3 возможно, но удобнее делать последовательно.
+- 48-T5 требует T1–T4 (использует `runWalkForward`, Prisma модель).
+- 48-T6 после T5 (UI вызывает эндпоинт).
+- 48-T7 — последняя задача или встроена инкрементально в каждую предыдущую.
+
+Каждая задача — отдельный PR.
+
+## Зависимости от других документов
+
+- `docs/49` — метрические утилиты (`sharpe`, `profitFactor`, `expectancy`, `maxDrawdownPct`) для `WalkForwardAggregate`. До закрытия `docs/49-T2` aggregate использует временный `_localSharpe.ts` helper (см. 48-T3 шаг 3). Это явный технический долг, удаляется follow-up PR-ом.
+- `docs/46-T1` — поле `fillAt` в `DslExecOpts`. Косвенная: до закрытия `docs/46-T1` `runWalkForward` не передаёт `fillAt` (его в типе нет). После — добавляется в `WalkForwardRequestBody` и пробрасывается.
+- **НЕ зависит от `docs/47`** — walk-forward сам по себе без оптимизации параметров. Walk-forward optimization (комбинация двух) — отдельная задача после стабилизации обоих.
+
+## Backward compatibility checklist
+
+- Walk-forward — полностью новый функционал. Никаких существующих API не модифицируется.
+- Prisma миграция additive (только `CREATE TABLE` для `WalkForwardRun` и нового enum-а).
+- `runBacktest`, `runDslBacktest`, `DslBacktestReport`, `DslTradeRecord`, `DslExecOpts` не изменяются.
+- `apps/web/src/app/lab/` — добавляется новый компонент, существующие компоненты не изменяются.
+- `reportVersion` не вводится (правило отложено в `docs/49`).
+- Метрические утилиты не дублируются вне walk-forward слоя — после `docs/49-T2` локальный sharpe удаляется.
+
+## Ожидаемый результат
+
+После завершения всех задач:
+- Walk-forward доступен как новый research-режим в Lab → Test.
+- Поддерживаются оба режима окна (rolling, anchored), задаваемые в bars.
+- Лимит `foldCount ≤ 20` соблюдён, fire-and-forget без BullMQ/worker pool.
+- Per-fold метрики и сводный aggregate сохранены в БД и доступны через poll-эндпоинт.
+- UI позволяет запустить walk-forward, отслеживать прогресс и видеть результаты fold-by-fold.
+- Ядро execution (`runBacktest`, `dslEvaluator`) не изменено.
+- Слой walk-forward готов к интеграции с `docs/47` (walk-forward optimization) как отдельная follow-up задача.

--- a/docs/48-walk-forward-plan.md
+++ b/docs/48-walk-forward-plan.md
@@ -82,13 +82,14 @@ type FoldConfig = {
    ```
 2. Реализовать `split(candles: Candle[], cfg: FoldConfig): Fold[]`:
    - Валидация: `isBars > 0`, `oosBars > 0`, `step > 0`, `candles.length ≥ isBars + oosBars`. Иначе бросать `Error` с понятным сообщением.
+   - **Не валидировать** `step >= oosBars` (overlapping OOS). Перекрытие — методологически неоптимально (одна сделка может попасть в OOS двух соседних fold-ов и исказить aggregate), но в некоторых research-сценариях допустимо. Решение: разрешить любые `step > 0`, при `step < oosBars` возвращать дополнительное warning из endpoint-а 48-T5 (поле `warnings: string[]` в response), сам `split` остаётся pure и не имеет понятия о "warning-канале". Фиксировать соглашение в JSDoc функции.
    - Для `i = 0, 1, 2, ...`:
      - `oosStart = isBars + i * step` (для anchored) ИЛИ `oosStart = isBars + i * step` с `isStart = i * step` (для rolling).
      - `isStart = anchored ? 0 : i * step`.
      - `oosEnd = oosStart + oosBars`.
      - Если `oosEnd > candles.length` → break.
      - Создать срезы (использовать `Array.prototype.slice`, не мутировать исходный массив).
-     - Заполнить `isRange.fromTsMs/toTsMs` из `candles[isStart].openTimeMs` и `candles[oosEnd-1].openTimeMs` (то же для OOS).
+     - Заполнить `isRange.fromTsMs/toTsMs` из `candles[isStart].openTime` и `candles[oosEnd-1].openTime` (то же для OOS). Поле на TS-интерфейсе `Candle` (`apps/api/src/lib/bybitCandles.ts:85-86`) называется `openTime: number; // ms` — значение уже в миллисекундах, так что отдельной конверсии не нужно. **Не путать с Prisma-полем** `MarketCandle.openTimeMs` — это другой слой; конверсия `openTimeMs → openTime` уже сделана в `apps/api/src/routes/lab.ts:1291-1292`.
 3. Обеспечить, что для anchored все fold-ы имеют общий начальный индекс 0; для rolling — одинаковую длину IS.
 4. Документировать в JSDoc формулу для каждого режима — это критично для воспроизводимости.
 
@@ -135,6 +136,7 @@ type FoldConfig = {
    - Получить `folds = split(candles, foldCfg)` (через 48-T1).
    - Для каждого fold-а: `isReport = runBacktest(fold.isSlice, dslJson, opts, undefined)`, затем `oosReport = runBacktest(fold.oosSlice, dslJson, opts, undefined)` — два независимых вызова.
    - `mtfContext` оставляем `undefined` в первой версии. Поддержка MTF в walk-forward — отдельная follow-up задача (требует нарезки MTF-контекста синхронно с базовыми свечами).
+   - **Pre-flight rejection MTF-стратегий**: до запуска `split` валидировать `dslJson` — если найден хотя бы один индикатор с непустым `sourceTimeframe` (`apps/api/src/lib/dslEvaluator.ts:101`), возвращать 400 на эндпоинте 48-T5 с сообщением `"Walk-forward для MTF-стратегий не реализован: индикатор '<type>' использует sourceTimeframe='<tf>'. См. follow-up к docs/48."`. Это явный safety-gate против silent degraded-результата (без MTF-контекста индикатор фоллбэчится на primary TF и даёт другие сигналы).
    - После каждого fold-а вызывать `onProgress?.(foldIndex + 1, folds.length)` для прогресса в БД-обёртке (48-T5).
 3. `opts.fillAt` пробрасывается как есть; до закрытия `docs/46-T1` поле может отсутствовать в типе и не передаваться.
 4. Обеспечить детерминизм: порядок fold-ов фиксирован (48-T1), `runBacktest` сам по себе детерминирован (по `docs/44`).
@@ -239,7 +241,10 @@ type FoldConfig = {
      @@index([strategyVersionId])
    }
    ```
-3. Связи (`workspace`, `strategyVersion`, `dataset`) — определить так же, как в `BacktestSweep`. Если у этих моделей есть `relation`-поля на родительские стороны — добавить аналогичные (например, `WorkspaceRelation` `walkForwardRuns WalkForwardRun[]`).
+3. Связи — **зеркалить точный паттерн `BacktestSweep`** (`apps/api/prisma/schema.prisma:686–708`):
+   - `workspace Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)` в самой `WalkForwardRun`.
+   - `walkForwardRuns WalkForwardRun[]` добавить в model `Workspace` (line 44, рядом с `backtestSweeps BacktestSweep[]` line 61).
+   - `strategyVersionId` и `datasetId` — простые foreign-key поля **без `@relation`**. Это сознательный выбор `BacktestSweep` (там у них тоже нет inverse relation на `StrategyVersion` / `MarketDataset`); удаление родительских записей не каскадится в research-логи.
 4. Размер `foldsJson`: per-fold отчёт включает `tradeLog`. Для 20 fold-ов с сотнями сделок JSON-объект может стать большим. **Решение для первой версии:** хранить в `foldsJson` усечённую форму — без `tradeLog` каждого fold-а, только метрики (`pnlPct`, `winRate`, `maxDrawdownPct`, `tradeCount`, `sharpe`, ranges, foldIndex). Полный `tradeLog` доступен только в момент исполнения и не сохраняется. Если в будущем понадобится — отдельная задача.
 5. Сгенерировать миграцию (`prisma migrate dev --name add_walk_forward_run`), убедиться, что она additive: только `CREATE TABLE` и `CREATE INDEX`, никаких изменений существующих таблиц.
 
@@ -276,7 +281,7 @@ type FoldConfig = {
    };
    ```
 2. `POST /lab/backtest/walk-forward`:
-   - Те же rate limits и concurrency, что у sweep (5/min, max 2 concurrent per workspace) — переиспользовать тот же middleware/счётчик.
+   - Rate limit: `5/min per workspace` — отдельный счётчик от sweep (свой Fastify rate-limit instance). Concurrency: **shared с sweep** — общая capacity `2 одновременно (sweep + walk-forward) per workspace`. Это намеренно: и sweep, и walk-forward — heavy in-process backtest jobs, без общего лимита один пользователь сможет загрузить event loop четырьмя параллельными запусками. Реализация: вынести существующий sweep-counter (`apps/api/src/routes/lab.ts` рядом со sweep handler-ом, `строка 902`) в shared workspace-level Map<string, number> и инкрементировать/декрементировать обоими handler-ами. Превышение → 429 с сообщением `"max 2 concurrent backtest jobs (sweep+walk-forward) per workspace"`.
    - Валидировать `fold`: позитивные числа, `isBars + oosBars ≤ candles.length` (после загрузки candles).
    - **Pre-flight foldCount check:** загрузить candles один раз (то же `findMany` что и у sweep, `apps/api/src/routes/lab.ts:1281–1298`), вызвать `split(candles, fold)`, проверить `folds.length ≤ 20`. Если больше или меньше 1 — 400 с понятным сообщением.
    - Создать `WalkForwardRun` со `status: PENDING`, `foldCount = folds.length`, `foldConfigJson = fold`, `progress = 0`. Вернуть `{ id }`.

--- a/docs/48-walk-forward-plan.md
+++ b/docs/48-walk-forward-plan.md
@@ -18,7 +18,7 @@
 - Шаблон fire-and-forget run-эндпоинта со статусной БД-моделью: sweep — `runSweepAsync` (`apps/api/src/routes/lab.ts:1258`), статусы `PENDING|RUNNING|DONE|FAILED` (`apps/api/prisma/schema.prisma:677`). Walk-forward повторяет этот паттерн.
 - Структурный шаблон Prisma модели: `BacktestSweep` (`apps/api/prisma/schema.prisma:686–708`) — поля `id`, `workspaceId`, `strategyVersionId`, `datasetId`, `status`, `progress`, `*Json`. Walk-forward Prisma модель повторяет ту же структуру.
 - Хранилище per-fold отчётов: можно использовать существующую `BacktestResult` (`apps/api/prisma/schema.prisma:578–619`) как референс структуры; в первом этапе храним fold-отчёты как JSON внутри родительской записи, без отдельной таблицы.
-- Метрики: `apps/api/src/lib/metrics.ts` сейчас содержит только Prometheus (`Registry`, `collectDefaultMetrics`, `Counter`, `Histogram`). Папка `apps/api/src/lib/metrics/` ещё **не создана** — она появится в `docs/49-T1` и принесёт `sharpe`, `profitFactor`, `expectancy`, `maxDrawdownPct` и т.п. Walk-forward aggregate использует именно эти функции после `docs/49`.
+- Метрики: `apps/api/src/lib/metrics.ts` сейчас содержит только Prometheus (`Registry`, `collectDefaultMetrics`, `Counter`, `Histogram`) и не относится к backtest-метрикам. Папка `apps/api/src/lib/backtestMetrics/` ещё **не создана** — она появится в `docs/49-T1` и принесёт pure-функции `sharpeRatio`, `profitFactor`, `expectancy`. `maxDrawdownPct` остаётся в `dslEvaluator.ts` (уже вычисляется там через `cumulativePnl/peakPnl`). Walk-forward aggregate использует утилиты из `backtestMetrics/` и поля `report.sharpe` / `report.profitFactor` / `report.expectancy` (появляются в `DslBacktestReport` после `docs/49-T2`).
 - В `apps/web/src/app/lab/` walk-forward UI отсутствует.
 
 ## Цель
@@ -272,7 +272,7 @@ type FoldConfig = {
      fold: { isBars: number; oosBars: number; step: number; anchored: boolean };
      feeBps?: number;
      slippageBps?: number;
-     fillAt?: "OPEN" | "CLOSE";   // только если docs/46-T1 закрыт
+     fillAt?: "OPEN" | "CLOSE" | "NEXT_OPEN";   // только если docs/46-T1 закрыт
    };
    ```
 2. `POST /lab/backtest/walk-forward`:

--- a/docs/49-backtest-metrics-plan.md
+++ b/docs/49-backtest-metrics-plan.md
@@ -1,0 +1,360 @@
+# 49. Backtest Metrics Plan
+
+Статус: draft  
+Владелец: core trading / lab  
+Последнее обновление: 2026-04-27  
+Родительский документ: `docs/44-strategy-engine-overview.md`  
+Дорожка: A (research workflow)
+
+## Контекст
+
+Текущее состояние (проверено по коду):
+
+- `DslBacktestReport` сейчас содержит **только базовые** метрики: `trades`, `wins`, `winrate`, `totalPnlPct`, `maxDrawdownPct`, `candles`, `tradeLog` (`apps/api/src/lib/dslEvaluator.ts:68–76`). Нет `sharpe`, `profitFactor`, `expectancy`.
+- Sharpe считается **локально** в роутере sweep-а: `function computeSharpe(pnlPcts: number[]): number | null` (`apps/api/src/routes/lab.ts:1420–1427`). Реализация: mean/stdDev по trade-pnl, аннуализация `Math.sqrt(252)`. Используется единственный раз — в `runSweepAsync` (`apps/api/src/routes/lab.ts:1358`).
+- `SweepRow.sharpe: number | null` (`apps/api/src/routes/lab.ts:1251`) пишется из локального `computeSharpe`, не из `report`.
+- Compare-эндпоинт `/lab/compare` уже читает `reportA.sharpe` / `reportB.sharpe` из `reportJson` (`apps/api/src/routes/lab.ts:661`), но в текущем `DslBacktestReport` поля `sharpe` **нет** — соответственно `reportJson.sharpe` всегда `undefined`, и `sharpeDelta` всегда `null`. Это скрытая мёртвая ветка.
+- `apps/api/src/lib/metrics.ts` — Prometheus-only (`Registry`, `collectDefaultMetrics`, `Counter`, `Histogram`); экспортирует runtime-counters, импортируется в 8 местах (`app.ts`, `botWorker.ts`, `periodicReconciler.ts`, `worker/intentExecutor.ts`, `routes/intents.ts`, `routes/metrics.ts`, тесты). К backtest-метрикам отношения не имеет — переименовывать его в этом этапе **не будем** (см. "Решение по неймингу").
+- `maxDrawdownPct` уже корректно вычисляется в `runDslBacktest` через `cumulativePnl/peakPnl/maxDrawdownPct` (`apps/api/src/lib/dslEvaluator.ts:917–919` и далее по коду) — оставляется без правок.
+- `DslTradeRecord.pnlPct` (`apps/api/src/lib/dslEvaluator.ts:50–66`) — единственный источник для всех trade-level метрик.
+- Тесты: ядро покрыто `apps/api/tests/lib/dslEvaluator.test.ts`, sweep — `apps/api/tests/routes/lab.test.ts:442–515`. Тестов на sharpe/profitFactor/expectancy в текущей кодобазе **нет**.
+
+## Цель
+
+- Вынести вычисление backtest-метрик из роутера в pure-модуль рядом с `dslEvaluator`.
+- Расширить `DslBacktestReport` дополнительными полями `sharpe`, `profitFactor`, `expectancy` (additive, optional на уровне типа для backward compat — но всегда заполняется ядром).
+- Удалить локальный `computeSharpe` из `lab.ts`; sweep и compare читают значения напрямую из отчёта.
+- Зафиксировать политику относительно `reportVersion` — здесь принимается решение, не в `docs/44` (там правило про "вводить, если нельзя дополнить additive" обозначено, но триггер не определён).
+- Подготовить наполнение для `rankBy` в `docs/47-T4`: `sharpe`, `profitFactor`, `expectancy` должны существовать на уровне отчёта.
+
+## Решение по неймингу модуля
+
+Существующий `apps/api/src/lib/metrics.ts` (Prometheus, 8 importer-ов) **не переименовывается** — это отдельный домен (HTTP/runtime observability), переименование вне scope этого документа и потребовало бы trivial-massnetuptan правок во всех importer-ах ради семантики.
+
+Новый модуль: **`apps/api/src/lib/backtestMetrics/`** (директория). Имя устраняет коллизию с `metrics.ts` и однозначно описывает домен (статистики по результатам backtest-а). Альтернативы (`stats/`, `perfMetrics/`, `reportMetrics/`) рассмотрены и отклонены: они менее самодокументируемы.
+
+Структура:
+
+```
+apps/api/src/lib/backtestMetrics/
+  index.ts          // re-exports
+  sharpe.ts         // sharpeRatio(returns, periodsPerYear)
+  profitFactor.ts   // profitFactor(returns)
+  expectancy.ts     // expectancy(returns)
+  types.ts          // shared MetricInput type if needed
+```
+
+## Решение по `reportVersion`
+
+`reportVersion` **не вводится в этом этапе**. Триггер для введения:
+
+> Поле или семантика существующего поля `DslBacktestReport` или `DslTradeRecord` меняется несовместимо (переименование, изменение типа, изменение единиц измерения, изменение знака). Additive (новые опциональные поля) — НЕ триггер.
+
+Текущие изменения 49-T2 — additive (новые поля `sharpe`, `profitFactor`, `expectancy`). Поэтому `reportVersion` не нужен. Когда триггер сработает (первое несовместимое изменение) — вводится поле `reportVersion: 1` в `DslBacktestReport`, существующие записи без поля интерпретируются как `reportVersion: 0`. Это решение фиксируется в `docs/44 §Backward compatibility` отдельной правкой шапки документа в рамках 49-T2.
+
+## Не входит в задачу
+
+- Sortino, Calmar, Omega, MAR ratio, Tail ratio. Sortino и Calmar — наиболее ценные follow-up (после стабилизации sharpe/PF/expectancy); добавляются отдельным PR.
+- Per-side метрики (long-only / short-only sharpe, etc.).
+- Equity curve / drawdown timeseries в отчёте (сейчас только `maxDrawdownPct` скаляр; timeseries требует значительного увеличения размера `reportJson` и хранения — отдельный план).
+- Confidence intervals, bootstrap, statistical significance — out of scope.
+- Реализация UI-визуализации новых метрик за пределами уже существующих snapshot/compare таблиц.
+- Изменения формы `DslTradeRecord` — все метрики строятся над уже существующим `pnlPct`.
+- Переименование `apps/api/src/lib/metrics.ts` или его importer-ов.
+- Изменения Prometheus-метрик. Этот документ **не** про observability.
+
+---
+
+## Задачи
+
+### 49-T1: Создать модуль `backtestMetrics/` с pure-функциями
+
+**Цель:** вынести вычисление статистик в изолированный модуль с unit-покрытием. Без зависимостей от БД, Express, dslEvaluator.
+
+**Файлы для изменения:**
+- Создать `apps/api/src/lib/backtestMetrics/sharpe.ts`.
+- Создать `apps/api/src/lib/backtestMetrics/profitFactor.ts`.
+- Создать `apps/api/src/lib/backtestMetrics/expectancy.ts`.
+- Создать `apps/api/src/lib/backtestMetrics/index.ts`.
+- Создать `apps/api/tests/lib/backtestMetrics/sharpe.test.ts`.
+- Создать `apps/api/tests/lib/backtestMetrics/profitFactor.test.ts`.
+- Создать `apps/api/tests/lib/backtestMetrics/expectancy.test.ts`.
+
+**Шаги реализации:**
+1. `sharpe.ts`:
+   ```ts
+   /**
+    * Annualized Sharpe ratio over per-trade pnl percentages.
+    * Mirrors the existing computeSharpe implementation in lab.ts:1420 bit-for-bit
+    * to preserve numerical compatibility with prior sweep results.
+    */
+   export function sharpeRatio(pnlPcts: number[], periodsPerYear = 252): number | null {
+     if (pnlPcts.length < 2) return null;
+     const mean = pnlPcts.reduce((s, v) => s + v, 0) / pnlPcts.length;
+     const variance = pnlPcts.reduce((s, v) => s + (v - mean) ** 2, 0) / (pnlPcts.length - 1);
+     const stdDev = Math.sqrt(variance);
+     if (stdDev === 0) return null;
+     return Math.round((mean / stdDev) * Math.sqrt(periodsPerYear) * 100) / 100;
+   }
+   ```
+   Параметр `periodsPerYear` — default 252 (соответствует существующему хардкоду). Документировать ограничение: "treats per-trade returns as if they were daily; a more accurate annualization requires per-bar returns and is left as future work".
+2. `profitFactor.ts`:
+   ```ts
+   /**
+    * Profit factor = sum(positive pnl%) / |sum(negative pnl%)|.
+    * Conventions:
+    *   - Empty array → null.
+    *   - All wins, no losses → +Infinity (consumers must handle this explicitly,
+    *     e.g. ranking treats Infinity as "best").
+    *   - All losses → 0.
+    */
+   export function profitFactor(pnlPcts: number[]): number | null {
+     if (pnlPcts.length === 0) return null;
+     let gross = 0;
+     let loss = 0;
+     for (const v of pnlPcts) { if (v > 0) gross += v; else if (v < 0) loss += -v; }
+     if (loss === 0 && gross === 0) return null;
+     if (loss === 0) return Number.POSITIVE_INFINITY;
+     return Math.round((gross / loss) * 100) / 100;
+   }
+   ```
+3. `expectancy.ts`:
+   ```ts
+   /**
+    * Per-trade expectancy in percent units:
+    *   E = winRate * avgWin - lossRate * avgLoss
+    * where avgWin = mean(positive pnl%), avgLoss = mean(|negative pnl%|).
+    * Empty array → null. Single trade → returns its own pnl% (degenerate case).
+    */
+   export function expectancy(pnlPcts: number[]): number | null {
+     if (pnlPcts.length === 0) return null;
+     const wins = pnlPcts.filter(v => v > 0);
+     const losses = pnlPcts.filter(v => v < 0).map(v => -v);
+     const winRate = wins.length / pnlPcts.length;
+     const lossRate = losses.length / pnlPcts.length;
+     const avgWin = wins.length ? wins.reduce((s, v) => s + v, 0) / wins.length : 0;
+     const avgLoss = losses.length ? losses.reduce((s, v) => s + v, 0) / losses.length : 0;
+     return Math.round((winRate * avgWin - lossRate * avgLoss) * 100) / 100;
+   }
+   ```
+4. `index.ts`:
+   ```ts
+   export { sharpeRatio } from "./sharpe.js";
+   export { profitFactor } from "./profitFactor.js";
+   export { expectancy } from "./expectancy.js";
+   ```
+5. Никаких side-effects, никаких импортов из `dslEvaluator`, БД, Express.
+
+**Тест-план:**
+- `sharpe`: пустой, 1-элемент → null. Constant series → null (stdDev=0). Известная синтетика (mean=1, stdDev=1, n=10, periodsPerYear=252) → assert на ожидаемое число. Negative mean → отрицательный sharpe.
+- `sharpe`: bit-for-bit совпадение со старой `computeSharpe` из `lab.ts:1420` на 5 фикстурах разной формы (см. 49-T3 — там сверка обязательна).
+- `profitFactor`: пустой → null. Все wins → `+Infinity`. Все losses → 0. Mixed: 2 wins по +5% и 1 loss -5% → 2.0.
+- `expectancy`: пустой → null. 50/50 win/loss с одинаковыми абс. величинами → 0. Asymmetric: 60% wins по +2, 40% losses по -1 → 1.2 - 0.4 = 0.80.
+- Numerical edge cases: `NaN`/`Infinity` на входе — поведение не специфицируется (assume callers пропускают их). Документировать в JSDoc.
+
+**Критерии готовности:**
+- `tsc --noEmit` проходит.
+- Все unit-тесты зелёные.
+- Никаких импортов из `dslEvaluator`, БД, Express.
+- `sharpeRatio` бит-в-бит соответствует существующей `computeSharpe` (golden test).
+
+---
+
+### 49-T2: Расширить `DslBacktestReport` метриками; заполнять в `runDslBacktest`
+
+**Цель:** добавить optional поля `sharpe`, `profitFactor`, `expectancy` в отчёт, заполнять их через утилиты из 49-T1. Изменение строго additive.
+
+**Файлы для изменения:**
+- `apps/api/src/lib/dslEvaluator.ts` — `DslBacktestReport` (`строка 68`), финальный `return` (`строка 1198`).
+- `apps/api/tests/lib/dslEvaluator.test.ts` — расширить тест-кейсы.
+- `docs/44-strategy-engine-overview.md` — внести правило о триггере `reportVersion` в `§Backward compatibility` (см. "Решение по `reportVersion`" в этом документе).
+
+**Шаги реализации:**
+1. Расширить тип:
+   ```ts
+   export interface DslBacktestReport {
+     trades: number;
+     wins: number;
+     winrate: number;
+     totalPnlPct: number;
+     maxDrawdownPct: number;
+     candles: number;
+     tradeLog: DslTradeRecord[];
+     // additive (49-T2)
+     sharpe: number | null;
+     profitFactor: number | null;
+     expectancy: number | null;
+   }
+   ```
+   Поля required (не optional) — это упрощает использование на стороне consumer-ов (`rankBy` в 47-T4, aggregate в 48-T3, sweep в 49-T3). `null` явно используется для "нельзя вычислить" (мало сделок, stdDev=0, и т.п.).
+2. **Backward compat**: чтобы не сломать существующих consumer-ов, которые могут читать `reportJson` старых записей (где новых полей нет), TypeScript-тип внешнего API (`BacktestReport` re-export в `backtest.ts:22`) сохраняется тот же, но при чтении из `reportJson` нужно обрабатывать `undefined` → `null`. Это уже частично сделано в compare-эндпоинте (`apps/api/src/routes/lab.ts:650` через хелпер `num`).
+3. В `runDslBacktest` после построения `tradeLog` и до `return`:
+   ```ts
+   const pnlPcts = tradeLog.map(t => t.pnlPct);
+   const sharpe = sharpeRatio(pnlPcts);
+   const pf = profitFactor(pnlPcts);
+   const exp = expectancy(pnlPcts);
+   ```
+   Импортировать из `./backtestMetrics/index.js`.
+4. Возвращаемый объект:
+   ```ts
+   return {
+     trades, wins,
+     winrate: Math.round(winrate * 10000) / 10000,
+     totalPnlPct: Math.round(totalPnlPct * 100) / 100,
+     maxDrawdownPct: Math.round(maxDrawdownPct * 100) / 100,
+     candles: candles.length,
+     tradeLog,
+     sharpe,
+     profitFactor: pf,
+     expectancy: exp,
+   };
+   ```
+5. `emptyReport` (`строка 853`) тоже обновить:
+   ```ts
+   const emptyReport: DslBacktestReport = {
+     trades: 0, wins: 0, winrate: 0, totalPnlPct: 0, maxDrawdownPct: 0,
+     candles: candles.length, tradeLog: [],
+     sharpe: null, profitFactor: null, expectancy: null,
+   };
+   ```
+6. Обновить `docs/44 §Backward compatibility`: добавить пункт "reportVersion введётся при первом несовместимом изменении формы DslBacktestReport / DslTradeRecord (rename, type change, unit change). Additive optional/required-with-null поля — НЕ триггер." Это явное закрепление правила, цитируется из `docs/49`.
+
+**Тест-план:**
+- Существующие тесты `dslEvaluator.test.ts` зелёные с минимальной правкой (добавить новые поля в expected fixtures, или использовать `expect.objectContaining` для частичного match-а).
+- Новый кейс: backtest с известным winrate/avg-pnl → `sharpe`, `profitFactor`, `expectancy` совпадают с тем, что вернёт прямой вызов утилит на тех же `pnlPct`.
+- Empty backtest (нет сделок) → `sharpe = null`, `profitFactor = null`, `expectancy = null`.
+- 1 сделка → `sharpe = null` (нужно ≥ 2 для stdDev), `profitFactor` и `expectancy` определены.
+
+**Критерии готовности:**
+- `tsc --noEmit` проходит.
+- Все существующие тесты зелёные.
+- Новые поля присутствуют в каждом возвращённом отчёте.
+- `docs/44` обновлён правилом `reportVersion`.
+
+---
+
+### 49-T3: Удалить локальный `computeSharpe`; sweep и compare читают `report.sharpe`
+
+**Цель:** убрать дублирование. После 49-T2 `report.sharpe` доступен из ядра — локальный `computeSharpe` больше не нужен. Заодно проверяем, что compare-эндпоинт корректно читает новые поля.
+
+**Файлы для изменения:**
+- `apps/api/src/routes/lab.ts` — удалить функцию (`строки 1420–1427`), заменить вызов в sweep (`строка 1358`), обновить delta в compare (`строки 661–663`).
+- `apps/api/tests/routes/lab.test.ts` — расширить sweep тесты для проверки `SweepRow.sharpe`.
+
+**Шаги реализации:**
+1. В `runSweepAsync` (`строка 1358`): заменить
+   ```ts
+   const sharpe = computeSharpe(report.tradeLog.map((t) => t.pnlPct));
+   ```
+   на
+   ```ts
+   const sharpe = report.sharpe;
+   ```
+   Поведение идентично — `report.sharpe` после 49-T2 заполняется через `sharpeRatio(...)`, которая бит-в-бит копия `computeSharpe` (см. 49-T1 шаг 1 docstring).
+2. Удалить функцию `computeSharpe` (`строки 1420–1427`) полностью. Никаких `_computeSharpe`-комментариев и backwards-compat шимов — функция нигде кроме `runSweepAsync` не используется (проверено: `grep -rn "computeSharpe" apps/api`).
+3. В compare-эндпоинте (`строки 647–663`): добавить `profitFactorDelta` и `expectancyDelta`:
+   ```ts
+   profitFactorDelta: num(reportA.profitFactor) !== null && num(reportB.profitFactor) !== null
+     ? (num(reportA.profitFactor)! - num(reportB.profitFactor)!) : null,
+   expectancyDelta: num(reportA.expectancy) !== null && num(reportB.expectancy) !== null
+     ? (num(reportA.expectancy)! - num(reportB.expectancy)!) : null,
+   ```
+   `sharpeDelta` остаётся как есть — после 49-T2 `reportA.sharpe` будет ненулевым для новых записей.
+4. **Старые `BacktestResult` без новых полей**: `num()` хелпер возвращает `null` для `undefined` — это уже корректное поведение, дельта = `null`. Никаких миграций reportJson-блоков делать **не надо**.
+5. Расширить `SweepRow` и схему ответа sweep — `profitFactor: number | null`, `expectancy: number | null` — additive поля. Для backward compat с UI: новые поля optional на TS-уровне; UI показывает их при наличии. Это подготавливает почву для `rankBy ∈ {profitFactor, expectancy}` в `docs/47-T4`.
+
+**Тест-план:**
+- Sweep e2e: новый запрос → `SweepRow.sharpe` совпадает с тем, что вернул бы прежний `computeSharpe` на тех же trade-pnl-ах. Использовать golden-тест с известной фикстурой свечей.
+- Sweep e2e: `SweepRow.profitFactor` и `SweepRow.expectancy` присутствуют в ответе.
+- Compare endpoint: два BacktestResult-а после 49-T2 → `sharpeDelta`, `profitFactorDelta`, `expectancyDelta` ненулевые при разных reportJson-ах.
+- Compare endpoint: один из BacktestResult-ов pre-49 (старый reportJson без `sharpe`) → дельты возвращают `null` без ошибок.
+- `grep "computeSharpe" apps/api` — пусто (функция удалена).
+
+**Критерии готовности:**
+- `tsc --noEmit` проходит.
+- `computeSharpe` удалён.
+- Существующие sweep тесты зелёные (с обновлёнными expected-полями).
+- Compare-эндпоинт работает на смеси старых и новых BacktestResult-ов.
+
+---
+
+### 49-T4: Тесты и golden values
+
+**Цель:** зафиксировать численные контракты utilities + report-shape + интеграцию с sweep/compare.
+
+**Файлы для изменения:**
+- `apps/api/tests/lib/backtestMetrics/*.test.ts` (созданы в 49-T1) — расширить если нужно.
+- `apps/api/tests/lib/dslEvaluator.test.ts` — golden report shape.
+- `apps/api/tests/routes/lab.test.ts` — sweep golden + compare smoke.
+
+**Шаги реализации:**
+1. Добавить файл `apps/api/tests/lib/backtestMetrics/_fixtures.ts` с 5 эталонными массивами `pnlPcts`:
+   - `EMPTY: []`
+   - `SINGLE_WIN: [3.5]`
+   - `MIXED_BALANCED: [2, -1, 3, -2, 1]`
+   - `ALL_WINS: [1.5, 2.0, 0.5]`
+   - `ALL_LOSSES: [-1, -2, -0.5]`
+   Для каждой — заранее посчитанные expected `sharpe`, `profitFactor`, `expectancy` (можно посчитать в Python/калькуляторе и зашить как комментарий с формулой).
+2. Прогнать каждую утилиту по фикстурам, assert на ожидаемые значения.
+3. **Bit-for-bit regression vs old `computeSharpe`**: сохранить копию старой функции `computeSharpe` в `apps/api/tests/lib/backtestMetrics/_legacySharpe.ts` как archived reference; тест проверяет, что для каждой фикстуры `sharpeRatio(x) === _legacySharpe(x)`. Файл `_legacySharpe.ts` помечен deprecated, удаляется через 1 minor release или после явного решения core-команды.
+4. В `dslEvaluator.test.ts`: golden фикстура с известным `tradeLog` → проверить, что `report.sharpe`, `report.profitFactor`, `report.expectancy` совпадают с прямым вызовом утилит на `tradeLog.map(t => t.pnlPct)`.
+5. В `lab.test.ts`:
+   - Sweep golden: запуск sweep на синтетической стратегии → `SweepRow[i].sharpe` за 1 row совпадает с прямым `sharpeRatio(...)`.
+   - Compare smoke: создать 2 BacktestResult с разными reportJson → `sharpeDelta`, `profitFactorDelta`, `expectancyDelta` корректны.
+   - Compare back-compat: один reportJson pre-49 (без новых полей) → дельты null, нет 500.
+6. Все тесты детерминированы: фикстуры зашиты, никаких `Date.now()`, никаких PRNG.
+
+**Тест-план:**
+- `npm test` (apps/api) полностью зелёный.
+- Bit-for-bit regression vs `_legacySharpe.ts` зелёный.
+- Compare smoke на смеси записей зелёный.
+
+**Критерии готовности:**
+- Все новые тесты зелёные.
+- `_legacySharpe.ts` присутствует с пометкой "deprecated, planned for removal".
+- Golden-таблица фикстур закоммичена с комментарием "do not edit without justification".
+
+---
+
+## Порядок выполнения задач
+
+```
+49-T1 → 49-T2 → 49-T3 → 49-T4
+```
+
+Каждая задача — отдельный PR.
+
+- T1 первой: pure utilities, без зависимостей.
+- T2 после T1: использует утилиты, расширяет публичный отчёт. Также правит `docs/44` (правило `reportVersion`).
+- T3 после T2: миграция consumer-ов на новые поля.
+- T4 — последняя задача или встроена инкрементально в T1..T3.
+
+## Зависимости от других документов
+
+- **`docs/47-T4`** (rankBy multi-metric) — становится исполнимым только после 49-T2 (поля `sharpe`, `profitFactor`, `expectancy` появляются в `DslBacktestReport`). Если 47-T4 запускается до 49-T2 — реализуется только `rankBy="pnlPct"`-ветка с 400 для остальных значений (см. 47-T4 шаг 2).
+- **`docs/48-T3`** (walk-forward aggregate) — использует `report.sharpe`. До 49-T2 использует временный `_localSharpe.ts` helper (см. 48-T3 шаг 3); после 49-T2 follow-up PR удаляет helper.
+- **`docs/44`** — обновляется в 49-T2 (правило `reportVersion`).
+- **`docs/46`** — независим. 46 и 49 могут идти параллельно.
+- **`docs/45`** — независим.
+
+## Backward compatibility checklist
+
+- `DslBacktestReport`-расширение additive: добавлены `sharpe`, `profitFactor`, `expectancy` (required, могут быть `null`).
+- Существующие `BacktestResult.reportJson` записи без новых полей — корректно обрабатываются: `num(reportA.sharpe)` возвращает `null`, дельты в compare возвращают `null`. Никаких миграций reportJson-блоков.
+- `computeSharpe` удалён, но его поведение бит-в-бит сохранено в `sharpeRatio` (см. 49-T1 + 49-T4 regression test).
+- `engineVersion` уже фиксирует версию engine — старые записи интерпретируются по своему `engineVersion`.
+- `SweepRow.sharpe` сохраняет тот же тип `number | null` и те же численные значения, что были до 49-T3 (regression test обязателен).
+- `reportVersion` **не вводится** — все правки additive.
+- `apps/api/src/lib/metrics.ts` (Prometheus) не затрагивается.
+- Frontend snapshot/compare-таблицы продолжают работать на старых записях; новые поля показываются как "—" при `null`.
+
+## Ожидаемый результат
+
+После завершения всех задач:
+- Backtest-метрики `sharpe`, `profitFactor`, `expectancy` доступны прямо в `DslBacktestReport`, а не вычисляются локально в роутерах.
+- `apps/api/src/lib/backtestMetrics/` — изолированный модуль с pure-функциями и unit-тестами.
+- `lab.ts` стал чище: локальный `computeSharpe` удалён, sweep и compare читают значения из единого источника.
+- `docs/47-T4` готов к полноценной реализации `rankBy ∈ {sharpe, profitFactor, expectancy}`.
+- `docs/48-T3` после follow-up PR удаляет временный `_localSharpe.ts`.
+- Правило для будущего `reportVersion` зафиксировано в `docs/44` — будущие изменения формы отчёта имеют чёткий триггер.


### PR DESCRIPTION
## Summary

Adds four interlocking research-track plans (docs/46–49) under `docs/44 — strategy engine overview`. Each plan follows the `docs/45` template (Контекст / Цель / Не входит / Tasks / Порядок / Зависимости / BC checklist / Ожидаемый результат) and is designed so each task = one small, additive PR.

**Documents added**

- `docs/46-backtest-realism-plan.md` (5 tasks) — поднимает `fillAt` в ядро `DslExecOpts`, расширяет до `OPEN | CLOSE | NEXT_OPEN`, делает slippage симметричным на entry/exit, готовит структуру под `takerFeeBps`/`makerFeeBps` (maker — задел под лимитные ордера). Funding и partial fills явно out of scope.
- `docs/47-strategy-optimizer-plan.md` (6 tasks) — расширяет существующий 1-D sweep до multi-parameter grid (1..3 параметра, лимит 20 runs), вводит серверный `rankBy: pnlPct | sharpe | profitFactor | expectancy`. Полная backward compatibility со старым `sweepParam` и старым `paramValue`.
- `docs/48-walk-forward-plan.md` (7 tasks) — вводит walk-forward как новый research-режим: pure `split` (rolling/anchored), per-fold backtest через существующий `runBacktest`, aggregate-метрики, новая Prisma модель `WalkForwardRun` (структурный аналог `BacktestSweep`), HTTP эндпоинты + минимальный UI.
- `docs/49-backtest-metrics-plan.md` (4 tasks) — выносит `sharpeRatio` / `profitFactor` / `expectancy` в новый модуль `apps/api/src/lib/backtestMetrics/`, расширяет `DslBacktestReport` этими полями, удаляет локальный `computeSharpe` из `lab.ts`, фиксирует правило триггера `reportVersion` в `docs/44`.

**Граф зависимостей задач**

- `docs/46` разблокирует `docs/47-T3` (fillAt в sweep) и `docs/48-T5` (fillAt в walk-forward request body).
- `docs/49-T2` разблокирует `docs/47-T4` (rankBy multi-metric) и позволяет `docs/48-T3` отказаться от временного `_localSharpe.ts` helper-а.
- `docs/46` и `docs/49` независимы между собой — могут идти параллельно.
- `docs/47` и `docs/48` независимы между собой.

**Cross-doc consistency**

Финальный коммит синхронизирует `docs/48` с принятыми в `docs/46`/`docs/49` решениями:
- `fillAt?: "OPEN" | "CLOSE"` → `"OPEN" | "CLOSE" | "NEXT_OPEN"` (полный enum из docs/46-T1).
- Ссылка на `apps/api/src/lib/metrics/` исправлена на `apps/api/src/lib/backtestMetrics/` (избегаем коллизии с существующим Prometheus-файлом `metrics.ts`, у которого 8 importer-ов).

**После мёрджа — 26 будущих PR-ов**: 4 (docs/45) + 5 (docs/46) + 6 (docs/47) + 7 (docs/48) + 4 (docs/49). Каждая T-задача — отдельный PR.

**Что важно при ревью**

1. Якоря в `Контекст`-секциях каждого документа проверены против HEAD (file:line ссылки).
2. Все правки полностью additive — никаких миграций Prisma в этом PR; миграции описаны в задачах docs/48-T4 (новая таблица `WalkForwardRun`) и явно отсутствуют в 46/47/49.
3. `reportVersion` нигде не вводится — правило триггера зафиксировано в `docs/49 §Решение по reportVersion`.
4. Engineering constraints из `docs/44` соблюдены: additive, deterministic (PRNG только с explicit seed), без distributed/BullMQ/worker rework.

## Test plan

- [ ] `docs/46`–`docs/49` рендерятся корректно в GitHub markdown preview.
- [ ] Все file:line якоря из секций "Контекст" указывают на актуальный код в `apps/api/src/`, `apps/web/src/`, `apps/api/prisma/schema.prisma`.
- [ ] Кросс-ссылки между документами консистентны (`fillAt` enum, имя модуля `backtestMetrics/`, статус `_localSharpe.ts`, правило `reportVersion`).
- [ ] Структура каждого документа повторяет `docs/45` (Контекст → Цель → Решение → Не входит → Tasks → Порядок → Зависимости → BC checklist → Ожидаемый результат).
- [ ] Каждая T-задача содержит: Цель / Файлы для изменения / Шаги реализации / Тест-план / Критерии готовности.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RsgJFerzf1BL6kwqNrDtyD)_