### PR TITLE
feat(lab): expose fillAt + taker/maker fees through API and UI (46-T4)

### DIFF
--- a/apps/api/prisma/migrations/20260428000000_add_backtestsweep_fillat/migration.sql
+++ b/apps/api/prisma/migrations/20260428000000_add_backtestsweep_fillat/migration.sql
@@ -1,0 +1,5 @@
+-- 46-T4: persist fillAt per sweep so each run replays with the same
+-- execution model. Additive migration — existing rows default to "CLOSE",
+-- which matches their actual pre-46 behavior.
+
+ALTER TABLE "BacktestSweep" ADD COLUMN "fillAt" TEXT NOT NULL DEFAULT 'CLOSE';

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -597,7 +597,7 @@ model BacktestResult {
   datasetHash   String?
   feeBps        Int            @default(0)
   slippageBps   Int            @default(0)
-  /// Fill price reference; Stage 19 v2.2 fixes to "CLOSE"
+  /// Fill price reference; supports OPEN | CLOSE | NEXT_OPEN per docs/46
   fillAt        String         @default("CLOSE")
   engineVersion String         @default("unknown")
   /// Phase 5 — explicit StrategyVersion binding for reproducible backtests
@@ -692,6 +692,9 @@ model BacktestSweep {
   sweepParamJson    Json
   feeBps            Int
   slippageBps       Int
+  /// Fill price reference; persisted per sweep so each run replays with the
+  /// same execution model (docs/46-T4). Existing rows default to "CLOSE".
+  fillAt            String      @default("CLOSE")
   status            SweepStatus @default(PENDING)
   progress          Int         @default(0)
   runCount          Int

--- a/apps/api/src/routes/lab.ts
+++ b/apps/api/src/routes/lab.ts
@@ -26,8 +26,16 @@ import {
 // Constants
 // ---------------------------------------------------------------------------
 
-/** Stage 19 v2.2: fill price reference is fixed to CLOSE */
-const ALLOWED_FILL_AT = ["CLOSE"] as const;
+/**
+ * Fill price reference (docs/46): three modes are supported.
+ *   "CLOSE"     — fill at the signal candle's close (legacy default).
+ *   "OPEN"      — fill at the signal candle's open.
+ *   "NEXT_OPEN" — fill at the next candle's open (lookahead-free for
+ *                 indicator signals computed on closed bars).
+ * The preview endpoint pins "CLOSE" intentionally — preview is a sanity
+ * check, not a full execution-realism rehearsal.
+ */
+const ALLOWED_FILL_AT = ["OPEN", "CLOSE", "NEXT_OPEN"] as const;
 type FillAt = typeof ALLOWED_FILL_AT[number];
 
 /** Reasonable upper bound for fee/slippage to prevent nonsensical inputs */
@@ -49,7 +57,12 @@ const PREVIEW_MAX_HOURS = 168;
 interface StartBacktestBody {
   strategyVersionId: string;
   datasetId: string;
+  /** @deprecated use takerFeeBps; retained as a backward-compat alias (docs/46-T3). */
   feeBps?: number;
+  /** Taker (market-order) fee in basis points (docs/46-T3). */
+  takerFeeBps?: number;
+  /** Maker (limit-order) fee in basis points; reserved, not yet used in formulas (docs/46-T3). */
+  makerFeeBps?: number;
   slippageBps?: number;
   fillAt?: FillAt;
 }
@@ -390,10 +403,16 @@ export async function labRoutes(app: FastifyInstance) {
     const {
       strategyVersionId,
       datasetId,
-      feeBps = 0,
+      feeBps,
+      takerFeeBps,
+      makerFeeBps,
       slippageBps = 0,
       fillAt = "CLOSE",
     } = request.body ?? {};
+
+    // 46-T3 fee normalization: takerFeeBps wins over the deprecated feeBps
+    // alias. The canonical taker value is what we persist + use downstream.
+    const effectiveTakerFeeBps = takerFeeBps ?? feeBps ?? 0;
 
     // ── Validation ──────────────────────────────────────────────────────────
     const errors: Array<{ field: string; message: string }> = [];
@@ -401,8 +420,18 @@ export async function labRoutes(app: FastifyInstance) {
     if (!strategyVersionId) errors.push({ field: "strategyVersionId", message: "strategyVersionId is required (Phase 5 explicit version binding)" });
     if (!datasetId)         errors.push({ field: "datasetId",         message: "datasetId is required (dataset-first contract)" });
 
-    if (!Number.isInteger(feeBps) || feeBps < 0 || feeBps > MAX_BPS) {
-      errors.push({ field: "feeBps", message: `feeBps must be integer 0–${MAX_BPS}` });
+    if (
+      !Number.isInteger(effectiveTakerFeeBps)
+      || effectiveTakerFeeBps < 0
+      || effectiveTakerFeeBps > MAX_BPS
+    ) {
+      errors.push({ field: "takerFeeBps", message: `takerFeeBps (or legacy feeBps) must be integer 0–${MAX_BPS}` });
+    }
+    if (
+      makerFeeBps !== undefined
+      && (!Number.isInteger(makerFeeBps) || makerFeeBps < 0 || makerFeeBps > MAX_BPS)
+    ) {
+      errors.push({ field: "makerFeeBps", message: `makerFeeBps must be integer 0–${MAX_BPS}` });
     }
     if (!Number.isInteger(slippageBps) || slippageBps < 0 || slippageBps > MAX_BPS) {
       errors.push({ field: "slippageBps", message: `slippageBps must be integer 0–${MAX_BPS}` });
@@ -449,10 +478,13 @@ export async function labRoutes(app: FastifyInstance) {
         fromTs,
         toTs,
         status:            "PENDING",
-        // Reproducibility snapshot
+        // Reproducibility snapshot. The existing `feeBps` column persists
+        // the canonical taker fee — the wider takerFeeBps/makerFeeBps split
+        // (docs/46-T3) lives in the API surface only until limit-order mode
+        // ships and a column for makerFeeBps is needed.
         datasetId:         dataset.id,
         datasetHash:       dataset.datasetHash,
-        feeBps,
+        feeBps:            effectiveTakerFeeBps,
         slippageBps,
         fillAt,
         engineVersion,
@@ -561,6 +593,9 @@ export async function labRoutes(app: FastifyInstance) {
 
     let report;
     try {
+      // Preview is a synchronous sanity-check — fillAt is intentionally
+      // pinned to "CLOSE" regardless of what the strategy will use in a
+      // full backtest (docs/46-T4).
       report = runBacktest(candles, dslJson, { feeBps: 0, slippageBps: 0, fillAt: "CLOSE" });
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -848,11 +883,15 @@ export async function labRoutes(app: FastifyInstance) {
       sweepParam,
       feeBps = 0,
       slippageBps = 0,
+      fillAt = "CLOSE",
     } = request.body ?? {};
 
     // ── Validation ──────────────────────────────────────────────────────────
     if (!datasetId || !strategyVersionId || !sweepParam) {
       return problem(reply, 400, "Validation Error", "datasetId, strategyVersionId, and sweepParam are required");
+    }
+    if (!ALLOWED_FILL_AT.includes(fillAt as FillAt)) {
+      return problem(reply, 400, "Validation Error", `fillAt must be one of: ${ALLOWED_FILL_AT.join(", ")}`);
     }
 
     if (!sweepParam.blockId || !sweepParam.paramName) {
@@ -916,6 +955,7 @@ export async function labRoutes(app: FastifyInstance) {
         sweepParamJson: sweepParam as object,
         feeBps,
         slippageBps,
+        fillAt,
         runCount,
         status: "PENDING",
       },
@@ -1239,6 +1279,7 @@ interface SweepRequestBody {
   };
   feeBps?: number;
   slippageBps?: number;
+  fillAt?: FillAt;
 }
 
 interface SweepRow {
@@ -1336,7 +1377,7 @@ async function runSweepAsync(sweepId: string): Promise<void> {
           datasetHash: dataset.datasetHash,
           feeBps: sweep.feeBps,
           slippageBps: sweep.slippageBps,
-          fillAt: "CLOSE",
+          fillAt: sweep.fillAt,
           engineVersion,
         },
       });
@@ -1346,7 +1387,7 @@ async function runSweepAsync(sweepId: string): Promise<void> {
         const report = runBacktest(candles, mutatedDsl, {
           feeBps: sweep.feeBps,
           slippageBps: sweep.slippageBps,
-          fillAt: "CLOSE",
+          fillAt: sweep.fillAt as FillAt,
         });
 
         await prisma.backtestResult.update({
@@ -1478,11 +1519,13 @@ async function runBacktestAsync(
     // Fetch fee/slippage from the BacktestResult record
     const btRecord = await prisma.backtestResult.findUnique({ where: { id: btId } });
 
-    // DSL-driven backtest — behavior determined entirely by compiled DSL
+    // DSL-driven backtest — behavior determined entirely by compiled DSL.
+    // The persisted fillAt is replayed so re-execution matches the original
+    // request (docs/46-T4).
     const report = runBacktest(candles, dslJson, {
       feeBps:      btRecord?.feeBps      ?? 0,
       slippageBps: btRecord?.slippageBps ?? 0,
-      fillAt:      "CLOSE",
+      fillAt:      (btRecord?.fillAt as FillAt | undefined) ?? "CLOSE",
     });
 
     await prisma.backtestResult.update({

--- a/apps/api/tests/routes/lab.test.ts
+++ b/apps/api/tests/routes/lab.test.ts
@@ -410,6 +410,80 @@ describe("POST /api/v1/lab/backtest", () => {
     });
     expect(res.statusCode).toBe(404);
   });
+
+  // 46-T4: fillAt now accepts OPEN | CLOSE | NEXT_OPEN. Each test uses a
+  // distinct X-Forwarded-For so the per-route rate-limit (5 req/min/ip) is
+  // not exhausted by the existing six tests above.
+  const fillAtHeaders = (ip: string) => ({ ...authHeaders(), "x-forwarded-for": ip });
+
+  it("46-T4: accepts fillAt=OPEN and persists it", async () => {
+    mockStrategyVersions["sv-1"] = { id: "sv-1", strategyId: "strat-1", strategy: { workspaceId: WS_ID }, dslJson: {} };
+    mockDatasets["ds-1"] = { id: "ds-1", workspaceId: WS_ID, exchange: "bybit", symbol: "BTCUSDT", interval: "M15", fromTsMs: BigInt(1704067200000), toTsMs: BigInt(1706745600000), datasetHash: "abc" };
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/lab/backtest",
+      headers: fillAtHeaders("10.46.4.1"),
+      payload: { strategyVersionId: "sv-1", datasetId: "ds-1", fillAt: "OPEN" },
+    });
+    expect(res.statusCode).toBe(202);
+    expect(res.json().fillAt).toBe("OPEN");
+  });
+
+  it("46-T4: accepts fillAt=NEXT_OPEN and persists it", async () => {
+    mockStrategyVersions["sv-1"] = { id: "sv-1", strategyId: "strat-1", strategy: { workspaceId: WS_ID }, dslJson: {} };
+    mockDatasets["ds-1"] = { id: "ds-1", workspaceId: WS_ID, exchange: "bybit", symbol: "BTCUSDT", interval: "M15", fromTsMs: BigInt(1704067200000), toTsMs: BigInt(1706745600000), datasetHash: "abc" };
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/lab/backtest",
+      headers: fillAtHeaders("10.46.4.2"),
+      payload: { strategyVersionId: "sv-1", datasetId: "ds-1", fillAt: "NEXT_OPEN" },
+    });
+    expect(res.statusCode).toBe(202);
+    expect(res.json().fillAt).toBe("NEXT_OPEN");
+  });
+
+  it("46-T4: rejects unknown fillAt with 400", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/lab/backtest",
+      headers: fillAtHeaders("10.46.4.3"),
+      payload: { strategyVersionId: "sv-1", datasetId: "ds-1", fillAt: "BOGUS" },
+    });
+    expect(res.statusCode).toBe(400);
+    const body = res.json();
+    expect(JSON.stringify(body)).toContain("fillAt");
+  });
+
+  it("46-T4: defaults fillAt to CLOSE when omitted", async () => {
+    mockStrategyVersions["sv-1"] = { id: "sv-1", strategyId: "strat-1", strategy: { workspaceId: WS_ID }, dslJson: {} };
+    mockDatasets["ds-1"] = { id: "ds-1", workspaceId: WS_ID, exchange: "bybit", symbol: "BTCUSDT", interval: "M15", fromTsMs: BigInt(1704067200000), toTsMs: BigInt(1706745600000), datasetHash: "abc" };
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/lab/backtest",
+      headers: fillAtHeaders("10.46.4.4"),
+      payload: { strategyVersionId: "sv-1", datasetId: "ds-1" },
+    });
+    expect(res.statusCode).toBe(202);
+    expect(res.json().fillAt).toBe("CLOSE");
+  });
+
+  it("46-T4: takerFeeBps overrides legacy feeBps in persisted feeBps column", async () => {
+    mockStrategyVersions["sv-1"] = { id: "sv-1", strategyId: "strat-1", strategy: { workspaceId: WS_ID }, dslJson: {} };
+    mockDatasets["ds-1"] = { id: "ds-1", workspaceId: WS_ID, exchange: "bybit", symbol: "BTCUSDT", interval: "M15", fromTsMs: BigInt(1704067200000), toTsMs: BigInt(1706745600000), datasetHash: "abc" };
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/lab/backtest",
+      headers: fillAtHeaders("10.46.4.5"),
+      payload: { strategyVersionId: "sv-1", datasetId: "ds-1", feeBps: 10, takerFeeBps: 30 },
+    });
+    expect(res.statusCode).toBe(202);
+    // The canonical taker fee wins over the deprecated alias.
+    expect(res.json().feeBps).toBe(30);
+  });
 });
 
 // ── GET /lab/backtest/:id ───────────────────────────────────────────────────
