### PR TITLE
feat(metrics): create backtestMetrics module with sharpe / pf / expectancy (49-T1)

### DIFF
--- a/apps/api/src/lib/backtestMetrics/expectancy.ts
+++ b/apps/api/src/lib/backtestMetrics/expectancy.ts
@@ -1,0 +1,32 @@
+/**
+ * Per-trade expectancy in percent units:
+ *
+ *   E = winRate * avgWin - lossRate * avgLoss
+ *
+ * where avgWin = mean(positive pnl%), avgLoss = mean(|negative pnl%|),
+ * winRate = wins.length / totalTrades, lossRate = losses.length / totalTrades.
+ *
+ * Conventions:
+ *   - Empty array       → null.
+ *   - Single trade      → degenerates to its own pnl% (winRate=1, avgWin=pnl
+ *                         for a winning trade; lossRate=1, avgLoss=|pnl| for
+ *                         a losing trade).
+ *   - Zero-pnl trades   → counted in totalTrades but contribute 0 to both
+ *                         numerator and denominator.
+ *
+ * Result is rounded to 2 decimals.
+ *
+ * Pure, deterministic — no I/O, no side effects.
+ *
+ * @param pnlPcts Array of per-trade PnL percentages.
+ */
+export function expectancy(pnlPcts: number[]): number | null {
+  if (pnlPcts.length === 0) return null;
+  const wins = pnlPcts.filter((v) => v > 0);
+  const losses = pnlPcts.filter((v) => v < 0).map((v) => -v);
+  const winRate = wins.length / pnlPcts.length;
+  const lossRate = losses.length / pnlPcts.length;
+  const avgWin = wins.length ? wins.reduce((s, v) => s + v, 0) / wins.length : 0;
+  const avgLoss = losses.length ? losses.reduce((s, v) => s + v, 0) / losses.length : 0;
+  return Math.round((winRate * avgWin - lossRate * avgLoss) * 100) / 100;
+}

--- a/apps/api/src/lib/backtestMetrics/index.ts
+++ b/apps/api/src/lib/backtestMetrics/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Backtest metrics — pure statistical functions over per-trade PnL series.
+ *
+ * Each function takes an array of per-trade PnL percentages and returns a
+ * single scalar (or null when the metric cannot be computed). No I/O, no
+ * dependencies on the evaluator, the database, or HTTP layer.
+ *
+ * Public API:
+ *   - sharpeRatio     — annualized Sharpe (default 252 periods/year)
+ *   - profitFactor    — gross profit / gross loss
+ *   - expectancy      — winRate * avgWin - lossRate * avgLoss
+ */
+
+export { sharpeRatio } from "./sharpe.js";
+export { profitFactor } from "./profitFactor.js";
+export { expectancy } from "./expectancy.js";

--- a/apps/api/src/lib/backtestMetrics/profitFactor.ts
+++ b/apps/api/src/lib/backtestMetrics/profitFactor.ts
@@ -1,0 +1,34 @@
+/**
+ * Profit factor — gross profit divided by gross loss.
+ *
+ *   profitFactor = sum(pnl% > 0) / |sum(pnl% < 0)|
+ *
+ * Conventions:
+ *   - Empty array                 → null.
+ *   - All wins, no losses         → +Infinity (consumers must handle this
+ *                                   explicitly — e.g. ranking treats Infinity
+ *                                   as "best", JSON serializers may need
+ *                                   special handling).
+ *   - All losses, no wins         → 0.
+ *   - Both gross and loss are 0   → null (no information; trades were all
+ *                                   exactly breakeven or array contains only
+ *                                   zeros).
+ *
+ * Result is rounded to 2 decimals (Infinity is preserved as-is).
+ *
+ * Pure, deterministic — no I/O, no side effects.
+ *
+ * @param pnlPcts Array of per-trade PnL percentages.
+ */
+export function profitFactor(pnlPcts: number[]): number | null {
+  if (pnlPcts.length === 0) return null;
+  let gross = 0;
+  let loss = 0;
+  for (const v of pnlPcts) {
+    if (v > 0) gross += v;
+    else if (v < 0) loss += -v;
+  }
+  if (loss === 0 && gross === 0) return null;
+  if (loss === 0) return Number.POSITIVE_INFINITY;
+  return Math.round((gross / loss) * 100) / 100;
+}

