### PR TITLE
feat(backtest): lift fillAt into core, add OPEN and NEXT_OPEN modes (46-T1)

### DIFF
--- a/apps/api/src/lib/backtest.ts
+++ b/apps/api/src/lib/backtest.ts
@@ -8,23 +8,31 @@
  * and maintains backward-compatible report types.
  *
  * Execution realism:
- *   fillAt = "CLOSE" — fill at candle close price (only supported value)
+ *   fillAt — fill price reference (default "CLOSE", backward-compatible):
+ *     "CLOSE"     — fill at the signal candle's close (legacy default)
+ *     "OPEN"      — fill at the signal candle's open
+ *     "NEXT_OPEN" — fill at the next candle's open (lookahead-free for
+ *                   indicator signals computed on closed bars)
  *   effectiveEntry = fillPrice * (1 + (feeBps + slippageBps) / 10_000)
  *   effectiveExit  = rawExit  * (1 - feeBps / 10_000)
- *   SL/TP levels and pnlPct are all computed from effective prices.
+ *   SL/TP/trailing trigger on intra-bar high/low and execute at their own
+ *   trigger prices — fillAt does not apply to them. fillAt applies only to
+ *   entry and indicator_exit fills.
  */
 
 import type { Candle } from "./bybitCandles.js";
 import { runDslBacktest } from "./dslEvaluator.js";
-import type { DslBacktestReport, DslTradeRecord, MtfBacktestContext } from "./dslEvaluator.js";
+import type { DslBacktestReport, DslTradeRecord, MtfBacktestContext, DslFillAt } from "./dslEvaluator.js";
 
 // Re-export DSL evaluator types as canonical backtest types
 export type { DslBacktestReport as BacktestReport, DslTradeRecord as TradeRecord, MtfBacktestContext };
 
