### PR TITLE
docs(indicators): finalize public API surface + defer SMC extraction (45-T4)

### DIFF
--- a/apps/api/src/lib/indicators/index.ts
+++ b/apps/api/src/lib/indicators/index.ts
@@ -3,6 +3,18 @@
  *
  * Each indicator is a pure function: (candles, params) → result array.
  * All results are same-length as input with null for warm-up bars.
+ *
+ * Public API:
+ *   - Moving averages:  calcSMA, calcEMA
+ *   - Momentum:         calcRSI, calcMACD (+ MACDResult)
+ *   - Volatility:       calcATR (+ trueRange), calcBollingerBands (+ BollingerBandsResult)
+ *   - Trend:            calcADX (+ ADXResult), calcSuperTrend (+ SuperTrendResult)
+ *   - Volume-weighted:  calcVWAP
+ *   - Shared types:     Candle
+ *
+ * SMC primitives (fvgSeries, sweepSeries, orderBlockSeries, mssSeries) remain
+ * in `runtime/patternEngine.ts` — extraction deferred to the next refactoring
+ * wave (no public consumer exists outside dslEvaluator / runtime layer).
  */
 
 export type { Candle } from "./types.js";

--- a/apps/api/tests/lib/indicators/index.smoke.test.ts
+++ b/apps/api/tests/lib/indicators/index.smoke.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import {
+  calcSMA,
+  calcEMA,
+  calcRSI,
+  calcBollingerBands,
+  calcATR,
+  trueRange,
+  calcVWAP,
+  calcADX,
+  calcSuperTrend,
+  calcMACD,
+  type Candle,
+  type BollingerBandsResult,
+  type ADXResult,
+  type SuperTrendResult,
+  type MACDResult,
+} from "../../../src/lib/indicators/index.js";
+
+describe("indicators public API (45-T4 smoke)", () => {
+  it("re-exports all base indicator functions through indicators/index.ts", () => {
+    expect(typeof calcSMA).toBe("function");
+    expect(typeof calcEMA).toBe("function");
+    expect(typeof calcRSI).toBe("function");
+    expect(typeof calcBollingerBands).toBe("function");
+    expect(typeof calcATR).toBe("function");
+    expect(typeof trueRange).toBe("function");
+    expect(typeof calcVWAP).toBe("function");
+    expect(typeof calcADX).toBe("function");
+    expect(typeof calcSuperTrend).toBe("function");
+    expect(typeof calcMACD).toBe("function");
+  });
+
+  it("re-exports all base indicator types through indicators/index.ts", () => {
+    // Compile-time check — types must resolve. Construct values to exercise them.
+    const candle: Candle = {
+      openTime: 1_700_000_000_000,
+      open: 100,
+      high: 101,
+      low: 99,
+      close: 100,
+      volume: 1000,
+    };
+    const bb: BollingerBandsResult = { upper: [], middle: [], lower: [] };
+    const adx: ADXResult = { adx: [], plusDI: [], minusDI: [] };
+    const st: SuperTrendResult = { supertrend: [], direction: [] };
+    const macd: MACDResult = { macd: [], signal: [], histogram: [] };
+
+    expect(candle.close).toBe(100);
+    expect(bb.upper).toEqual([]);
+    expect(adx.adx).toEqual([]);
+    expect(st.supertrend).toEqual([]);
+    expect(macd.macd).toEqual([]);
+  });
+
+  it("indicator functions return same-length arrays from a shared candle input", () => {
+    const candles: Candle[] = Array.from({ length: 30 }, (_, i) => ({
+      openTime: 1_700_000_000_000 + i * 60_000,
+      open: 100 + i,
+      high: 101 + i,
+      low: 99 + i,
+      close: 100 + i,
+      volume: 1000,
+    }));
+
+    expect(calcSMA(candles, 14)).toHaveLength(30);
+    expect(calcEMA(candles, 14)).toHaveLength(30);
+    expect(calcRSI(candles, 14)).toHaveLength(30);
+    expect(calcATR(candles, 14)).toHaveLength(30);
+    expect(calcVWAP(candles)).toHaveLength(30);
+    expect(trueRange(candles)).toHaveLength(30);
+
+    const bb = calcBollingerBands(candles, 20, 2);
+    expect(bb.upper).toHaveLength(30);
+    expect(bb.middle).toHaveLength(30);
+    expect(bb.lower).toHaveLength(30);
+
+    const adx = calcADX(candles, 14);
+    expect(adx.adx).toHaveLength(30);
+
+    const st = calcSuperTrend(candles, 10, 3);
+    expect(st.supertrend).toHaveLength(30);
+
+    const macd = calcMACD(candles, 12, 26, 9);
+    expect(macd.macd).toHaveLength(30);
+  });
+});