--- a/apps/api/src/lib/backtestMetrics/sharpe.ts
+++ b/apps/api/src/lib/backtestMetrics/sharpe.ts
@@ -1,0 +1,32 @@
+/**
+ * Annualized Sharpe ratio over per-trade PnL percentages.
+ *
+ *   Sharpe = (mean / stdDev) * sqrt(periodsPerYear)
+ *
+ * `stdDev` is the sample standard deviation (Bessel's correction, n-1).
+ * Result is rounded to 2 decimals to match the historical lab.ts contract.
+ *
+ * Returns null when:
+ *   - the input has fewer than 2 trades (variance undefined);
+ *   - all returns are equal (stdDev = 0).
+ *
+ * Limitation: the function treats per-trade returns as if they were daily
+ * returns; a more accurate annualization would require per-bar returns and
+ * is left as future work. The 252-default mirrors the legacy implementation
+ * in apps/api/src/routes/lab.ts (`computeSharpe`) bit-for-bit so existing
+ * sweep results stay numerically comparable across the 49-T2/T3 migration.
+ *
+ * Pure, deterministic — no I/O, no side effects.
+ *
+ * @param pnlPcts        Array of per-trade PnL percentages.
+ * @param periodsPerYear Annualization factor (default 252, ≈ trading days).
+ */
+export function sharpeRatio(pnlPcts: number[], periodsPerYear = 252): number | null {
+  if (pnlPcts.length < 2) return null;
+  const mean = pnlPcts.reduce((s, v) => s + v, 0) / pnlPcts.length;
+  const variance =
+    pnlPcts.reduce((s, v) => s + (v - mean) ** 2, 0) / (pnlPcts.length - 1);
+  const stdDev = Math.sqrt(variance);
+  if (stdDev === 0) return null;
+  return Math.round((mean / stdDev) * Math.sqrt(periodsPerYear) * 100) / 100;
+}

--- a/apps/api/tests/lib/backtestMetrics/expectancy.test.ts
+++ b/apps/api/tests/lib/backtestMetrics/expectancy.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { expectancy } from "../../../src/lib/backtestMetrics/expectancy.js";
+
+describe("expectancy", () => {
+  it("returns null on an empty array", () => {
+    expect(expectancy([])).toBeNull();
+  });
+
+  it("matches a hand-calculated reference (mixed wins/losses)", () => {
+    // pnl = [2, -1, 3, -2, 1]
+    //   wins=[2,3,1] losses-abs=[1,2]
+    //   winRate=3/5=0.6  lossRate=2/5=0.4
+    //   avgWin=(2+3+1)/3=2  avgLoss=(1+2)/2=1.5
+    //   E = 0.6*2 - 0.4*1.5 = 1.2 - 0.6 = 0.60
+    expect(expectancy([2, -1, 3, -2, 1])).toBe(0.6);
+  });
+
+  it("returns 0 for a balanced 50/50 win/loss with equal magnitudes", () => {
+    // winRate=0.5, avgWin=2, lossRate=0.5, avgLoss=2 → 0
+    expect(expectancy([2, -2, 2, -2])).toBe(0);
+  });
+
+  it("matches a hand-calculated asymmetric series", () => {
+    // 60% wins at +2, 40% losses at -1: 5 trades [2,2,2,-1,-1]
+    //   winRate=0.6 avgWin=2  lossRate=0.4 avgLoss=1
+    //   E = 0.6*2 - 0.4*1 = 1.2 - 0.4 = 0.80
+    expect(expectancy([2, 2, 2, -1, -1])).toBe(0.8);
+  });
+
+  it("returns the trade's own pnl% for a single winning trade", () => {
+    expect(expectancy([3.5])).toBe(3.5);
+  });
+
+  it("returns the trade's own pnl% (negative) for a single losing trade", () => {
+    expect(expectancy([-1.25])).toBe(-1.25);
+  });
+
+  it("returns positive expectancy for an all-wins series", () => {
+    // winRate=1, avgWin=mean, lossRate=0, avgLoss=0 → mean of wins.
+    // [1.5, 2.0, 0.5] → mean = 4/3 ≈ 1.3333 → rounded 1.33
+    expect(expectancy([1.5, 2.0, 0.5])).toBe(1.33);
+  });
+
+  it("returns negative expectancy for an all-losses series", () => {
+    // [-1, -2, -0.5] → avgLoss = 3.5/3 ≈ 1.1667 → -1.17
+    expect(expectancy([-1, -2, -0.5])).toBe(-1.17);
+  });
+
+  it("counts zero-pnl entries in totalTrades but contributes nothing", () => {
+    // [2, 0, -1, 0] → wins=[2] losses=[1]
+    //   winRate=1/4=0.25 lossRate=1/4=0.25
+    //   avgWin=2 avgLoss=1
+    //   E = 0.25*2 - 0.25*1 = 0.25
+    expect(expectancy([2, 0, -1, 0])).toBe(0.25);
+  });
+});

