### PR TITLE
feat(indicators): extract calcRSI to public indicators module (45-T2)

### DIFF
--- a/apps/api/src/lib/dslEvaluator.ts
+++ b/apps/api/src/lib/dslEvaluator.ts
@@ -24,6 +24,7 @@
 import type { Candle } from "./bybitCandles.js";
 import { calcSMA } from "./indicators/sma.js";
 import { calcEMA } from "./indicators/ema.js";
+import { calcRSI } from "./indicators/rsi.js";
 import { calcATR } from "./indicators/atr.js";
 import { calcADX } from "./indicators/adx.js";
 import { calcSuperTrend } from "./indicators/supertrend.js";
@@ -236,40 +237,6 @@ export function createIndicatorCache(): IndicatorCache {
     smcPatterns: new Map(),
     volumeProfile: new Map(),
   };
-}
-
-// ---------------------------------------------------------------------------
-// Simple indicator computations (RSI)
-// These are pure, deterministic functions matching the block types.
-// SMA and EMA live in indicators/sma.ts and indicators/ema.ts.
-// ---------------------------------------------------------------------------
-
-function calcRSI(candles: Candle[], length: number): (number | null)[] {
-  const n = candles.length;
-  const result: (number | null)[] = new Array(n).fill(null);
-  if (n < length + 1) return result;
-
-  let gainSum = 0;
-  let lossSum = 0;
-  for (let i = 1; i <= length; i++) {
-    const change = candles[i].close - candles[i - 1].close;
-    if (change > 0) gainSum += change;
-    else lossSum += Math.abs(change);
-  }
-
-  let avgGain = gainSum / length;
-  let avgLoss = lossSum / length;
-  result[length] = avgLoss === 0 ? 100 : 100 - 100 / (1 + avgGain / avgLoss);
-
-  for (let i = length + 1; i < n; i++) {
-    const change = candles[i].close - candles[i - 1].close;
-    const gain = change > 0 ? change : 0;
-    const loss = change < 0 ? Math.abs(change) : 0;
-    avgGain = (avgGain * (length - 1) + gain) / length;
-    avgLoss = (avgLoss * (length - 1) + loss) / length;
-    result[i] = avgLoss === 0 ? 100 : 100 - 100 / (1 + avgGain / avgLoss);
-  }
-  return result;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/src/lib/indicators/index.ts
+++ b/apps/api/src/lib/indicators/index.ts
@@ -8,6 +8,7 @@
 export type { Candle } from "./types.js";
 export { calcSMA } from "./sma.js";
 export { calcEMA } from "./ema.js";
+export { calcRSI } from "./rsi.js";
 export { calcATR, trueRange } from "./atr.js";
 export { calcVWAP } from "./vwap.js";
 export { calcADX } from "./adx.js";

--- a/apps/api/src/lib/indicators/rsi.ts
+++ b/apps/api/src/lib/indicators/rsi.ts
@@ -1,0 +1,50 @@
+/**
+ * Relative Strength Index (RSI) — Wilder's smoothed RSI.
+ *
+ * Formula:
+ *   change[i]   = close[i] - close[i-1]
+ *   gain[i]     = max(change[i], 0)
+ *   loss[i]     = max(-change[i], 0)
+ *   avgGain[length] = SMA of gains over the first `length` changes (seed)
+ *   avgLoss[length] = SMA of losses over the first `length` changes (seed)
+ *   avgGain[i]  = (avgGain[i-1] * (length - 1) + gain[i]) / length   (Wilder)
+ *   avgLoss[i]  = (avgLoss[i-1] * (length - 1) + loss[i]) / length   (Wilder)
+ *   RSI[i]      = 100 - 100 / (1 + avgGain[i] / avgLoss[i])
+ *
+ * Special case: when avgLoss === 0, RSI is defined as 100 (no downward
+ * pressure observed in the smoothed window).
+ *
+ * Returns array of same length as input; first `length` values are null
+ * (warm-up — RSI requires `length` price changes, i.e. `length + 1` candles).
+ * Pure, deterministic — no I/O, no side effects.
+ */
+
+import type { Candle } from "./types.js";
+
+export function calcRSI(candles: Candle[], length: number): (number | null)[] {
+  const n = candles.length;
+  const result: (number | null)[] = new Array(n).fill(null);
+  if (n < length + 1) return result;
+
+  let gainSum = 0;
+  let lossSum = 0;
+  for (let i = 1; i <= length; i++) {
+    const change = candles[i].close - candles[i - 1].close;
+    if (change > 0) gainSum += change;
+    else lossSum += Math.abs(change);
+  }
+
+  let avgGain = gainSum / length;
+  let avgLoss = lossSum / length;
+  result[length] = avgLoss === 0 ? 100 : 100 - 100 / (1 + avgGain / avgLoss);
+
+  for (let i = length + 1; i < n; i++) {
+    const change = candles[i].close - candles[i - 1].close;
+    const gain = change > 0 ? change : 0;
+    const loss = change < 0 ? Math.abs(change) : 0;
+    avgGain = (avgGain * (length - 1) + gain) / length;
+    avgLoss = (avgLoss * (length - 1) + loss) / length;
+    result[i] = avgLoss === 0 ? 100 : 100 - 100 / (1 + avgGain / avgLoss);
+  }
+  return result;
+}

--- a/apps/api/tests/lib/indicators/rsi.test.ts
+++ b/apps/api/tests/lib/indicators/rsi.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { calcRSI } from "../../../src/lib/indicators/rsi.js";
+import { makeUptrend, makeDowntrend, makeFlat } from "../../fixtures/candles.js";
+
+interface Candle {
+  openTime: number;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+function candlesFromCloses(closes: number[]): Candle[] {
+  return closes.map((c, i) => ({
+    openTime: 1_700_000_000_000 + i * 60_000,
+    open: c,
+    high: c,
+    low: c,
+    close: c,
+    volume: 1000,
+  }));
+}
+
+describe("calcRSI", () => {
+  it("returns null for warm-up bars (i < length) and value from index `length` onward", () => {
+    const candles = candlesFromCloses([10, 11, 9, 12, 13, 11]);
+    const result = calcRSI(candles, 3);
+
+    expect(result).toHaveLength(6);
+    expect(result[0]).toBeNull();
+    expect(result[1]).toBeNull();
+    expect(result[2]).toBeNull();
+    expect(result[3]).not.toBeNull();
+  });
+
+  it("returns all-null when n < length + 1", () => {
+    // length=5 needs ≥ 6 candles (5 changes); 5 candles produce only 4 changes.
+    const candles = candlesFromCloses([1, 2, 3, 4, 5]);
+    const result = calcRSI(candles, 5);
+    expect(result).toHaveLength(5);
+    expect(result.every((v) => v === null)).toBe(true);
+  });
+
+  it("matches hand-calculated reference (length=2, closes=[10, 12, 11, 14])", () => {
+    // Step-by-step:
+    //   diffs:  +2 (gain), -1 (loss), +3 (gain)
+    //   seed (i=1..2): gainSum=2, lossSum=1 → avgGain=1, avgLoss=0.5
+    //   RSI[2] = 100 - 100/(1 + 1/0.5) = 100 - 100/3 = 66.6667
+    //
+    //   step i=3: gain=3, loss=0
+    //     avgGain = (1*(2-1) + 3)/2 = 2
+    //     avgLoss = (0.5*(2-1) + 0)/2 = 0.25
+    //     RSI[3] = 100 - 100/(1 + 2/0.25) = 100 - 100/9 = 88.8889
+    const candles = candlesFromCloses([10, 12, 11, 14]);
+    const result = calcRSI(candles, 2);
+
+    expect(result[0]).toBeNull();
+    expect(result[1]).toBeNull();
+    expect(result[2]).toBeCloseTo(100 - 100 / 3, 8);
+    expect(result[3]).toBeCloseTo(100 - 100 / 9, 8);
+  });
+
+  it("returns 100 for a monotonic uptrend (avgLoss = 0 branch)", () => {
+    const candles = makeUptrend(30, 100, 1);
+    const result = calcRSI(candles, 14);
+
+    expect(result[13]).toBeNull();
+    expect(result[14]).toBe(100);
+    expect(result[result.length - 1]).toBe(100);
+  });
+
+  it("returns 0 for a monotonic downtrend (avgGain = 0 → RS = 0)", () => {
+    const candles = makeDowntrend(30, 200, 1);
+    const result = calcRSI(candles, 14);
+
+    expect(result[13]).toBeNull();
+    expect(result[14]).toBe(0);
+    expect(result[result.length - 1]).toBe(0);
+  });
+
+  it("returns 100 for a flat series (both sums zero — avgLoss = 0 branch)", () => {
+    const candles = makeFlat(20, 100);
+    const result = calcRSI(candles, 14);
+
+    expect(result[14]).toBe(100);
+    expect(result[19]).toBe(100);
+  });
+
+  it("recovers from oversold towards mid-range as gains arrive", () => {
+    // 14 down moves of -1, then 7 up moves of +1.
+    // After the seed window: avgGain=0, avgLoss=1, RSI=0.
+    // Subsequent up moves push RSI upward.
+    const closes = [
+      ...Array.from({ length: 15 }, (_, i) => 100 - i), // 100..86 (14 losses)
+      ...Array.from({ length: 7 }, (_, i) => 86 + (i + 1)), // 87..93 (7 gains)
+    ];
+    const candles = candlesFromCloses(closes);
+    const result = calcRSI(candles, 14);
+
+    expect(result[14]).toBe(0);
+    const last = result[result.length - 1];
+    expect(last).not.toBeNull();
+    expect(last as number).toBeGreaterThan(0);
+    expect(last as number).toBeLessThan(100);
+  });
+
+  it("returns array of same length as input", () => {
+    const candles = candlesFromCloses([1, 2, 3, 4, 5, 6, 7, 8]);
+    expect(calcRSI(candles, 3)).toHaveLength(8);
+  });
+
+  it("handles empty array", () => {
+    expect(calcRSI([], 14)).toEqual([]);
+  });
+});


### PR DESCRIPTION
Реализация задачи **45-T2** из `docs/45-indicator-engine-extraction-plan.md`. Продолжение паттерна, заложенного в **45-T1** (#294).

## Что сделано

- Создан `apps/api/src/lib/indicators/rsi.ts` — `calcRSI(candles, length)`, byte-в-byte копия из `dslEvaluator.ts` (Wilder's smoothed RSI; `avgLoss === 0 → RSI = 100` special branch сохранён).
- `apps/api/src/lib/indicators/index.ts` — добавлен публичный `export { calcRSI }`.
- `apps/api/src/lib/dslEvaluator.ts` — приватное объявление и section-комментарий «Simple indicator computations (RSI)» удалены, добавлен `import { calcRSI } from "./indicators/rsi.js"`. Вызов в `IndicatorCache` (`cache.rsi.set(len, calcRSI(candles, len))`) — без правок.
- Новые unit-тесты `apps/api/tests/lib/indicators/rsi.test.ts` (9 кейсов):
  - warm-up nulls (`i < length`);
  - `n < length + 1` → all-null;
  - **руками посчитанная эталонная серия** (`length=2`, `closes=[10, 12, 11, 14]` → RSI[2]=66.6667, RSI[3]=88.8889) — закрывает замечание #1 из ревью T1 о тавтологичных тестах;
  - монотонный uptrend → RSI = 100 (avgLoss = 0 branch);
  - монотонный downtrend → RSI = 0 (avgGain = 0 → RS = 0);
  - flat series → RSI = 100 (оба sum = 0 → avgLoss = 0 branch);
  - recovery from oversold (после серии лоссов RSI выходит из 0);
  - длина массива == длина входа;
  - empty array.

## Иммутабельность логики

- Diff тела `calcRSI` относительно `main` — только `export` keyword.
- Существующие тесты `apps/api/tests/lib/dslEvaluator.test.ts` (56) **не правились** и проходят зелёными.

## Не входит в задачу

- `calcBollingerBands`, `getBollingerBands`, `getVolumeProfileCached` — задача 45-T3.
- Решение по SMC primitives и финал `indicators/index.ts` — задача 45-T4.
- `IndicatorCache`, `getIndicatorValues`, `DslBacktestReport`, `DslTradeRecord`, `exitReason` — out of scope per docs/45 «Не входит в задачу».
- Prisma-миграции отсутствуют.

## Критерии готовности (из docs/45)

- [x] `tsc --noEmit` проходит.
- [x] `calcRSI` доступна через `indicators/index.ts` (`import { calcRSI } from "../indicators/index.js"`).
- [x] Приватное объявление удалено из `dslEvaluator.ts`.
- [x] Все существующие тесты зелёные (97 файлов / 1742 теста, +9 vs T1).

## Тест-план для ревьюера

```bash
cd apps/api
npx prisma generate
npx tsc --noEmit
npx vitest run
```

Branch: `claude/45-t2-extract-rsi` · 4 files changed (+168/−34) · commit `c379e00`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmfV8BXGWUJSFNGArYKe9k)_