+export type FillAt = DslFillAt;
+
 export interface ExecOpts {
   feeBps: number;
   slippageBps: number;
-  fillAt: "CLOSE";
+  fillAt: FillAt;
 }
 
 /**
@@ -45,5 +53,6 @@ export function runBacktest(
   return runDslBacktest(candleData, dslJson, {
     feeBps: opts.feeBps ?? 0,
     slippageBps: opts.slippageBps ?? 0,
+    fillAt: opts.fillAt ?? "CLOSE",
   }, mtfContext);
 }

--- a/apps/api/src/lib/dslEvaluator.ts
+++ b/apps/api/src/lib/dslEvaluator.ts
@@ -82,9 +82,12 @@ export interface DslBacktestReport {
   tradeLog: DslTradeRecord[];
 }
 
+export type DslFillAt = "OPEN" | "CLOSE" | "NEXT_OPEN";
+
 export interface DslExecOpts {
   feeBps: number;
   slippageBps: number;
+  fillAt: DslFillAt;
 }
 
 // ---------------------------------------------------------------------------
@@ -727,7 +730,7 @@ export function runDslBacktest(
   opts: Partial<DslExecOpts> = {},
   mtfContext?: MtfBacktestContext,
 ): DslBacktestReport {
-  const { feeBps = 0, slippageBps = 0 } = opts;
+  const { feeBps = 0, slippageBps = 0, fillAt = "CLOSE" } = opts;
 
   // MTF-aware indicator resolution helper (#134-slice4):
   // When mtfContext is provided, indicator refs with sourceTimeframe resolve
@@ -909,6 +912,12 @@ export function runDslBacktest(
       }
 
       // --- Exit checks (priority: SL → trailing → indicator → TP → time) ---
+      //
+      // SL / TP / trailing trigger on intra-bar high/low and execute at their
+      // respective trigger prices — fillAt does NOT apply to them.
+      // fillAt applies only to entry and indicator_exit fills. time_exit and
+      // end_of_data are synthetic forced exits at the bar's close regardless
+      // of fillAt.
 
       // 1. Stop loss
       if (positionSide === "long") {
@@ -963,12 +972,28 @@ export function runDslBacktest(
           const indVals = resolveIndicator(ie.indicator, candles, cache);
           const val = indVals[i];
           if (val !== null && evalOp(ie.condition.op, val, ie.condition.value)) {
-            const exitPrice = c.close;
+            // Resolve exit fill based on fillAt mode (mirror of entry).
+            // For NEXT_OPEN on the last candle there is no next bar — fall
+            // back to current close so the position closes on the bar that
+            // produced the signal rather than rolling beyond the dataset.
+            let exitPrice: number;
+            let exitTime: number;
+            if (fillAt === "OPEN") {
+              exitPrice = c.open;
+              exitTime = c.openTime;
+            } else if (fillAt === "NEXT_OPEN" && i + 1 < candles.length) {
+              const next = candles[i + 1];
+              exitPrice = next.open;
+              exitTime = next.openTime;
+            } else {
+              exitPrice = c.close;
+              exitTime = c.openTime;
+            }
             const pnlDirection = positionSide === "long"
               ? exitPrice * exitMult - effectiveEntry
               : effectiveEntry - exitPrice * exitMult;
             const outcome = pnlDirection > 0 ? "WIN" : pnlDirection < 0 ? "LOSS" : "NEUTRAL";
-            recordTrade(c.openTime, exitPrice, outcome, "indicator_exit", barsHeld);
+            recordTrade(exitTime, exitPrice, outcome, "indicator_exit", barsHeld);
             continue;
           }
         }
@@ -1030,12 +1055,38 @@ export function runDslBacktest(
       // Proximity filter gate
       if (!evaluateProximityFilter(entry.proximityFilter, i, candles, cache)) continue;
 
+      // Resolve fill price based on fillAt mode.
+      //   "CLOSE"     → fill at this bar's close (legacy behavior).
+      //   "OPEN"      → fill at this bar's open.
+      //   "NEXT_OPEN" → fill at the next bar's open (lookahead-free for
+      //                 indicator signals computed on closed bars). If the
+      //                 signal fires on the last candle there is no next bar
+      //                 to execute against — entry is skipped.
+      let entryFillPrice: number;
+      let entryFillTime: number;
+      let entryFillBarIndex: number;
+      if (fillAt === "OPEN") {
+        entryFillPrice = c.open;
+        entryFillTime = c.openTime;
+        entryFillBarIndex = i;
+      } else if (fillAt === "NEXT_OPEN") {
+        if (i + 1 >= candles.length) continue;
+        const next = candles[i + 1];
+        entryFillPrice = next.open;
+        entryFillTime = next.openTime;
+        entryFillBarIndex = i + 1;
+      } else {
+        entryFillPrice = c.close;
+        entryFillTime = c.openTime;
+        entryFillBarIndex = i;
+      }
+
       // Enter position
       inPosition = true;
       positionSide = side;
-      effectiveEntry = c.close * entryMult;
-      entryTime = c.openTime;
-      entryBarIndex = i;
+      effectiveEntry = entryFillPrice * entryMult;
+      entryTime = entryFillTime;
+      entryBarIndex = entryFillBarIndex;
 
       // Compute SL/TP levels
       const levels = computeExitLevels(slDef, tpDef, effectiveEntry, side, i, candles, cache);

--- a/apps/api/tests/lib/dslEvaluator.test.ts
+++ b/apps/api/tests/lib/dslEvaluator.test.ts
@@ -816,3 +816,156 @@ describe("evaluateProximityFilter", () => {
     expect(evaluateProximityFilter(pfFail, 29, trendCandles, cache)).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// 46-T1: fillAt modes — OPEN, CLOSE, NEXT_OPEN
+// ---------------------------------------------------------------------------
+
+describe("dslEvaluator – fillAt modes (46-T1)", () => {
+  it("default fillAt='CLOSE' fills entry at the signal bar's close", () => {
+    const candles = makeFlatThenUp(80, 25, 100, 2);
+    const report = runDslBacktest(candles, makeSmaLongDsl(5, 20, 2, 4));
+    expect(report.trades).toBeGreaterThanOrEqual(1);
+
+    const first = report.tradeLog[0];
+    const entryBar = candles.find((c) => c.openTime === first.entryTime)!;
+    // No fee/slippage by default → entryPrice exactly equals close.
+    expect(first.entryPrice).toBeCloseTo(entryBar.close, 10);
+  });
+
+  it("fillAt='OPEN' fills entry at the signal bar's open", () => {
+    const candles = makeFlatThenUp(80, 25, 100, 2);
+    const report = runDslBacktest(candles, makeSmaLongDsl(5, 20, 2, 4), {
+      fillAt: "OPEN",
+    });
+    expect(report.trades).toBeGreaterThanOrEqual(1);
+
+    const first = report.tradeLog[0];
+    const entryBar = candles.find((c) => c.openTime === first.entryTime)!;
+    expect(first.entryPrice).toBeCloseTo(entryBar.open, 10);
+    // Sanity: makeFlatThenUp seeds open = close - step*0.3 in the trend phase,
+    // so OPEN < CLOSE on the entry bar.
+    expect(first.entryPrice).toBeLessThan(entryBar.close);
+  });
+
+  it("fillAt='NEXT_OPEN' fills entry at the next bar's open and shifts entryTime", () => {
+    const candles = makeFlatThenUp(80, 25, 100, 2);
+    // Reference run with CLOSE to locate the signal bar.
+    const refReport = runDslBacktest(candles, makeSmaLongDsl(5, 20, 2, 4));
+    const refSignalTime = refReport.tradeLog[0].entryTime;
+    const refSignalIdx = candles.findIndex((c) => c.openTime === refSignalTime);
+    expect(refSignalIdx).toBeGreaterThanOrEqual(0);
+    expect(refSignalIdx + 1).toBeLessThan(candles.length);
+
+    const report = runDslBacktest(candles, makeSmaLongDsl(5, 20, 2, 4), {
+      fillAt: "NEXT_OPEN",
+    });
+    expect(report.trades).toBeGreaterThanOrEqual(1);
+
+    const first = report.tradeLog[0];
+    const expectedBar = candles[refSignalIdx + 1];
+    expect(first.entryTime).toBe(expectedBar.openTime);
+    expect(first.entryPrice).toBeCloseTo(expectedBar.open, 10);
+  });
+
+  it("fillAt='NEXT_OPEN' skips entry when the signal fires on the last candle", () => {
+    // Construct a fixture where the SMA crossover fires only on the very last
+    // bar: 25 flat bars then a single sharp upward jump. With SMA(2)/SMA(3)
+    // and a one-bar spike at the end, the crossover lands on the last bar.
+    const candles = [];
+    for (let i = 0; i < 4; i++) {
+      candles.push({
+        openTime: 1_700_000_000_000 + i * 60_000,
+        open: 100, high: 100, low: 100, close: 100, volume: 1000,
+      });
+    }
+    candles.push({
+      openTime: 1_700_000_000_000 + 4 * 60_000,
+      open: 100, high: 200, low: 100, close: 200, volume: 1000,
+    });
+
+    const dsl = makeSmaLongDsl(2, 3, 2, 4);
+    const closeReport = runDslBacktest(candles, dsl, { fillAt: "CLOSE" });
+    const nextOpenReport = runDslBacktest(candles, dsl, { fillAt: "NEXT_OPEN" });
+
+    // Signal fires on the last bar (index 4) under CLOSE → 1 trade closed via end_of_data.
+    expect(closeReport.trades).toBe(1);
+    // NEXT_OPEN has no next candle → entry skipped, no trade recorded.
+    expect(nextOpenReport.trades).toBe(0);
+  });
+
+  it("fillAt='NEXT_OPEN' indicator_exit on the last candle falls back to current close", () => {
+    // Fixture: SMA(2) crosses above SMA(3) on bar 3, then RSI(2) > 70 on
+    // bar 4 forces an indicator_exit on the last candle. With NEXT_OPEN the
+    // exit must fall back to bar 4's close (no next bar exists).
+    const candles = [
+      { openTime: 0,       open: 100, high: 100, low: 100, close: 100, volume: 1000 },
+      { openTime: 60_000,  open: 100, high: 100, low: 100, close: 100, volume: 1000 },
+      { openTime: 120_000, open: 100, high: 100, low: 100, close: 100, volume: 1000 },
+      { openTime: 180_000, open: 150, high: 200, low: 150, close: 200, volume: 1000 },
+      { openTime: 240_000, open: 250, high: 300, low: 250, close: 300, volume: 1000 },
+    ];
+
+    const dsl = {
+      id: "rsi-exit-last",
+      name: "RSI exit on last bar",
+      dslVersion: 2,
+      enabled: true,
+      market: { exchange: "bybit", env: "demo", category: "linear", symbol: "BTCUSDT" },
+      entry: {
+        side: "Buy",
+        signal: {
+          type: "crossover",
+          fast: { blockType: "SMA", length: 2 },
+          slow: { blockType: "SMA", length: 3 },
+        },
+      },
+      exit: {
+        // SL/TP set wide so they don't fire on this fixture.
+        stopLoss: { type: "fixed_pct", value: 99 },
+        takeProfit: { type: "fixed_pct", value: 99 },
+        indicatorExit: {
+          indicator: { type: "RSI", length: 2 },
+          condition: { op: "gt", value: 70 },
+          appliesTo: "long",
+        },
+      },
+      risk: { maxPositionSizeUsd: 100, riskPerTradePct: 99, cooldownSeconds: 0 },
+      execution: { orderType: "Market", clientOrderIdPrefix: "test_" },
+      guards: { maxOpenPositions: 1, maxOrdersPerMinute: 10, pauseOnError: true },
+    };
+
+    const report = runDslBacktest(candles, dsl, { fillAt: "NEXT_OPEN" });
+    const indExits = report.tradeLog.filter((t) => t.exitReason === "indicator_exit");
+    expect(indExits.length).toBe(1);
+
+    const exit = indExits[0];
+    const lastBar = candles[candles.length - 1];
+    expect(exit.exitTime).toBe(lastBar.openTime);
+    // Fallback path: no next candle → exit fills at the current bar's close.
+    expect(exit.exitPrice).toBeCloseTo(lastBar.close, 10);
+  });
+
+  it("fillAt='OPEN' indicator_exit fills at the signal bar's open", () => {
+    const candles = makeFlatThenUp(80, 25, 100, 2);
+    const dsl = {
+      ...makeSmaLongDsl(5, 20, 50, 50),
+      exit: {
+        stopLoss: { type: "fixed_pct", value: 50 },
+        takeProfit: { type: "fixed_pct", value: 50 },
+        indicatorExit: {
+          indicator: { type: "RSI", length: 14 },
+          condition: { op: "gt", value: 70 },
+          appliesTo: "both",
+        },
+      },
+    };
+    const report = runDslBacktest(candles, dsl, { fillAt: "OPEN" });
+    const indExits = report.tradeLog.filter((t) => t.exitReason === "indicator_exit");
+    expect(indExits.length).toBeGreaterThanOrEqual(1);
+
+    const exit = indExits[0];
+    const exitBar = candles.find((c) => c.openTime === exit.exitTime)!;
+    expect(exit.exitPrice).toBeCloseTo(exitBar.open, 10);
+  });
+});


### PR DESCRIPTION
Реализация задачи **46-T1** из `docs/46-backtest-realism-plan.md`. Открывает направление «2. Backtest realism» из `docs/44`.

## Что сделано

### Ядро (`dslEvaluator.ts`)

- Добавлен `export type DslFillAt = "OPEN" | "CLOSE" | "NEXT_OPEN"`.
- `DslExecOpts` расширен полем `fillAt: DslFillAt`. В `runDslBacktest` поле дефолтится в `"CLOSE"` через destructuring → **все существующие вызовы работают без правок**.
- Entry-fill (бывший хардкод `c.close * entryMult`) заменён на `fillAt`-aware блок:
  - `"CLOSE"`     → `c.close * entryMult` (legacy default).
  - `"OPEN"`      → `c.open * entryMult`, `entryTime = c.openTime`, `entryBarIndex = i`.
  - `"NEXT_OPEN"` → `candles[i+1].open * entryMult`, `entryTime = candles[i+1].openTime`, `entryBarIndex = i+1`. Если `i+1 >= candles.length` → entry **пропускается** (`continue`), trade не открывается.
- `indicator_exit` (бывший хардкод `c.close`) использует тот же switch:
  - `"CLOSE"`/`"OPEN"` → текущая свеча.
  - `"NEXT_OPEN"` → next candle's open. Если next нет → fallback на `c.close` (deg­raded), чтобы позиция не повисла.
- Перед блоком SL→TP→trailing→indicator→time-exit добавлен явный комментарий: «SL/TP/trailing trigger on intra-bar high/low and execute at their own trigger prices — fillAt does NOT apply to them. fillAt applies only to entry and indicator_exit fills. time_exit and end_of_data are synthetic forced exits at the bar's close regardless of fillAt.»

### Wrapper (`backtest.ts`)

- `ExecOpts` отзеркалил `fillAt: FillAt` (FillAt = DslFillAt).
- `runBacktest` пробрасывает `opts.fillAt ?? "CLOSE"` в `runDslBacktest`.
- Header docstring обновлён — перечислены три значения `fillAt` и явно указано, что fillAt не применяется к SL/TP/trailing.

## Backward compatibility (per docs/46 §«Backward compatibility checklist»)

- ✅ Все вызовы `runBacktest({feeBps, slippageBps})` без `fillAt` → default `"CLOSE"`, идентичное поведение.
- ✅ Явный `fillAt: "CLOSE"` → бит-в-бит совпадает с pre-46 версией.
- ✅ `routes/lab.ts` продолжает использовать узкий `ALLOWED_FILL_AT = ["CLOSE"]` — пользователи API не получают `OPEN`/`NEXT_OPEN` до **46-T4**, который явно расширит валидацию.
- ✅ Prisma не трогается (`BacktestResult.fillAt String @default("CLOSE")` уже совместим).
- ✅ Все 56 существующих тестов в `dslEvaluator.test.ts` — без правок и зелёные.

## Тесты (6 новых кейсов)

`apps/api/tests/lib/dslEvaluator.test.ts` — новый блок `describe("dslEvaluator – fillAt modes (46-T1)")`:

1. **default fillAt='CLOSE'** — `entryPrice == bar.close` (sanity).
2. **fillAt='OPEN'** — `entryPrice == bar.open` + sanity-check `OPEN < CLOSE` для `makeFlatThenUp` (open=close-step*0.3 в trend-фазе).
3. **fillAt='NEXT_OPEN'** — нахождение signal-бара через reference run, затем assert `entryPrice == candles[signalIdx+1].open` и `entryTime == candles[signalIdx+1].openTime`.
4. **NEXT_OPEN edge: signal на последней свече** — фикстура с резким спайком на последнем баре; CLOSE даёт 1 trade, NEXT_OPEN даёт **0** (entry skipped, нет next-бара).
5. **NEXT_OPEN edge: indicator_exit на последней свече** — handcrafted 5-бар фикстура (SMA(2) cross SMA(3) на bar 3, RSI(2) > 70 на bar 4). Assert `exitPrice == lastBar.close` (fallback path).
6. **fillAt='OPEN' indicator_exit** — `exit.exitPrice == bar.open`.

## Не входит в задачу (per docs/46 § «Не входит в задачу»)

- Симметричный slippage на exit — задача **46-T2**.
- `takerFeeBps`/`makerFeeBps` alias — задача **46-T3**.
- API/UI экспонирование (`routes/lab.ts`, `ClassicMode.tsx`, `test/page.tsx`) — задача **46-T4**.
- Golden-table тесты по 12-комбинационной матрице — задача **46-T5**.
- Funding accrual, partial fills, queue/latency model — out of scope всего документа.
- Изменение SL/TP/trailing/end_of_data поведения — явно **запрещено** планом.

## Зависимости и анлоки

После мёрджа 46-T1:
- ✅ `docs/47-T3` (Strategy Optimizer sweep) разблокирован — больше не нужно хардкодить `fillAt: "CLOSE"`.
- ✅ `docs/48-T5` (Walk-Forward) разблокирован — `WalkForwardRequestBody.fillAt?: FillAt` становится возможным.

## Критерии готовности (из docs/46-T1)

- [x] `tsc --noEmit` проходит.
- [x] Все существующие тесты зелёные (99 файлов / 1760 тестов).
- [x] Новые тест-кейсы (6) зелёные.
- [x] В `backtest.ts` docstring отражает три значения `fillAt`.

## Тест-план для ревьюера

```bash
cd apps/api
npx prisma generate
npx tsc --noEmit
npx vitest run
```

Branch: `claude/46-t1-fillat-into-core` · 3 files changed (+223/−10) · commit `20c7871`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmfV8BXGWUJSFNGArYKe9k)_