--- a/apps/api/tests/lib/backtestMetrics/profitFactor.test.ts
+++ b/apps/api/tests/lib/backtestMetrics/profitFactor.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { profitFactor } from "../../../src/lib/backtestMetrics/profitFactor.js";
+
+describe("profitFactor", () => {
+  it("returns null on an empty array", () => {
+    expect(profitFactor([])).toBeNull();
+  });
+
+  it("returns null when all entries are exactly zero", () => {
+    // Both gross and loss are 0 → no information to report.
+    expect(profitFactor([0, 0, 0])).toBeNull();
+  });
+
+  it("returns +Infinity for a series of wins with no losses", () => {
+    expect(profitFactor([1.5, 2.0, 0.5])).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it("returns 0 for a series of losses with no wins", () => {
+    expect(profitFactor([-1, -2, -0.5])).toBe(0);
+  });
+
+  it("matches a hand-calculated reference (mixed wins/losses)", () => {
+    // gross = 2 + 3 + 1 = 6; loss = 1 + 2 = 3; pf = 6 / 3 = 2.00
+    expect(profitFactor([2, -1, 3, -2, 1])).toBe(2);
+  });
+
+  it("rounds to 2 decimals (gross 5, loss 3 → 1.67)", () => {
+    expect(profitFactor([5, -3])).toBe(1.67);
+  });
+
+  it("ignores zero entries (treated as neither win nor loss)", () => {
+    expect(profitFactor([2, 0, -1, 0])).toBe(2);
+  });
+});

--- a/apps/api/tests/lib/backtestMetrics/sharpe.test.ts
+++ b/apps/api/tests/lib/backtestMetrics/sharpe.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { sharpeRatio } from "../../../src/lib/backtestMetrics/sharpe.js";
+
+/**
+ * Bit-for-bit copy of the pre-49-T3 `computeSharpe` from
+ * apps/api/src/routes/lab.ts (lines 1461–1468 in main @ 6580564).
+ * Locks the numerical contract so any future change to `sharpeRatio` is
+ * caught against the historical lab.ts implementation.
+ */
+function legacyComputeSharpe(pnlPcts: number[]): number | null {
+  if (pnlPcts.length < 2) return null;
+  const mean = pnlPcts.reduce((s, v) => s + v, 0) / pnlPcts.length;
+  const variance =
+    pnlPcts.reduce((s, v) => s + (v - mean) ** 2, 0) / (pnlPcts.length - 1);
+  const stdDev = Math.sqrt(variance);
+  if (stdDev === 0) return null;
+  return Math.round((mean / stdDev) * Math.sqrt(252) * 100) / 100;
+}
+
+describe("sharpeRatio", () => {
+  it("returns null for fewer than 2 trades", () => {
+    expect(sharpeRatio([])).toBeNull();
+    expect(sharpeRatio([1.5])).toBeNull();
+  });
+
+  it("returns null when all returns are equal (stdDev = 0)", () => {
+    expect(sharpeRatio([2, 2, 2, 2])).toBeNull();
+    expect(sharpeRatio([0, 0])).toBeNull();
+  });
+
+  it("matches a hand-calculated reference (mixed wins/losses)", () => {
+    // Hand-calc:
+    //   pnl = [2, -1, 3, -2, 1]
+    //   mean = 3/5 = 0.6
+    //   sumSq = 1.96 + 2.56 + 5.76 + 6.76 + 0.16 = 17.2
+    //   variance = 17.2 / (5 - 1) = 4.3
+    //   stdDev = sqrt(4.3) ≈ 2.0736
+    //   mean / stdDev ≈ 0.28934
+    //   * sqrt(252) ≈ 4.5933 → rounded 4.59
+    expect(sharpeRatio([2, -1, 3, -2, 1])).toBeCloseTo(4.59, 2);
+  });
+
+  it("returns a negative value for a losing series with positive variance", () => {
+    const result = sharpeRatio([-1, -2, -0.5]);
+    expect(result).not.toBeNull();
+    expect(result as number).toBeLessThan(0);
+  });
+
+  it("respects custom periodsPerYear", () => {
+    // sqrt(1) = 1 → annualization is a no-op, just rounded mean/stdDev.
+    const result = sharpeRatio([2, -1, 3, -2, 1], 1);
+    // mean/stdDev ≈ 0.28934, rounded 0.29
+    expect(result).toBeCloseTo(0.29, 2);
+  });
+
+  it("is bit-for-bit identical to the legacy computeSharpe (regression anchor)", () => {
+    const fixtures: number[][] = [
+      [],
+      [3.5],
+      [2, -1, 3, -2, 1],
+      [1.5, 2.0, 0.5],
+      [-1, -2, -0.5],
+      [0.1, -0.05, 0.2, -0.15, 0.3, -0.1],
+      Array.from({ length: 50 }, (_, i) => Math.sin(i / 5)),
+    ];
+    for (const fx of fixtures) {
+      expect(sharpeRatio(fx)).toBe(legacyComputeSharpe(fx));
+    }
+  });
+});


### PR DESCRIPTION
Реализация задачи **49-T1** из `docs/49-backtest-metrics-plan.md`. Открывает направление «3. Backtest metrics» из `docs/44`.

## Что сделано

Создан изолированный модуль `apps/api/src/lib/backtestMetrics/` с тремя pure-функциями:

| Файл | Экспорт | Контракт |
|---|---|---|
| `sharpe.ts` | `sharpeRatio(pnlPcts, periodsPerYear=252)` | Annualized Sharpe; `n<2` или `stdDev=0` → `null`; bit-в-bit копия legacy `computeSharpe`. |
| `profitFactor.ts` | `profitFactor(pnlPcts)` | `gross/loss`; `[]` → `null`; all-wins → `+Infinity`; all-losses → `0`; всё-нули → `null`. |
| `expectancy.ts` | `expectancy(pnlPcts)` | `winRate*avgWin - lossRate*avgLoss`; `[]` → `null`; single-trade → собственный pnl%. |
| `index.ts` | re-exports | Только эти три функции; никаких side-effect-импортов. |

### Решение по неймингу

Per docs/49 §«Решение по неймингу модуля»: имя **`backtestMetrics/`** (не `metrics/`) — устраняет коллизию с уже существующим `apps/api/src/lib/metrics.ts` (Prometheus, 8 importer-ов). Существующий `metrics.ts` **не переименовывается** — это отдельный домен (HTTP/runtime observability), out of scope.

## Backward compatibility

- ✅ Никаких импортов из `dslEvaluator`, БД, Express. Это pure utility модуль — следующие задачи (49-T2/T3) будут импортировать из него.
- ✅ Существующий `computeSharpe` в `lab.ts` не тронут. 49-T3 удалит его, после того как 49-T2 заполнит `report.sharpe`.
- ✅ `sharpeRatio` бит-в-bit идентичен legacy `computeSharpe`: 7-fixture regression test это закрепляет.
- ✅ Никакой Prometheus-метрики не затронуто.

## Тесты (22 новых кейса)

Новая директория `apps/api/tests/lib/backtestMetrics/`:

### `sharpe.test.ts` (6 кейсов)
- `n < 2` → null;
- stdDev = 0 → null;
- hand-calc reference (`[2,-1,3,-2,1]` → 4.59);
- negative series → < 0;
- `periodsPerYear=1` (no annualization) → 0.29;
- **regression test**: 7 фикстур (включая `Math.sin(i/5)` для i=0..49), `sharpeRatio(fx) === legacyComputeSharpe(fx)` для каждой. Legacy implementation вшит в тест-файл как закреплённая копия из `lab.ts:1461-1468`.

### `profitFactor.test.ts` (7 кейсов)
- `[]` → null;
- all-zero → null;
- all-wins → `+Infinity`;
- all-losses → 0;
- hand-calc (`[2,-1,3,-2,1]` → 2);
- rounding 2dp (`[5,-3]` → 1.67);
- zero-entries не считаются ни win, ни loss.

### `expectancy.test.ts` (9 кейсов)
- `[]` → null;
- hand-calc reference (`[2,-1,3,-2,1]` → 0.6);
- balanced 50/50 same magnitudes → 0;
- asymmetric (`[2,2,2,-1,-1]` → 0.8);
- single win/loss degenerate (`[3.5]` → 3.5; `[-1.25]` → -1.25);
- all-wins (`[1.5,2.0,0.5]` → 1.33);
- all-losses (`[-1,-2,-0.5]` → -1.17);
- zero-entries в totalTrades не дают вклада.

## Не входит в задачу (per docs/49 § «Не входит в задачу»)

- Заполнение `DslBacktestReport.{sharpe, profitFactor, expectancy}` — задача **49-T2**.
- Удаление `computeSharpe` из `lab.ts` и переход sweep/compare на `report.sharpe` — задача **49-T3**.
- Sortino, Calmar, Omega, MAR, Tail ratio — отдельный follow-up.
- Per-side метрики, equity-curve в отчёте, confidence intervals — out of scope.
- Переименование `metrics.ts` (Prometheus) — out of scope.

## Критерии готовности (из docs/49-T1)

- [x] `tsc --noEmit` проходит.
- [x] Все unit-тесты зелёные (103 файла / 1800 тестов, +22 vs main).
- [x] Никаких импортов из `dslEvaluator`, БД, Express.
- [x] `sharpeRatio` бит-в-bit соответствует legacy `computeSharpe` (regression test).

## Тест-план для ревьюера

```bash
cd apps/api
npx prisma generate
npx tsc --noEmit
npx vitest run tests/lib/backtestMetrics/   # 3 files, 22 tests
npx vitest run                              # full suite — 103 files, 1800 tests
```

Branch: `claude/49-t1-backtest-metrics` · 7 files added (+274) · commit `6311335`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmfV8BXGWUJSFNGArYKe9k)_