### PR TITLE
feat(backtest): apply slippage symmetrically on entry and exit (46-T2)

### DIFF
--- a/apps/api/src/lib/backtest.ts
+++ b/apps/api/src/lib/backtest.ts
@@ -14,7 +14,11 @@
  *     "NEXT_OPEN" — fill at the next candle's open (lookahead-free for
  *                   indicator signals computed on closed bars)
  *   effectiveEntry = fillPrice * (1 + (feeBps + slippageBps) / 10_000)
- *   effectiveExit  = rawExit  * (1 - feeBps / 10_000)
+ *   effectiveExit  = rawExit  * (1 - (feeBps + slippageBps) / 10_000)
+ *   Slippage is symmetric: applied at both entry (cost up) and exit
+ *   (proceeds down) — round-trip cost reflects realistic market conditions.
+ *   At slippageBps = 0 the formulas reduce to fee-only behavior; existing
+ *   results with default slippage stay bit-for-bit unchanged.
  *   SL/TP/trailing trigger on intra-bar high/low and execute at their own
  *   trigger prices — fillAt does not apply to them. fillAt applies only to
  *   entry and indicator_exit fills.

--- a/apps/api/src/lib/dslEvaluator.ts
+++ b/apps/api/src/lib/dslEvaluator.ts
@@ -795,8 +795,12 @@ export function runDslBacktest(
   // Pre-compute indicator cache
   const cache = createIndicatorCache();
 
+  // Symmetric round-trip cost: slippage applied at BOTH entry (cost up) and
+  // exit (proceeds down). When slippageBps = 0 these formulas reduce to the
+  // pre-46 behavior (only feeBps shaves both sides), so existing tests with
+  // default slippage stay bit-for-bit identical.
   const entryMult = 1 + (feeBps + slippageBps) / 10_000;
-  const exitMult = 1 - feeBps / 10_000;
+  const exitMult = 1 - (feeBps + slippageBps) / 10_000;
 
   const tradeLog: DslTradeRecord[] = [];
 

--- a/apps/api/tests/lib/dslEvaluator.test.ts
+++ b/apps/api/tests/lib/dslEvaluator.test.ts
@@ -411,6 +411,114 @@ describe("dslEvaluator – execution opts (fees/slippage)", () => {
       expect(withFees.totalPnlPct).toBeLessThanOrEqual(noFees.totalPnlPct + 0.01);
     }
   });