@@ -485,6 +559,22 @@ describe("POST /api/v1/lab/backtest/sweep", () => {
       },
     });
     expect(res.statusCode).toBe(422);
+  });
+
+  // 46-T4: sweep accepts and persists fillAt.
+  it("46-T4: rejects unknown fillAt with 400", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/lab/backtest/sweep",
+      headers: authHeaders(),
+      payload: {
+        datasetId: "ds-1",
+        strategyVersionId: "sv-1",
+        sweepParam: { blockId: "b1", paramName: "p1", from: 1, to: 5, step: 1 },
+        fillAt: "BOGUS",
+      },
+    });
+    expect(res.statusCode).toBe(400);
   });
 });
 

--- a/apps/web/src/app/lab/ClassicMode.tsx
+++ b/apps/web/src/app/lab/ClassicMode.tsx
@@ -77,9 +77,18 @@ interface BacktestItem {
   datasetHash: string | null;
   feeBps: number;
   slippageBps: number;
-  fillAt: string;
+  fillAt: FillAt;
   engineVersion: string;
 }
+
+/** Fill price reference (docs/46): three modes are supported. */
+type FillAt = "OPEN" | "CLOSE" | "NEXT_OPEN";
+
+const FILL_AT_LABELS: Record<FillAt, string> = {
+  CLOSE: "On candle close (default)",
+  OPEN: "On candle open",
+  NEXT_OPEN: "Next candle open (lookahead-free)",
+};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -468,6 +477,7 @@ export function AuthLabClassicMode() {
   const [datasets, setDatasets] = useState<DatasetItem[]>([]);
   const [strategyId, setStrategyId] = useState("");
   const [datasetId, setDatasetId] = useState("");
+  const [fillAt, setFillAt] = useState<FillAt>("CLOSE");
 
   const [running, setRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -538,7 +548,7 @@ export function AuthLabClassicMode() {
         datasetId: datasetId.trim(),
         feeBps: 0,
         slippageBps: 0,
-        fillAt: "CLOSE",
+        fillAt,
       }),
     });
 