### PR DESCRIPTION
Финальная задача **45-T4** из `docs/45-indicator-engine-extraction-plan.md`. Завершает цепочку 45-T1 (#294) → 45-T2 (#295) → 45-T3 (#296) → **45-T4**.

## Решение по SMC primitives

Согласно правилу `docs/44` («Indicator engine extraction»):

> Если в рамках этапа появляется более одного нового публичного потребителя SMC-логики вне `dslEvaluator.ts` / runtime-слоя, вынос выполняется в этом этапе; иначе — вторая волна.

Проверка `grep -rln "fvgSeries\|sweepSeries\|orderBlockSeries\|mssSeries" apps/api/src --include="*.ts"`:

```
apps/api/src/lib/dslEvaluator.ts        ← evaluator (исключается)
apps/api/src/lib/runtime/patternEngine.ts ← runtime layer (исключается, definition site)
```

Внешних потребителей вне `dslEvaluator.ts` / `runtime/patternEngine.ts` — **0** (≤ 1) → **SMC остаются в `runtime/patternEngine.ts`**, вынос отложен на следующую волну refactoring. Деферрал явно зафиксирован в doc-комментарии `indicators/index.ts`.

## Что сделано

- `apps/api/src/lib/indicators/index.ts`:
  - Расширен header doc-комментарий — перечисляет полный публичный API surface, сгруппированный по категориям:
    - Moving averages: `calcSMA`, `calcEMA`
    - Momentum: `calcRSI`, `calcMACD` (+ `MACDResult`)
    - Volatility: `calcATR` (+ `trueRange`), `calcBollingerBands` (+ `BollingerBandsResult`)
    - Trend: `calcADX` (+ `ADXResult`), `calcSuperTrend` (+ `SuperTrendResult`)
    - Volume-weighted: `calcVWAP`
    - Shared types: `Candle`
  - Добавлен явный SMC-deferral комментарий с указанием причины.
- `apps/api/tests/lib/indicators/index.smoke.test.ts` — новый smoke-тест (3 кейса):
  - все 10 функций (`calcSMA`, `calcEMA`, `calcRSI`, `calcBollingerBands`, `calcATR`, `trueRange`, `calcVWAP`, `calcADX`, `calcSuperTrend`, `calcMACD`) резолвятся через `indicators/index.ts` и являются functions;
  - все 5 публичных типов (`Candle`, `BollingerBandsResult`, `ADXResult`, `SuperTrendResult`, `MACDResult`) резолвятся (compile-time check + value construction);
  - все индикаторы возвращают массивы длиной = длине входа на одном общем candle-fixture'е.

## Метрика «уменьшения evaluator»

`dslEvaluator.ts` (cumulative T1+T2+T3+T4):

| state | lines |
|---|---|
| pre-T1 (`4a6af47`) | 1207 |
| post-T3 (`1e5601f`) | 1109 |
| **reduction** | **−98** (критерий ≥ 80 ✅) |

Удалены 4 приватные вычислительные функции (`calcSMA`, `calcEMA`, `calcRSI`, `calcBollingerBands`) и интерфейс `BollingerBandsResult`. `getBollingerBands` оставлен как cache-обёртка (использует `IndicatorCache`).

## Не входит в задачу

- Вынос SMC primitives — отложен (явно задокументировано).
- `IndicatorCache`, `getIndicatorValues`, `createIndicatorCache`, `getVolumeProfileCached` — out of scope per docs/45.
- `DslBacktestReport`, `DslTradeRecord`, `exitReason` — без правок.
- Prisma-миграции отсутствуют.

## Критерии готовности (из docs/45-T4)

- [x] `tsc --noEmit` проходит.
- [x] Все существующие тесты зелёные (99 файлов / 1754 теста, +3 smoke).
- [x] `indicators/index.ts` содержит полный список базовых индикаторов в актуализированном doc-комментарии.
- [x] Решение по SMC зафиксировано в PR-описании и в самом файле.
- [x] `dslEvaluator.ts` стал короче на **98 строк** (≥ 80, критерий выполнен).
- [x] Smoke-тест: все 4 базовых индикатора (SMA, EMA, RSI, Bollinger) + остальные 5 (ATR, VWAP, ADX, SuperTrend, MACD) корректно резолвятся через `indicators/index.ts`.

## Тест-план для ревьюера

```bash
cd apps/api
npx prisma generate
npx tsc --noEmit
npx vitest run
```

## Завершение направления

После мёрджа этого PR направление **«1. Indicator engine extraction»** из `docs/44` считается закрытым:
- ✅ базовые индикаторы вынесены в `apps/api/src/lib/indicators/`;
- ✅ единый публичный API через `indicators/index.ts`;
- ✅ связность `dslEvaluator.ts` снижена (1207 → 1109 строк, −98);
- ✅ решение по SMC зафиксировано явно (defer to next wave).

Branch: `claude/45-t4-finalize-indicators` · 2 files changed (+99/−0) · commit `88ff883`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmfV8BXGWUJSFNGArYKe9k)_