### PR TITLE
feat(indicators): extract calcBollingerBands to public indicators module (45-T3)

### DIFF
--- a/apps/api/src/lib/dslEvaluator.ts
+++ b/apps/api/src/lib/dslEvaluator.ts
@@ -25,6 +25,10 @@ import type { Candle } from "./bybitCandles.js";
 import { calcSMA } from "./indicators/sma.js";
 import { calcEMA } from "./indicators/ema.js";
 import { calcRSI } from "./indicators/rsi.js";
+import {
+  calcBollingerBands,
+  type BollingerBandsResult,
+} from "./indicators/bollingerBands.js";
 import { calcATR } from "./indicators/atr.js";
 import { calcADX } from "./indicators/adx.js";
 import { calcSuperTrend } from "./indicators/supertrend.js";
@@ -199,12 +203,6 @@ export interface ParsedDsl {
 // Indicator computation cache
 // ---------------------------------------------------------------------------
 
-export interface BollingerBandsResult {
-  upper: (number | null)[];
-  middle: (number | null)[];
-  lower: (number | null)[];
-}
-
 export interface IndicatorCache {
   sma: Map<number, (number | null)[]>;
   ema: Map<number, (number | null)[]>;
@@ -240,39 +238,8 @@ export function createIndicatorCache(): IndicatorCache {
 }
 
 // ---------------------------------------------------------------------------
-// Bollinger Bands computation
+// Bollinger Bands cache wrapper
 // ---------------------------------------------------------------------------
-
-function calcBollingerBands(
-  candles: Candle[],
-  period: number,
-  stdDevMult: number,
-): BollingerBandsResult {
-  const n = candles.length;
-  const upper: (number | null)[] = new Array(n).fill(null);
-  const middle: (number | null)[] = new Array(n).fill(null);
-  const lower: (number | null)[] = new Array(n).fill(null);
-  if (n < period) return { upper, middle, lower };
-
-  for (let i = period - 1; i < n; i++) {
-    let sum = 0;
-    for (let j = i - period + 1; j <= i; j++) sum += candles[j].close;
-    const mean = sum / period;
-
-    let sqSum = 0;
-    for (let j = i - period + 1; j <= i; j++) {
-      const diff = candles[j].close - mean;
-      sqSum += diff * diff;
-    }
-    const stdDev = Math.sqrt(sqSum / period);
-
-    middle[i] = mean;
-    upper[i] = mean + stdDevMult * stdDev;
-    lower[i] = mean - stdDevMult * stdDev;
-  }
-
-  return { upper, middle, lower };
-}
 
 function getBollingerBands(
   params: { period?: number; length?: number; stdDevMult?: number; multiplier?: number },

--- a/apps/api/src/lib/indicators/bollingerBands.ts
+++ b/apps/api/src/lib/indicators/bollingerBands.ts
@@ -1,0 +1,54 @@
+/**
+ * Bollinger Bands.
+ *
+ * For each bar i ≥ period - 1:
+ *   middle[i] = SMA(close, period) over the most recent `period` closes
+ *   stdDev[i] = sqrt( Σ (close[j] - middle[i])² / period )   (population stdDev)
+ *   upper[i]  = middle[i] + stdDevMult * stdDev[i]
+ *   lower[i]  = middle[i] - stdDevMult * stdDev[i]
+ *
+ * Returns three parallel arrays of the same length as input; the first
+ * `period - 1` values in each array are null (warm-up). When all closes in
+ * the window are equal, stdDev is 0 and upper === middle === lower.
+ *
+ * Pure, deterministic — no I/O, no side effects.
+ */
+
+import type { Candle } from "./types.js";
+
+export interface BollingerBandsResult {
+  upper: (number | null)[];
+  middle: (number | null)[];
+  lower: (number | null)[];
+}
+
+export function calcBollingerBands(
+  candles: Candle[],
+  period: number,
+  stdDevMult: number,
+): BollingerBandsResult {
+  const n = candles.length;
+  const upper: (number | null)[] = new Array(n).fill(null);
+  const middle: (number | null)[] = new Array(n).fill(null);
+  const lower: (number | null)[] = new Array(n).fill(null);
+  if (n < period) return { upper, middle, lower };
+
+  for (let i = period - 1; i < n; i++) {
+    let sum = 0;
+    for (let j = i - period + 1; j <= i; j++) sum += candles[j].close;
+    const mean = sum / period;
+
+    let sqSum = 0;
+    for (let j = i - period + 1; j <= i; j++) {
+      const diff = candles[j].close - mean;
+      sqSum += diff * diff;
+    }
+    const stdDev = Math.sqrt(sqSum / period);
+
+    middle[i] = mean;
+    upper[i] = mean + stdDevMult * stdDev;
+    lower[i] = mean - stdDevMult * stdDev;
+  }
+
+  return { upper, middle, lower };
+}

--- a/apps/api/src/lib/indicators/index.ts
+++ b/apps/api/src/lib/indicators/index.ts
@@ -9,6 +9,8 @@ export type { Candle } from "./types.js";
 export { calcSMA } from "./sma.js";
 export { calcEMA } from "./ema.js";
 export { calcRSI } from "./rsi.js";
+export { calcBollingerBands } from "./bollingerBands.js";
+export type { BollingerBandsResult } from "./bollingerBands.js";
 export { calcATR, trueRange } from "./atr.js";
 export { calcVWAP } from "./vwap.js";
 export { calcADX } from "./adx.js";

--- a/apps/api/tests/lib/indicators/bollingerBands.test.ts
+++ b/apps/api/tests/lib/indicators/bollingerBands.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "vitest";
+import { calcBollingerBands } from "../../../src/lib/indicators/bollingerBands.js";
+import { makeFlat, makeUptrend } from "../../fixtures/candles.js";
+
+interface Candle {
+  openTime: number;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+function candlesFromCloses(closes: number[]): Candle[] {
+  return closes.map((c, i) => ({
+    openTime: 1_700_000_000_000 + i * 60_000,
+    open: c,
+    high: c,
+    low: c,
+    close: c,
+    volume: 1000,
+  }));
+}
+
+describe("calcBollingerBands", () => {
+  it("returns null for warm-up bars (i < period - 1) on all three series", () => {
+    const candles = candlesFromCloses([1, 2, 3, 4, 5, 6]);
+    const { upper, middle, lower } = calcBollingerBands(candles, 4, 2);
+
+    expect(upper).toHaveLength(6);
+    expect(middle).toHaveLength(6);
+    expect(lower).toHaveLength(6);
+    for (let i = 0; i < 3; i++) {
+      expect(upper[i]).toBeNull();
+      expect(middle[i]).toBeNull();
+      expect(lower[i]).toBeNull();
+    }
+    expect(middle[3]).not.toBeNull();
+  });
+
+  it("returns all-null arrays when n < period", () => {
+    const candles = candlesFromCloses([1, 2, 3]);
+    const result = calcBollingerBands(candles, 5, 2);
+    expect(result.upper).toHaveLength(3);
+    expect(result.upper.every((v) => v === null)).toBe(true);
+    expect(result.middle.every((v) => v === null)).toBe(true);
+    expect(result.lower.every((v) => v === null)).toBe(true);
+  });
+
+  it("matches hand-calculated reference (period=2, mult=1, closes=[1, 3])", () => {
+    // Window at i=1: [1, 3]; mean = 2;
+    //   sqDiffs = [(1-2)², (3-2)²] = [1, 1]; sqSum = 2;
+    //   stdDev = sqrt(2/2) = 1;
+    //   upper = 2 + 1*1 = 3; lower = 2 - 1*1 = 1.
+    const candles = candlesFromCloses([1, 3]);
+    const { upper, middle, lower } = calcBollingerBands(candles, 2, 1);
+
+    expect(middle[1]).toBeCloseTo(2, 10);
+    expect(upper[1]).toBeCloseTo(3, 10);
+    expect(lower[1]).toBeCloseTo(1, 10);
+  });
+
+  it("matches hand-calculated reference (period=4, mult=2, closes=[10, 12, 11, 13, 15])", () => {
+    // i=3: window=[10,12,11,13]; mean=11.5;
+    //   sqDiffs = [2.25, 0.25, 0.25, 2.25]; sqSum=5; stdDev=sqrt(5/4)=sqrt(1.25);
+    //   upper=11.5+2*sqrt(1.25); lower=11.5-2*sqrt(1.25).
+    // i=4: window=[12,11,13,15]; mean=12.75;
+    //   sqDiffs=[0.5625, 3.0625, 0.0625, 5.0625]; sqSum=8.75; stdDev=sqrt(8.75/4)=sqrt(2.1875);
+    //   upper=12.75+2*sqrt(2.1875); lower=12.75-2*sqrt(2.1875).
+    const candles = candlesFromCloses([10, 12, 11, 13, 15]);
+    const { upper, middle, lower } = calcBollingerBands(candles, 4, 2);
+
+    const sd1 = Math.sqrt(1.25);
+    expect(middle[3]).toBeCloseTo(11.5, 10);
+    expect(upper[3]).toBeCloseTo(11.5 + 2 * sd1, 10);
+    expect(lower[3]).toBeCloseTo(11.5 - 2 * sd1, 10);
+
+    const sd2 = Math.sqrt(2.1875);
+    expect(middle[4]).toBeCloseTo(12.75, 10);
+    expect(upper[4]).toBeCloseTo(12.75 + 2 * sd2, 10);
+    expect(lower[4]).toBeCloseTo(12.75 - 2 * sd2, 10);
+  });
+
+  it("collapses bands to middle on a flat series (stdDev = 0)", () => {
+    const candles = makeFlat(20, 100);
+    const { upper, middle, lower } = calcBollingerBands(candles, 5, 2);
+
+    for (let i = 4; i < 20; i++) {
+      expect(middle[i]).toBeCloseTo(100, 10);
+      expect(upper[i]).toBeCloseTo(100, 10);
+      expect(lower[i]).toBeCloseTo(100, 10);
+    }
+  });
+
+  it("middle equals the SMA of the most recent `period` closes", () => {
+    const closes = [5, 10, 15, 20, 25, 30, 35];
+    const candles = candlesFromCloses(closes);
+    const period = 3;
+    const { middle } = calcBollingerBands(candles, period, 2);
+
+    for (let i = period - 1; i < closes.length; i++) {
+      const expected =
+        closes.slice(i - period + 1, i + 1).reduce((a, b) => a + b, 0) / period;
+      expect(middle[i]).toBeCloseTo(expected, 10);
+    }
+  });
+
+  it("keeps upper > middle > lower whenever stdDev > 0", () => {
+    const candles = makeUptrend(20, 100, 1);
+    const { upper, middle, lower } = calcBollingerBands(candles, 5, 2);
+
+    for (let i = 4; i < 20; i++) {
+      expect(upper[i]).not.toBeNull();
+      expect(middle[i]).not.toBeNull();
+      expect(lower[i]).not.toBeNull();
+      expect(upper[i] as number).toBeGreaterThan(middle[i] as number);
+      expect(middle[i] as number).toBeGreaterThan(lower[i] as number);
+    }
+  });
+
+  it("upper / lower are symmetric around middle (mult * stdDev each side)", () => {
+    const candles = candlesFromCloses([10, 15, 12, 18, 14, 20, 13, 17]);
+    const { upper, middle, lower } = calcBollingerBands(candles, 4, 2.5);
+
+    for (let i = 3; i < candles.length; i++) {
+      const m = middle[i] as number;
+      const u = upper[i] as number;
+      const l = lower[i] as number;
+      expect(u - m).toBeCloseTo(m - l, 10);
+    }
+  });
+
+  it("handles empty array", () => {
+    const result = calcBollingerBands([], 5, 2);
+    expect(result.upper).toEqual([]);
+    expect(result.middle).toEqual([]);
+    expect(result.lower).toEqual([]);
+  });
+});


### PR DESCRIPTION
Реализация задачи **45-T3** из `docs/45-indicator-engine-extraction-plan.md`. Продолжение цепочки 45-T1 (#294) → 45-T2 (#295).

## Что сделано

- Создан `apps/api/src/lib/indicators/bollingerBands.ts` — `calcBollingerBands(candles, period, stdDevMult)` + `BollingerBandsResult` interface, byte-в-byte копия из `dslEvaluator.ts`. Population stdDev, симметричные полосы `mean ± stdDevMult * stdDev`.
- `apps/api/src/lib/indicators/index.ts` — добавлены публичные `export { calcBollingerBands }` и `export type { BollingerBandsResult }`.
- `apps/api/src/lib/dslEvaluator.ts`:
  - Удалены приватная функция `calcBollingerBands` и интерфейс `BollingerBandsResult`.
  - Добавлен импорт обоих символов из `./indicators/bollingerBands.js`.
  - **`getBollingerBands` оставлен в `dslEvaluator.ts`** как приватная обёртка над `calcBollingerBands` — это рекомендованный вариант из плана (использует `IndicatorCache`, который остаётся в evaluator и не входит в публичный indicator API). Section-комментарий обновлён на «Bollinger Bands cache wrapper».
  - 3 call-site `getBollingerBands(...)` не тронуты.
- Новые unit-тесты `apps/api/tests/lib/indicators/bollingerBands.test.ts` (9 кейсов):
  - warm-up nulls на всех 3 сериях (`upper`, `middle`, `lower`);
  - `n < period` → all-null на всех сериях;
  - **руками посчитанная эталонная серия #1** (`period=2`, `mult=1`, `closes=[1, 3]` → `middle=2`, `upper=3`, `lower=1`);
  - **руками посчитанная эталонная серия #2** (`period=4`, `mult=2`, `closes=[10, 12, 11, 13, 15]` — два валидных бара, формулы развёрнуты в комментарии);
  - flat series → `upper === middle === lower` (stdDev = 0);
  - **`middle[i]` равен SMA окна** — cross-check инварианта;
  - `upper > middle > lower` для не-flat окон;
  - симметрия: `upper - middle === middle - lower`;
  - empty array.

## Иммутабельность логики

- Diff тела `calcBollingerBands` относительно `main` — только `export` keyword + перенос определения из dslEvaluator.
- Существующие тесты `apps/api/tests/lib/dslEvaluator.test.ts` (56) **не правились** и проходят зелёными — основной критерий нерегрессии.
- `getBollingerBands` и `IndicatorCache.bollinger: Map<string, BollingerBandsResult>` сохранили семантику; `BollingerBandsResult` импортируется как тип в `dslEvaluator.ts`.

## Backward compatibility

- `BollingerBandsResult` ранее был `export`-ed из `dslEvaluator.ts`. Проверено `grep`-ом: внешних потребителей нет (ни в `apps/api/src/**`, ни в тестах) → удаление re-export'а из dslEvaluator безопасно. Тип теперь экспортируется через `indicators/index.ts`.
- `DslBacktestReport`, `DslTradeRecord`, `exitReason`, `IndicatorCache.bollinger` — без правок.

## Не входит в задачу

- Решение по SMC primitives (fvgSeries, sweepSeries, orderBlockSeries, mssSeries) и финал `indicators/index.ts` doc-комментария — задача 45-T4.
- `getVolumeProfileCached`, `IndicatorCache`, `getIndicatorValues`, `createIndicatorCache` — out of scope per docs/45 «Не входит в задачу».
- Prisma-миграции отсутствуют.

## Критерии готовности (из docs/45)

- [x] `tsc --noEmit` проходит.
- [x] `BollingerBandsResult` и `calcBollingerBands` доступны через `indicators/index.ts`.
- [x] Объявления `BollingerBandsResult` и `calcBollingerBands` удалены из `dslEvaluator.ts`.
- [x] Все существующие тесты зелёные (98 файлов / 1751 тест, +9 vs T2).

## Тест-план для ревьюера

```bash
cd apps/api
npx prisma generate
npx tsc --noEmit
npx vitest run
```

Branch: `claude/45-t3-extract-bollinger` · 4 files changed (+200/−38) · commit `5f31531`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmfV8BXGWUJSFNGArYKe9k)_