### PR TITLE
refactor(lab): drop local computeSharpe, read metrics from report (49-T3)

### DIFF
--- a/apps/api/src/routes/lab.ts
+++ b/apps/api/src/routes/lab.ts
@@ -695,6 +695,10 @@ export async function labRoutes(app: FastifyInstance) {
         ? (num(reportA.trades)! - num(reportB.trades)!) : null,
       sharpeDelta: num(reportA.sharpe) !== null && num(reportB.sharpe) !== null
         ? (num(reportA.sharpe)! - num(reportB.sharpe)!) : null,
+      profitFactorDelta: num(reportA.profitFactor) !== null && num(reportB.profitFactor) !== null
+        ? (num(reportA.profitFactor)! - num(reportB.profitFactor)!) : null,
+      expectancyDelta: num(reportA.expectancy) !== null && num(reportB.expectancy) !== null
+        ? (num(reportA.expectancy)! - num(reportB.expectancy)!) : null,
     };
 
     // Task 26: enrich compare response with lineage data
@@ -1290,6 +1294,9 @@ interface SweepRow {
   maxDrawdownPct: number;
   tradeCount: number;
   sharpe: number | null;
+  /** Risk-adjusted ranking inputs (49-T3). Both can be null when undefined. */
+  profitFactor: number | null;
+  expectancy: number | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -1395,9 +1402,10 @@ async function runSweepAsync(sweepId: string): Promise<void> {
           data: { status: "DONE", reportJson: report as unknown as object },
         });
 
-        // Compute Sharpe ratio (annualised, assuming 365 trading days)
-        const sharpe = computeSharpe(report.tradeLog.map((t) => t.pnlPct));
-
+        // Risk-adjusted metrics now come straight from the report (49-T3).
+        // The local computeSharpe helper has been removed; sharpeRatio in
+        // apps/api/src/lib/backtestMetrics is bit-for-bit identical (locked
+        // by the 49-T1 regression test), so SweepRow.sharpe is unchanged.
         results.push({
           paramValue: roundedParam,
           backtestResultId: bt.id,
@@ -1405,7 +1413,9 @@ async function runSweepAsync(sweepId: string): Promise<void> {
           winRate: report.winrate,
           maxDrawdownPct: report.maxDrawdownPct,
           tradeCount: report.trades,
-          sharpe,
+          sharpe: report.sharpe,
+          profitFactor: report.profitFactor,
+          expectancy: report.expectancy,
         });
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
@@ -1422,6 +1432,8 @@ async function runSweepAsync(sweepId: string): Promise<void> {
           maxDrawdownPct: 0,
           tradeCount: 0,
           sharpe: null,
+          profitFactor: null,
+          expectancy: null,
         });
       }
 
@@ -1455,16 +1467,6 @@ async function runSweepAsync(sweepId: string): Promise<void> {
     }).catch(() => undefined);
     logger.error({ sweepId, error: msg }, "Sweep failed");
   }