+
+  // -------------------------------------------------------------------------
+  // 46-T2: symmetric slippage on entry AND exit
+  // -------------------------------------------------------------------------
+
+  it("46-T2: slippage applies symmetrically on entry and exit (long)", () => {
+    const candles = makeFlatThenUp(80, 25, 100, 2);
+    const dsl = makeSmaLongDsl(5, 20, 2, 4);
+    const slippageBps = 50;
+
+    const baseline = runDslBacktest(candles, dsl, { feeBps: 0, slippageBps: 0 });
+    const withSlip = runDslBacktest(candles, dsl, { feeBps: 0, slippageBps });
+
+    expect(baseline.trades).toBeGreaterThanOrEqual(1);
+    expect(withSlip.trades).toBe(baseline.trades);
+
+    const entryMult = 1 + slippageBps / 10_000;
+    const exitMult = 1 - slippageBps / 10_000;
+
+    for (const trade of withSlip.tradeLog) {
+      // Entry: default fillAt = "CLOSE" → raw entry is bar.close.
+      const entryBar = candles.find((c) => c.openTime === trade.entryTime)!;
+      expect(trade.entryPrice / entryBar.close).toBeCloseTo(entryMult, 8);
+
+      // Exit: rawExitPrice depends on exit reason. For SL/TP the trigger
+      // price is captured in slPrice/tpPrice; effective exit = trigger * exitMult.
+      // For indicator/time/end_of_data the raw exit is bar.close.
+      if (trade.exitReason === "sl") {
+        expect(trade.exitPrice / trade.slPrice).toBeCloseTo(exitMult, 8);
+      } else if (trade.exitReason === "tp") {
+        expect(trade.exitPrice / trade.tpPrice).toBeCloseTo(exitMult, 8);
+      } else {
+        const exitBar = candles.find((c) => c.openTime === trade.exitTime)!;
+        expect(trade.exitPrice / exitBar.close).toBeCloseTo(exitMult, 8);
+      }
+    }
+  });
+
+  it("46-T2: slippage applies symmetrically on entry and exit (short)", () => {
+    const candles = makeFlatThenDown(80, 25, 200, 2);
+    const dsl = makeSmaShortDsl(5, 20, 2, 4);
+    const slippageBps = 50;
+
+    const baseline = runDslBacktest(candles, dsl, { feeBps: 0, slippageBps: 0 });
+    const withSlip = runDslBacktest(candles, dsl, { feeBps: 0, slippageBps });
+
+    expect(baseline.trades).toBeGreaterThanOrEqual(1);
+    expect(withSlip.trades).toBe(baseline.trades);
+
+    const entryMult = 1 + slippageBps / 10_000;
+    const exitMult = 1 - slippageBps / 10_000;
+
+    for (const trade of withSlip.tradeLog) {
+      const entryBar = candles.find((c) => c.openTime === trade.entryTime)!;
+      expect(trade.entryPrice / entryBar.close).toBeCloseTo(entryMult, 8);
+      if (trade.exitReason === "sl") {
+        expect(trade.exitPrice / trade.slPrice).toBeCloseTo(exitMult, 8);
+      } else if (trade.exitReason === "tp") {
+        expect(trade.exitPrice / trade.tpPrice).toBeCloseTo(exitMult, 8);
+      } else {
+        const exitBar = candles.find((c) => c.openTime === trade.exitTime)!;
+        expect(trade.exitPrice / exitBar.close).toBeCloseTo(exitMult, 8);
+      }
+    }
+  });
+
+  it("46-T2: slippageBps > 0 strictly reduces totalPnlPct in a multi-trade run", () => {
+    // Long-side strategy on flat-then-up — with default SL/TP=2/4 we get
+    // multiple trades over an 80-bar series, enough to make the slippage
+    // delta clearly negative in aggregate.
+    const candles = makeFlatThenUp(80, 25, 100, 2);
+    const dsl = makeSmaLongDsl(5, 20, 2, 4);
+
+    const noSlip = runDslBacktest(candles, dsl, { feeBps: 0, slippageBps: 0 });
+    const withSlip = runDslBacktest(candles, dsl, { feeBps: 0, slippageBps: 100 });
+
+    expect(withSlip.trades).toBe(noSlip.trades);
+    expect(withSlip.trades).toBeGreaterThanOrEqual(1);
+    // Strictly less when slippage > 0 (real round-trip cost is non-zero).
+    expect(withSlip.totalPnlPct).toBeLessThan(noSlip.totalPnlPct);
+  });
+
+  it("46-T2: slippageBps = 0 keeps the engine bit-identical to fee-only behavior", () => {
+    // Backward-compat anchor: at slippageBps = 0, the new symmetric formula
+    // reduces to old fee-only behavior on exit (exitMult = 1 - feeBps/10_000).
+    // Verify entry/exit multipliers match the legacy expectation directly.
+    const candles = makeFlatThenUp(80, 25, 100, 2);
+    const dsl = makeSmaLongDsl(5, 20, 2, 4);
+    const feeBps = 30;
+    const report = runDslBacktest(candles, dsl, { feeBps, slippageBps: 0 });
+
+    const expectedEntryMult = 1 + feeBps / 10_000;
+    const expectedExitMult = 1 - feeBps / 10_000;
+
+    expect(report.trades).toBeGreaterThanOrEqual(1);
+    for (const trade of report.tradeLog) {
+      const entryBar = candles.find((c) => c.openTime === trade.entryTime)!;
+      expect(trade.entryPrice / entryBar.close).toBeCloseTo(expectedEntryMult, 8);
+      if (trade.exitReason === "sl") {
+        expect(trade.exitPrice / trade.slPrice).toBeCloseTo(expectedExitMult, 8);
+      } else if (trade.exitReason === "tp") {
+        expect(trade.exitPrice / trade.tpPrice).toBeCloseTo(expectedExitMult, 8);
+      } else {
+        const exitBar = candles.find((c) => c.openTime === trade.exitTime)!;
+        expect(trade.exitPrice / exitBar.close).toBeCloseTo(expectedExitMult, 8);
+      }
+    }
+  });
 });
 
 describe("dslEvaluator – report field rounding", () => {


### PR DESCRIPTION
Реализация задачи **46-T2** из `docs/46-backtest-realism-plan.md`. Продолжение направления «Backtest realism» после 46-T1 (#298).

## Что сделано

Изменена формула `exitMult` в `runDslBacktest`:

```diff
  const entryMult = 1 + (feeBps + slippageBps) / 10_000;
- const exitMult  = 1 - feeBps / 10_000;
+ const exitMult  = 1 - (feeBps + slippageBps) / 10_000;
```

Теперь slippage применяется **симметрично**: как cost увеличивается на entry, так и proceeds уменьшаются на exit.

- **Long**: bought higher, sold lower → реальный round-trip cost.
- **Short**: shorted lower (фактический entry — продажа в short), covered higher (фактический exit — покупка) → симметричная картина.

Обновлены header-комментарии в `dslEvaluator.ts` (с явной ссылкой на bit-identical поведение при `slippageBps = 0`) и в `backtest.ts` (новая формула и note про backward compatibility).

## Backward compatibility (per docs/46 §«Backward compatibility checklist»)

- ✅ **При `slippageBps = 0`** новые формулы тождественны старым: `entryMult = 1 + feeBps/10_000`, `exitMult = 1 - feeBps/10_000`. Все 96 ранее существовавших тестов проходят **без правок**.
- ✅ Существующий тест `dslEvaluator.test.ts:402` (`fees reduce effective PnL`) использует `slippageBps: 5` с loose-проверкой `withFees.totalPnlPct ≤ noFees.totalPnlPct + 0.01` — всё ещё проходит (новая формула делает проверку строже, но не ломает её).
- ⚠️ **При `slippageBps > 0`** `totalPnlPct` строго уменьшается — это **сознательное** изменение, отражающее реальный round-trip cost. Старые `BacktestResult` записи остаются интерпретируемыми по `engineVersion`, который уже фиксируется в каждой записи (`process.env.COMMIT_SHA ?? "unknown"`). Сравнимость абсолютных pnlPct между записями разных engineVersion — не гарантируется (это ожидаемо).

## Тесты (4 новых кейса)

Все добавлены в `describe("dslEvaluator – execution opts (fees/slippage)")`:

1. **`46-T2: slippage applies symmetrically on entry and exit (long)`** — для каждого trade в `withSlip.tradeLog`:
   - `trade.entryPrice / bar.close == 1 + slippageBps/10_000`;
   - для exit'а: SL → ratio к `trade.slPrice`, TP → к `trade.tpPrice`, indicator/time/end_of_data → к `bar.close`. Все ratio == `1 - slippageBps/10_000`.
2. **`(short)`** — симметрично на `makeFlatThenDown`.
3. **`slippageBps > 0 strictly reduces totalPnlPct in a multi-trade run`** — multi-trade fixture, assert `withSlip.totalPnlPct < noSlip.totalPnlPct` (строго).
4. **Backward-compat anchor** — `slippageBps = 0, feeBps = 30`: проверяет, что мультипликаторы точно равны legacy формулам fee-only. Это «контракт» того, что bit-identical reduction соблюдается.

## Не входит в задачу (per docs/46 § «Не входит в задачу»)

- `takerFeeBps`/`makerFeeBps` alias — задача **46-T3**.
- API/UI — задача **46-T4**.
- Golden-table 12-комбинационная — задача **46-T5**.
- Funding/partial fills/queue — out of scope всего документа.

## Критерии готовности (из docs/46-T2)

- [x] `tsc --noEmit` проходит.
- [x] Все существующие тесты зелёные (99 файлов / 1764 теста, +4 vs T1).
- [x] Шапка `backtest.ts` и `dslEvaluator.ts` отражают симметричную формулу.

## Тест-план для ревьюера

```bash
cd apps/api
npx prisma generate
npx tsc --noEmit
npx vitest run
```

Branch: `claude/46-t2-symmetric-slippage` · 3 files changed (+118/−2) · commit `d61c58b`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmfV8BXGWUJSFNGArYKe9k)_