@@ -626,6 +636,19 @@ export function AuthLabClassicMode() {
               {selectedDataset.candleCount} candles · hash: <code>{shortHash(selectedDataset.datasetHash)}</code> · {selectedDataset.status}
             </div>
           )}
+
+          <label style={{ ...labelStyle, gridColumn: "1 / -1" }}>
+            Fill price (execution model)
+            <select
+              style={inputStyle}
+              value={fillAt}
+              onChange={(e) => setFillAt(e.target.value as FillAt)}
+            >
+              {(Object.keys(FILL_AT_LABELS) as FillAt[]).map((k) => (
+                <option key={k} value={k}>{FILL_AT_LABELS[k]}</option>
+              ))}
+            </select>
+          </label>
         </div>
 
         {error && (

--- a/apps/web/src/app/lab/test/page.tsx
+++ b/apps/web/src/app/lab/test/page.tsx
@@ -38,6 +38,15 @@ type TopTab = "backtest" | "optimise";
 
 type BacktestStatus = "PENDING" | "RUNNING" | "DONE" | "FAILED";
 
+/** Fill price reference (docs/46): three modes are supported. */
+type FillAt = "OPEN" | "CLOSE" | "NEXT_OPEN";
+
+const FILL_AT_LABELS: Record<FillAt, string> = {
+  CLOSE: "On candle close (default)",
+  OPEN: "On candle open",
+  NEXT_OPEN: "Next candle open (lookahead-free)",
+};
+
 interface BacktestListItem {
   id: string;
   strategyId: string;
@@ -51,7 +60,7 @@ interface BacktestListItem {
   status: BacktestStatus;
   feeBps: number;
   slippageBps: number;
-  fillAt: string;
+  fillAt: FillAt;
   engineVersion: string;
   reportJson: BacktestReport | null;
   errorMessage: string | null;
@@ -442,7 +451,7 @@ function BacktestForm({
 }: {
   datasets: DatasetListItem[];
   strategyVersions: StrategyVersionItem[];
-  onSubmit: (params: { strategyVersionId: string; datasetId: string; feeBps: number; slippageBps: number }) => void;
+  onSubmit: (params: { strategyVersionId: string; datasetId: string; feeBps: number; slippageBps: number; fillAt: FillAt }) => void;
   submitting: boolean;
   error: string | null;
   activeDatasetId: string | null;
@@ -454,6 +463,7 @@ function BacktestForm({
   const [versionId, setVersionId] = useState(lastCompileVersionId ?? strategyVersions[0]?.id ?? "");
   const [feeBps, setFeeBps] = useState(10);
   const [slippageBps, setSlippageBps] = useState(5);
+  const [fillAt, setFillAt] = useState<FillAt>("CLOSE");
 
   // Sync default dataset when props change
   useEffect(() => {
@@ -551,6 +561,20 @@ function BacktestForm({
         </FormRow>
       </div>
 
+      {/* Fill price reference (execution model) */}
+      <FormRow label="Fill price (execution model)">
+        <select
+          style={selectStyle}
+          value={fillAt}
+          onChange={(e) => setFillAt(e.target.value as FillAt)}
+          disabled={submitting}
+        >
+          {(Object.keys(FILL_AT_LABELS) as FillAt[]).map((k) => (
+            <option key={k} value={k}>{FILL_AT_LABELS[k]}</option>
+          ))}
+        </select>
+      </FormRow>
+
       {error && <div style={errorBoxStyle}>{error}</div>}
 
       <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
@@ -561,7 +585,7 @@ function BacktestForm({
             cursor: canSubmit ? "pointer" : "not-allowed",
           }}
           disabled={!canSubmit}
-          onClick={() => onSubmit({ strategyVersionId: versionId, datasetId, feeBps, slippageBps })}
+          onClick={() => onSubmit({ strategyVersionId: versionId, datasetId, feeBps, slippageBps, fillAt })}
         >
           {submitting ? "Starting…" : "Run Backtest"}
         </button>
@@ -1086,7 +1110,7 @@ function ResultDetail({
   activeDatasetId: string | null;
   lastCompileVersionId: string | null;
   lastCompileGraphVersionId: string | null;
-  onSubmit: (params: { strategyVersionId: string; datasetId: string; feeBps: number; slippageBps: number }) => void;
+  onSubmit: (params: { strategyVersionId: string; datasetId: string; feeBps: number; slippageBps: number; fillAt: FillAt }) => void;
 }) {
   const [activeTab, setActiveTab] = useState<ResultTab>("run");
 
@@ -1298,6 +1322,7 @@ export default function LabTestPage() {
     datasetId: string;
     feeBps: number;
     slippageBps: number;
+    fillAt: FillAt;
   }) => {
     if (!getWorkspaceId()) return;
     setSubmitting(true);
@@ -1305,7 +1330,7 @@ export default function LabTestPage() {
 
     const res = await apiFetch<BacktestListItem>("/lab/backtest", {
       method: "POST",
-      body: JSON.stringify({ ...params, fillAt: "CLOSE" }),
+      body: JSON.stringify(params),
     });
 
     setSubmitting(false);


### PR DESCRIPTION
Реализация задачи **46-T4** из `docs/46-backtest-realism-plan.md`. Замыкает 46-T1 (#298) → 46-T2 (#299) → 46-T3 (#300) → **46-T4** в API/UI.

## Что сделано

### API (`apps/api/src/routes/lab.ts`)

- `ALLOWED_FILL_AT = ["OPEN", "CLOSE", "NEXT_OPEN"] as const`. Doc-комментарий фиксирует, что **preview-эндпоинт намеренно остаётся pinned-CLOSE** (sanity-check, не execution-realism rehearsal).
- `StartBacktestBody` расширен:
  - `takerFeeBps?: number`, `makerFeeBps?: number` — новые поля 46-T3.
  - `feeBps?: number` сохранён как deprecated alias.
  - Серверная нормализация: `effectiveTakerFeeBps = takerFeeBps ?? feeBps ?? 0`. Записывается в существующую колонку `BacktestResult.feeBps` (additive, без миграции для нового поля).
  - Валидация: `takerFeeBps`/`makerFeeBps` (если присутствует) проверяется на `[0, MAX_BPS]`.
- `SweepRequestBody.fillAt?: FillAt` + валидация против `ALLOWED_FILL_AT`. Значение **персистится в `BacktestSweep.fillAt`** через новую колонку → каждый run внутри `runSweepAsync` реплеит с тем же execution-model.
- `runSweepAsync`: `sweep.fillAt` пробрасывается в `BacktestResult.create({ fillAt: sweep.fillAt })` и в `runBacktest({ fillAt: sweep.fillAt })`.
- Одиночный backtest fire-and-forget (`runBacktestAsync`): `btRecord?.fillAt` теперь реплеится (вместо хардкода `"CLOSE"`).
- Хардкод `fillAt: "CLOSE"` остался только в preview, с явным комментарием почему.

### Prisma

- **Миграция** `20260428000000_add_backtestsweep_fillat`:
  ```sql
  ALTER TABLE "BacktestSweep" ADD COLUMN "fillAt" TEXT NOT NULL DEFAULT 'CLOSE';
  ```
  Additive, безопасна — старые записи получают `"CLOSE"`, что соответствует их фактическому pre-46 поведению.
- `BacktestSweep.fillAt String @default("CLOSE")` в schema.prisma + doc-comment.
- `BacktestResult.fillAt` doc-comment обновлён со «Stage 19 v2.2 fixes to "CLOSE"» на «supports OPEN | CLOSE | NEXT_OPEN per docs/46».

### UI

**`apps/web/src/app/lab/ClassicMode.tsx`:**
- Типизация `BacktestItem.fillAt: FillAt` (вместо `string`).
- Локальный тип `FillAt` + словарь `FILL_AT_LABELS` с человекочитаемыми подписями: «On candle close (default)», «On candle open», «Next candle open (lookahead-free)».
- `useState<FillAt>("CLOSE")` + `<select>` рядом с dataset-селектом.
- POST `/lab/backtest` body теперь шлёт значение из state (не хардкод).

**`apps/web/src/app/lab/test/page.tsx`:**
- Тип `FillAt` + `FILL_AT_LABELS` + `BacktestListItem.fillAt: FillAt`.
- `BacktestForm`: новый state `fillAt` с default `"CLOSE"`, новый `<FormRow label="Fill price">` с `<select>`. `onSubmit` сигнатура расширена.
- `handleSubmit` больше не подмешивает `fillAt: "CLOSE"` — пробрасывает значение из формы.
- Snapshot-ряд `bt.fillAt` уже существовал — без правок (просто отображает новые значения).
- **Не вводился отдельный UI** для `takerFeeBps`/`makerFeeBps` (план §6: «UI для двух полей — отдельная задача после внедрения maker-режима»).

### e2e тесты (`apps/api/tests/routes/lab.test.ts`)

6 новых кейсов с distinct `X-Forwarded-For` per request — обходим per-route rate limit (5 req/min/ip):

1. `accepts fillAt=OPEN and persists it` — `BacktestResult.fillAt = "OPEN"`.
2. `accepts fillAt=NEXT_OPEN and persists it`.
3. `rejects unknown fillAt with 400` (single backtest).
4. `defaults fillAt to CLOSE when omitted`.
5. `takerFeeBps overrides legacy feeBps in persisted feeBps column` (`feeBps: 10, takerFeeBps: 30` → персистится `30`).
6. `sweep: rejects unknown fillAt with 400`.

## Backward compatibility (per docs/46 §«Backward compatibility checklist»)

- ✅ POST без `fillAt` → default `"CLOSE"` (validated by test).
- ✅ Существующие 75 тестов в `lab.test.ts` — без правок и зелёные.
- ✅ Старые `BacktestResult` записи: `fillAt` колонка уже существовала, миграции для них не нужно.
- ✅ Старые `BacktestSweep` записи получают `"CLOSE"` через DEFAULT в новой колонке — соответствует их фактическому поведению.
- ✅ Preview сохраняет `fillAt: "CLOSE"` — никакой regress на preview-вызовы.
- ✅ Frontend default = `"CLOSE"`; пользователи, которые не открывают новый `<select>`, видят прежнее поведение.

## Не входит в задачу (per docs/46 § «Не входит в задачу»)

- Golden-table тесты по 12-комбинационной матрице — задача **46-T5**.
- UI для `takerFeeBps`/`makerFeeBps` (отдельные input-поля) — после внедрения maker-режима.
- Удаление deprecated `feeBps` — отдельная follow-up задача.
- Funding/partial fills/queue — out of scope.

## Зависимости (анлоки после мёрджа)

- ✅ `docs/47-T3` (Strategy Optimizer sweep) — sweep уже принимает `fillAt`, замена хардкода завершена.
- ✅ `docs/48-T5` (Walk-Forward) — Backend готов принимать `fillAt` через любой новый body, добавление в WalkForwardRequestBody — тривиально.

## Критерии готовности (из docs/46-T4)

- [x] `tsc --noEmit` проходит и в api, и в web.
- [x] Все существующие тесты зелёные (99 файлов / 1774 теста, +6 vs T3).
- [x] Новые e2e тесты (6) зелёные.
- [x] Хардкоды `"CLOSE"` в `lab.ts` остались только в preview (обоснованно).
- [x] Lab UI golden-path доступен в браузере для всех трёх значений `fillAt` (`<select>` добавлен в обоих режимах Lab).

## Тест-план для ревьюера

```bash
cd apps/api
npx prisma generate
npx prisma migrate deploy   # apply BacktestSweep.fillAt migration
npx tsc --noEmit
npx vitest run

cd ../../apps/web
npx tsc --noEmit
```

Smoke в Lab → Test:
1. Запуск с «On candle close» — `pnlPct` совпадает с pre-46-T1 значением (golden); snapshot показывает `CLOSE`.
2. Запуск с «Next candle open» — `pnlPct` отличается (как ожидается); snapshot показывает `NEXT_OPEN`.
3. Sweep с `fillAt: OPEN` — все runs внутри sweep имеют `BacktestResult.fillAt = "OPEN"`.

Branch: `claude/46-t4-fillat-api-ui` · 6 files changed (+208/−19) + new migration · commit `3295c15`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmfV8BXGWUJSFNGArYKe9k)_