-}
-
-/** Compute annualised Sharpe ratio from per-trade PnL % array */
-function computeSharpe(pnlPcts: number[]): number | null {
-  if (pnlPcts.length < 2) return null;
-  const mean = pnlPcts.reduce((s, v) => s + v, 0) / pnlPcts.length;
-  const variance = pnlPcts.reduce((s, v) => s + (v - mean) ** 2, 0) / (pnlPcts.length - 1);
-  const stdDev = Math.sqrt(variance);
-  if (stdDev === 0) return null;
-  return Math.round((mean / stdDev) * Math.sqrt(252) * 100) / 100;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/tests/routes/lab.test.ts
+++ b/apps/api/tests/routes/lab.test.ts
@@ -660,6 +660,53 @@ describe("GET /api/v1/lab/backtests/compare", () => {
     expect(body.delta.winrateDelta).toBeNull();
   });
 
+  // 49-T3: compare exposes profitFactorDelta and expectancyDelta.
+  it("49-T3: returns profitFactorDelta and expectancyDelta when both reports carry them", async () => {
+    mockBacktests["bt-pf-a"] = {
+      id: "bt-pf-a", workspaceId: WS_ID, status: "DONE",
+      reportJson: { totalPnlPct: 10, winrate: 60, maxDrawdownPct: 4, trades: 12, sharpe: 1.5, profitFactor: 2.4, expectancy: 0.8 },
+      feeBps: 10, slippageBps: 5, engineVersion: "abc123",
+    };
+    mockBacktests["bt-pf-b"] = {
+      id: "bt-pf-b", workspaceId: WS_ID, status: "DONE",
+      reportJson: { totalPnlPct: 7,  winrate: 55, maxDrawdownPct: 6, trades: 12, sharpe: 0.9, profitFactor: 1.4, expectancy: 0.3 },
+      feeBps: 10, slippageBps: 5, engineVersion: "abc123",
+    };
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/lab/backtests/compare?a=bt-pf-a&b=bt-pf-b",
+      headers: authHeaders(),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.delta.profitFactorDelta).toBeCloseTo(1.0, 2);
+    expect(body.delta.expectancyDelta).toBeCloseTo(0.5, 2);
+  });
+
+  it("49-T3: profitFactorDelta and expectancyDelta are null on legacy pre-49 reports", async () => {
+    // bt-old has the pre-49 reportJson shape (no new fields). The new
+    // delta keys must surface as null without throwing.
+    mockBacktests["bt-old"] = {
+      id: "bt-old", workspaceId: WS_ID, status: "DONE",
+      reportJson: { totalPnlPct: 5, winrate: 50, maxDrawdownPct: 3, trades: 8, sharpe: 0.7 },
+    };
+    mockBacktests["bt-new"] = {
+      id: "bt-new", workspaceId: WS_ID, status: "DONE",
+      reportJson: { totalPnlPct: 10, winrate: 60, maxDrawdownPct: 2, trades: 9, sharpe: 1.1, profitFactor: 1.9, expectancy: 0.4 },
+    };
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/lab/backtests/compare?a=bt-old&b=bt-new",
+      headers: authHeaders(),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.delta.profitFactorDelta).toBeNull();
+    expect(body.delta.expectancyDelta).toBeNull();
+    // sharpeDelta still works because both rows carry sharpe.
+    expect(body.delta.sharpeDelta).toBeCloseTo(-0.4, 2);
+  });
+
   it("includes lineage data in compare response", async () => {
     mockGraphs["g-lin"] = { id: "g-lin", workspaceId: WS_ID, name: "My Strategy", graphJson: {} };
     mockStrategyVersions["sv-lin"] = { id: "sv-lin", strategyId: "strat-lin" };


### PR DESCRIPTION
Реализация задачи **49-T3** из `docs/49-backtest-metrics-plan.md`. Продолжение направления «Backtest metrics» после 49-T1 (#303) → 49-T2 (#304).

## Что сделано

### `apps/api/src/routes/lab.ts`

- **`runSweepAsync`**: `SweepRow.sharpe = report.sharpe` (вместо локального `computeSharpe(report.tradeLog.map(t => t.pnlPct))`). После 49-T2 `report.sharpe` бит-в-bit идентичен старому `computeSharpe` — закреплено regression-тестом 49-T1.
- **`computeSharpe`** удалён полностью (8 строк, lines 1463–1471 в pre-T3 main). Никаких backwards-compat шимов или `_legacy`-алиасов: функция нигде в `apps/api/src` или `apps/api/tests` больше не вызывается. Оставшиеся упоминания в коде — только комментарии в `backtestMetrics/sharpe.ts` (закрепляют контракт) и в `backtestMetrics/sharpe.test.ts` (regression-anchor).
- **`SweepRow`** расширен:
  ```ts
  profitFactor: number | null;
  expectancy: number | null;
  ```
  Заполняется из `report.profitFactor` / `report.expectancy` на success и `null` в FAILED-ветке. Подготавливает `rankBy ∈ {profitFactor, expectancy}` для `docs/47-T4`.
- **`/lab/backtests/compare`** получает два новых дельт-поля:
  ```ts
  profitFactorDelta: num(reportA.profitFactor) !== null && num(reportB.profitFactor) !== null
    ? (num(reportA.profitFactor)! - num(reportB.profitFactor)!) : null,
  expectancyDelta: num(reportA.expectancy) !== null && num(reportB.expectancy) !== null
    ? (num(reportA.expectancy)! - num(reportB.expectancy)!) : null,
  ```
  Существующий `num()` helper уже корректно мапит `undefined → null` для legacy reportJson-рядов — никаких миграций reportJson **не требуется**.

## Backward compatibility

- ✅ **Bit-for-bit numerical contract**: `SweepRow.sharpe` для существующих фикстур даёт те же числа, что и до 49-T3 (regression-тест 49-T1).
- ✅ **Pre-49 `BacktestResult` записи** в compare: `num(reportA.profitFactor)` возвращает `null` для отсутствующего ключа → `profitFactorDelta = null` без 500. Покрыто новым тестом.
- ✅ Existing 81 `lab.test.ts` тестов — **без правок** и зелёные.
- ✅ `engineVersion` уже фиксирует версию engine — старые записи интерпретируются по своему `engineVersion`.

## Тесты (2 новых кейса)

В `describe("GET /api/v1/lab/backtests/compare")`:

1. **`returns profitFactorDelta and expectancyDelta when both reports carry them`** — оба отчёта 49-T2-shape с разными PF/expectancy. `profitFactorDelta == 1.0` (2.4 − 1.4), `expectancyDelta == 0.5` (0.8 − 0.3). Hand-calc reference.
2. **`profitFactorDelta and expectancyDelta are null on legacy pre-49 reports`** — side A pre-49 (без новых ключей), side B 49-T2-shape. Новые дельты `null`, `sharpeDelta` всё ещё computes (оба имеют sharpe). Закрепляет, что compare устойчив к смешанным записям.

## Не входит в задачу (per docs/49 § «Не входит в задачу»)

- Golden-fixtures + bit-for-bit regression тест на sweep уровне — задача **49-T4**.
- `_legacySharpe.ts` archived reference — задача 49-T4.
- Sortino, Calmar, Omega — отдельный follow-up.
- UI-визуализация новых дельт — за пределами этого этапа.

## Зависимости (анлоки после мёрджа)

- ✅ `docs/47-T4` (rankBy multi-metric) — `SweepRow.profitFactor` и `SweepRow.expectancy` доступны для ранжирования.

## Критерии готовности (из docs/49-T3)

- [x] `tsc --noEmit` проходит.
- [x] `computeSharpe` удалён (`grep -n "function computeSharpe" apps/api/src` пусто).
- [x] Существующие sweep тесты зелёные.
- [x] Compare-эндпоинт работает на смеси старых и новых `BacktestResult`-ов (новый тест).
- [x] 103 файла / 1805 тестов, +2 vs T2.

## Тест-план для ревьюера

```bash
cd apps/api
npx prisma generate
npx tsc --noEmit
npx vitest run tests/routes/lab.test.ts   # 83 tests
npx vitest run                            # full suite — 103 files, 1805 tests
grep -n "function computeSharpe" src tests   # empty (function removed)
```

Branch: `claude/49-t3-remove-computesharpe` · 2 files changed (+63/−14) · commit `0791961`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmfV8BXGWUJSFNGArYKe9k)_