### PR TITLE
feat(indicators): extract calcSMA and calcEMA to public indicators module (45-T1)

### DIFF
--- a/apps/api/src/lib/dslEvaluator.ts
+++ b/apps/api/src/lib/dslEvaluator.ts
@@ -22,6 +22,8 @@
  */
 
 import type { Candle } from "./bybitCandles.js";
+import { calcSMA } from "./indicators/sma.js";
+import { calcEMA } from "./indicators/ema.js";
 import { calcATR } from "./indicators/atr.js";
 import { calcADX } from "./indicators/adx.js";
 import { calcSuperTrend } from "./indicators/supertrend.js";
@@ -237,44 +239,10 @@ export function createIndicatorCache(): IndicatorCache {
 }
 
 // ---------------------------------------------------------------------------
-// Simple indicator computations (SMA, EMA, RSI)
+// Simple indicator computations (RSI)
 // These are pure, deterministic functions matching the block types.
+// SMA and EMA live in indicators/sma.ts and indicators/ema.ts.
 // ---------------------------------------------------------------------------
-
-function calcSMA(candles: Candle[], length: number): (number | null)[] {
-  const n = candles.length;
-  const result: (number | null)[] = new Array(n).fill(null);
-  if (n < length) return result;
-
-  let sum = 0;
-  for (let i = 0; i < length; i++) sum += candles[i].close;
-  result[length - 1] = sum / length;
-
-  for (let i = length; i < n; i++) {
-    sum += candles[i].close - candles[i - length].close;
-    result[i] = sum / length;
-  }
-  return result;
-}
-
-function calcEMA(candles: Candle[], length: number): (number | null)[] {
-  const n = candles.length;
-  const result: (number | null)[] = new Array(n).fill(null);
-  if (n < length) return result;
-
-  // Seed with SMA
-  let sum = 0;
-  for (let i = 0; i < length; i++) sum += candles[i].close;
-  let ema = sum / length;
-  result[length - 1] = ema;
-
-  const k = 2 / (length + 1);
-  for (let i = length; i < n; i++) {
-    ema = candles[i].close * k + ema * (1 - k);
-    result[i] = ema;
-  }
-  return result;
-}
 
 function calcRSI(candles: Candle[], length: number): (number | null)[] {
   const n = candles.length;

--- a/apps/api/src/lib/indicators/ema.ts
+++ b/apps/api/src/lib/indicators/ema.ts
@@ -1,0 +1,31 @@
+/**
+ * Exponential Moving Average (EMA).
+ *
+ * Seeded with the SMA of the first `length` closes; subsequent bars apply
+ * the standard exponential smoothing factor k = 2 / (length + 1):
+ *   EMA[i] = close[i] * k + EMA[i-1] * (1 - k)
+ *
+ * Returns array of same length as input; first `length - 1` values are null
+ * (warm-up). Pure, deterministic — no I/O, no side effects.
+ */
+
+import type { Candle } from "./types.js";
+
+export function calcEMA(candles: Candle[], length: number): (number | null)[] {
+  const n = candles.length;
+  const result: (number | null)[] = new Array(n).fill(null);
+  if (n < length) return result;
+
+  // Seed with SMA
+  let sum = 0;
+  for (let i = 0; i < length; i++) sum += candles[i].close;
+  let ema = sum / length;
+  result[length - 1] = ema;
+
+  const k = 2 / (length + 1);
+  for (let i = length; i < n; i++) {
+    ema = candles[i].close * k + ema * (1 - k);
+    result[i] = ema;
+  }
+  return result;
+}

--- a/apps/api/src/lib/indicators/index.ts
+++ b/apps/api/src/lib/indicators/index.ts
@@ -6,6 +6,8 @@
  */
 
 export type { Candle } from "./types.js";
+export { calcSMA } from "./sma.js";
+export { calcEMA } from "./ema.js";
 export { calcATR, trueRange } from "./atr.js";
 export { calcVWAP } from "./vwap.js";
 export { calcADX } from "./adx.js";

--- a/apps/api/src/lib/indicators/sma.ts
+++ b/apps/api/src/lib/indicators/sma.ts
@@ -1,0 +1,26 @@
+/**
+ * Simple Moving Average (SMA).
+ *
+ * SMA[i] = average of the most recent `length` closes ending at bar i.
+ *
+ * Returns array of same length as input; first `length - 1` values are null
+ * (warm-up). Pure, deterministic — no I/O, no side effects.
+ */
+
+import type { Candle } from "./types.js";
+
+export function calcSMA(candles: Candle[], length: number): (number | null)[] {
+  const n = candles.length;
+  const result: (number | null)[] = new Array(n).fill(null);
+  if (n < length) return result;
+
+  let sum = 0;
+  for (let i = 0; i < length; i++) sum += candles[i].close;
+  result[length - 1] = sum / length;
+
+  for (let i = length; i < n; i++) {
+    sum += candles[i].close - candles[i - length].close;
+    result[i] = sum / length;
+  }
+  return result;
+}

--- a/apps/api/tests/lib/indicators/ema.test.ts
+++ b/apps/api/tests/lib/indicators/ema.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { calcEMA } from "../../../src/lib/indicators/ema.js";
+import { makeFlat } from "../../fixtures/candles.js";
+
+interface Candle {
+  openTime: number;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+function candlesFromCloses(closes: number[]): Candle[] {
+  return closes.map((c, i) => ({
+    openTime: 1_700_000_000_000 + i * 60_000,
+    open: c,
+    high: c,
+    low: c,
+    close: c,
+    volume: 1000,
+  }));
+}
+
+describe("calcEMA", () => {
+  it("returns null for warm-up bars (i < length - 1)", () => {
+    const candles = candlesFromCloses([1, 2, 3, 4, 5, 6, 7, 8]);
+    const result = calcEMA(candles, 4);
+
+    expect(result).toHaveLength(8);
+    expect(result[0]).toBeNull();
+    expect(result[1]).toBeNull();
+    expect(result[2]).toBeNull();
+    expect(result[3]).not.toBeNull();
+  });
+
+  it("seeds the first value with SMA of the first `length` closes", () => {
+    const closes = [10, 20, 30, 40, 50, 60];
+    const candles = candlesFromCloses(closes);
+    const length = 4;
+    const result = calcEMA(candles, length);
+    const seedSma = (10 + 20 + 30 + 40) / length;
+    expect(result[length - 1]).toBeCloseTo(seedSma, 10);
+  });
+
+  it("applies smoothing factor k = 2 / (length + 1) on subsequent bars", () => {
+    const closes = [10, 20, 30, 40, 50, 60];
+    const candles = candlesFromCloses(closes);
+    const length = 4;
+    const result = calcEMA(candles, length);
+
+    const seed = (10 + 20 + 30 + 40) / length;
+    const k = 2 / (length + 1);
+    const expectedAt4 = closes[4] * k + seed * (1 - k);
+    const expectedAt5 = closes[5] * k + expectedAt4 * (1 - k);
+
+    expect(result[4]).toBeCloseTo(expectedAt4, 10);
+    expect(result[5]).toBeCloseTo(expectedAt5, 10);
+  });
+
+  it("returns all-null when n < length", () => {
+    const candles = candlesFromCloses([1, 2, 3]);
+    const result = calcEMA(candles, 5);
+    expect(result).toHaveLength(3);
+    expect(result.every((v) => v === null)).toBe(true);
+  });
+
+  it("equals the constant price for a flat series (no movement to converge to)", () => {
+    const candles = makeFlat(20, 100);
+    const result = calcEMA(candles, 5);
+    expect(result[4]).toBeCloseTo(100, 10);
+    expect(result[19]).toBeCloseTo(100, 10);
+  });
+
+  it("converges towards a new price level after a step change", () => {
+    // First 10 bars at 100, then 90 bars at 200 — EMA should approach 200.
+    const closes = [
+      ...Array.from({ length: 10 }, () => 100),
+      ...Array.from({ length: 90 }, () => 200),
+    ];
+    const candles = candlesFromCloses(closes);
+    const result = calcEMA(candles, 5);
+    const last = result[result.length - 1];
+    expect(last).not.toBeNull();
+    expect(last as number).toBeGreaterThan(199);
+    expect(last as number).toBeLessThanOrEqual(200);
+  });
+
+  it("returns array of same length as input", () => {
+    const candles = candlesFromCloses([1, 2, 3, 4, 5, 6, 7]);
+    expect(calcEMA(candles, 3)).toHaveLength(7);
+  });
+});

--- a/apps/api/tests/lib/indicators/sma.test.ts
+++ b/apps/api/tests/lib/indicators/sma.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { calcSMA } from "../../../src/lib/indicators/sma.js";
+import { makeUptrend, makeFlat } from "../../fixtures/candles.js";
+
+interface Candle {
+  openTime: number;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+function candlesFromCloses(closes: number[]): Candle[] {
+  return closes.map((c, i) => ({
+    openTime: 1_700_000_000_000 + i * 60_000,
+    open: c,
+    high: c,
+    low: c,
+    close: c,
+    volume: 1000,
+  }));
+}
+
+describe("calcSMA", () => {
+  it("returns null for warm-up bars (i < length - 1) and SMA from length-1 onward", () => {
+    const candles = candlesFromCloses([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    const result = calcSMA(candles, 4);
+
+    expect(result).toHaveLength(10);
+    expect(result[0]).toBeNull();
+    expect(result[1]).toBeNull();
+    expect(result[2]).toBeNull();
+    expect(result[3]).toBeCloseTo((1 + 2 + 3 + 4) / 4, 10);
+    expect(result[4]).toBeCloseTo((2 + 3 + 4 + 5) / 4, 10);
+    expect(result[9]).toBeCloseTo((7 + 8 + 9 + 10) / 4, 10);
+  });
+
+  it("returns last value as the average of the most recent `length` closes", () => {
+    const closes = [10, 12, 14, 16, 18, 20, 22, 24];
+    const candles = candlesFromCloses(closes);
+    const length = 5;
+    const result = calcSMA(candles, length);
+    const expected =
+      closes.slice(closes.length - length).reduce((a, b) => a + b, 0) / length;
+    expect(result[result.length - 1]).toBeCloseTo(expected, 10);
+  });
+
+  it("returns all-null when n < length", () => {
+    const candles = candlesFromCloses([1, 2, 3]);
+    const result = calcSMA(candles, 5);
+    expect(result).toHaveLength(3);
+    expect(result.every((v) => v === null)).toBe(true);
+  });
+
+  it("equals the constant price for a flat series", () => {
+    const candles = makeFlat(20, 100);
+    const result = calcSMA(candles, 5);
+    expect(result[4]).toBeCloseTo(100, 10);
+    expect(result[19]).toBeCloseTo(100, 10);
+  });
+
+  it("matches manual SMA on a steady uptrend", () => {
+    const candles = makeUptrend(10, 100, 1);
+    const result = calcSMA(candles, 3);
+    // closes: 100,101,102,...,109 → SMA(3) at i=2 → (100+101+102)/3
+    expect(result[0]).toBeNull();
+    expect(result[1]).toBeNull();
+    expect(result[2]).toBeCloseTo(101, 10);
+    expect(result[9]).toBeCloseTo((107 + 108 + 109) / 3, 10);
+  });
+
+  it("handles empty array", () => {
+    expect(calcSMA([], 5)).toEqual([]);
+  });
+});


### PR DESCRIPTION
Реализация задачи **45-T1** из `docs/45-indicator-engine-extraction-plan.md`.

## Что сделано

- Создан `apps/api/src/lib/indicators/sma.ts` — `calcSMA(candles, length)`, byte-в-byte копия из `dslEvaluator.ts`.
- Создан `apps/api/src/lib/indicators/ema.ts` — `calcEMA(candles, length)`, seed = SMA, k = 2/(length+1).
- `apps/api/src/lib/indicators/index.ts` — добавлены публичные `export { calcSMA }` и `export { calcEMA }`.
- `apps/api/src/lib/dslEvaluator.ts` — приватные объявления удалены, вызовы заменены на импорты из `./indicators/{sma,ema}.js`. Логика evaluator не изменена.
- Новые unit-тесты:
  - `apps/api/tests/lib/indicators/sma.test.ts` (6 кейсов: warm-up nulls, скользящее окно, n<length, flat-серия, uptrend, empty array).
  - `apps/api/tests/lib/indicators/ema.test.ts` (7 кейсов: warm-up, seed=SMA, smoothing factor, n<length, flat, step-convergence, длина).

## Иммутабельность логики

- Diff тел `calcSMA` / `calcEMA` относительно `main` — отличие только в `export` keyword.
- Существующие тесты `apps/api/tests/lib/dslEvaluator.test.ts` (56 шт.) **не правились** и проходят зелёными — это и есть основной критерий нерегрессии.

## Не входит в задачу

- `calcRSI`, `calcBollingerBands`, `getBollingerBands`, `getVolumeProfileCached` — задачи 45-T2/T3.
- Изменения `IndicatorCache`, `getIndicatorValues`, `DslBacktestReport`, `DslTradeRecord`, `exitReason` — out of scope per docs/45 «Не входит в задачу».
- Решение по SMC primitives — задача 45-T4.
- Prisma-миграции отсутствуют.

## Критерии готовности (из docs/45)

- [x] `tsc --noEmit` проходит.
- [x] Все существующие тесты зелёные (96 файлов, 1733 теста).
- [x] Новые unit-тесты для SMA и EMA зелёные.
- [x] `calcSMA` и `calcEMA` доступны через `import { calcSMA, calcEMA } from "../indicators/index.js"`.
- [x] Приватные объявления `calcSMA`/`calcEMA` удалены из `dslEvaluator.ts`.

## Тест-план для ревьюера

```bash
cd apps/api
npx prisma generate
npx tsc --noEmit
npx vitest run
```

Branch: `claude/45-t1-extract-sma-ema-UQTMW` · 6 files changed (+232/−36).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmfV8BXGWUJSFNGArYKe9k)_