### PR TITLE
feat(walkForward): add pure split fold-generator (48-T1)

### DIFF
--- a/apps/api/src/lib/walkForward/split.ts
+++ b/apps/api/src/lib/walkForward/split.ts
@@ -1,0 +1,81 @@
+/**
+ * Pure walk-forward fold generator.
+ *
+ * For a candle array of length N and a `FoldConfig`, produces consecutive
+ * (IS, OOS) pairs until the next OOS block would run past the end of the
+ * data. Two layouts are supported:
+ *
+ *   anchored = false  (rolling)
+ *     fold i:  IS  = [i*step, i*step + isBars)
+ *              OOS = [i*step + isBars, i*step + isBars + oosBars)
+ *     The IS window has fixed length isBars; the whole pair slides forward
+ *     by `step` each iteration.
+ *
+ *   anchored = true   (anchored)
+ *     fold i:  IS  = [0, isBars + i*step)
+ *              OOS = [isBars + i*step, isBars + i*step + oosBars)
+ *     The IS window always starts at 0 and grows; only the OOS slides.
+ *
+ * The function is pure: it neither mutates the input nor performs I/O.
+ *
+ * Validation:
+ *   - isBars, oosBars, step must all be positive integers.
+ *   - candles.length >= isBars + oosBars (otherwise no fold fits).
+ *   - step < oosBars is allowed — the resulting OOS blocks overlap, which
+ *     is methodologically suboptimal (a single trade can land in two
+ *     adjacent folds and skew the aggregate). The HTTP layer (48-T5)
+ *     flags this in a `warnings` array; the split function itself stays
+ *     pure and has no warning channel.
+ *
+ * Determinism: identical inputs always yield identical outputs.
+ */
+
+import type { Candle } from "../bybitCandles.js";
+import type { FoldConfig, Fold, FoldRange } from "./types.js";
+
+function rangeOf(candles: Candle[], from: number, to: number): FoldRange {
+  return {
+    fromIndex: from,
+    toIndex: to,
+    fromTsMs: candles[from].openTime,
+    toTsMs: candles[to - 1].openTime,
+  };
+}
+
+export function split(candles: Candle[], cfg: FoldConfig): Fold[] {
+  if (!Number.isFinite(cfg.isBars) || cfg.isBars <= 0) {
+    throw new Error("isBars must be a positive number");
+  }
+  if (!Number.isFinite(cfg.oosBars) || cfg.oosBars <= 0) {
+    throw new Error("oosBars must be a positive number");
+  }
+  if (!Number.isFinite(cfg.step) || cfg.step <= 0) {
+    throw new Error("step must be a positive number");
+  }
+  if (candles.length < cfg.isBars + cfg.oosBars) {
+    throw new Error(
+      `candles.length (${candles.length}) < isBars + oosBars (${cfg.isBars + cfg.oosBars})`,
+    );
+  }
+
+  const folds: Fold[] = [];
+  for (let i = 0; ; i++) {
+    const isStart = cfg.anchored ? 0 : i * cfg.step;
+    const oosStart = cfg.isBars + i * cfg.step;
+    const oosEnd = oosStart + cfg.oosBars;
+
+    if (oosEnd > candles.length) break;
+
+    const isSlice = candles.slice(isStart, oosStart);
+    const oosSlice = candles.slice(oosStart, oosEnd);
+
+    folds.push({
+      foldIndex: i,
+      isSlice,
+      oosSlice,
+      isRange: rangeOf(candles, isStart, oosStart),
+      oosRange: rangeOf(candles, oosStart, oosEnd),
+    });
+  }
+  return folds;
+}

--- a/apps/api/src/lib/walkForward/types.ts
+++ b/apps/api/src/lib/walkForward/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Walk-forward validation — shared types.
+ *
+ * Configuration is expressed in **bars** (candle counts), not in time, so
+ * the layout is deterministic regardless of gaps in the underlying market
+ * data. See docs/48 §«Решение по форме fold-конфигурации».
+ */
+
+import type { Candle } from "../bybitCandles.js";
+
+export type FoldConfig = {
+  /** Length of the in-sample window (bars). Must be > 0. */
+  isBars: number;
+  /** Length of the out-of-sample window (bars). Must be > 0. */
+  oosBars: number;
+  /** Step between consecutive folds (bars). Must be > 0. Equal to oosBars
+   *  for non-overlapping OOS blocks; smaller values produce overlapping
+   *  OOS regions and are flagged as a `warning` by the HTTP layer (48-T5),
+   *  but the pure split allows them. */
+  step: number;
+  /** When true, the IS window starts at index 0 and only grows; when false,
+   *  the IS window has a fixed length and the whole pair slides. */
+  anchored: boolean;
+};
+
+export type FoldRange = {
+  fromIndex: number;
+  /** Exclusive end index (matches Array.prototype.slice semantics). */
+  toIndex: number;
+  /** First candle's openTime in ms. */
+  fromTsMs: number;
+  /** Last candle's openTime in ms (inclusive). */
+  toTsMs: number;
+};
+
+export type Fold = {
+  foldIndex: number;
+  isSlice: Candle[];
+  oosSlice: Candle[];
+  isRange: FoldRange;
+  oosRange: FoldRange;
+};

--- a/apps/api/tests/lib/walkForward/split.test.ts
+++ b/apps/api/tests/lib/walkForward/split.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import { split } from "../../../src/lib/walkForward/split.js";
+import type { FoldConfig } from "../../../src/lib/walkForward/types.js";
+
+interface Candle {
+  openTime: number;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+function makeCandles(n: number): Candle[] {
+  return Array.from({ length: n }, (_, i) => ({
+    openTime: 1_700_000_000_000 + i * 60_000,
+    open: 100,
+    high: 100,
+    low: 100,
+    close: 100,
+    volume: 1000,
+  }));
+}
+
+describe("walkForward.split", () => {
+  it("rolling: 100 candles, isBars=50/oosBars=10/step=10 → 5 folds, sliding IS", () => {
+    const cfg: FoldConfig = { isBars: 50, oosBars: 10, step: 10, anchored: false };
+    const folds = split(makeCandles(100), cfg);
+
+    expect(folds).toHaveLength(5);
+    expect(folds.map((f) => f.foldIndex)).toEqual([0, 1, 2, 3, 4]);
+
+    // Fold 0
+    expect(folds[0].isRange).toMatchObject({ fromIndex: 0, toIndex: 50 });
+    expect(folds[0].oosRange).toMatchObject({ fromIndex: 50, toIndex: 60 });
+    expect(folds[0].isSlice).toHaveLength(50);
+    expect(folds[0].oosSlice).toHaveLength(10);
+
+    // Fold 4 — last fits exactly: IS [40..90), OOS [90..100)
+    expect(folds[4].isRange).toMatchObject({ fromIndex: 40, toIndex: 90 });
+    expect(folds[4].oosRange).toMatchObject({ fromIndex: 90, toIndex: 100 });
+
+    // Rolling: every IS has exactly isBars
+    for (const f of folds) expect(f.isSlice).toHaveLength(50);
+  });
+
+  it("anchored: 100 candles, isBars=50/oosBars=10/step=10 → 5 folds, growing IS", () => {
+    const cfg: FoldConfig = { isBars: 50, oosBars: 10, step: 10, anchored: true };
+    const folds = split(makeCandles(100), cfg);
+
+    expect(folds).toHaveLength(5);
+
+    // Anchored: every IS starts at index 0 and grows by step.
+    expect(folds.map((f) => f.isRange.fromIndex)).toEqual([0, 0, 0, 0, 0]);
+    expect(folds.map((f) => f.isRange.toIndex)).toEqual([50, 60, 70, 80, 90]);
+    expect(folds.map((f) => f.isSlice.length)).toEqual([50, 60, 70, 80, 90]);
+
+    // OOS slides identically: [50..60), [60..70), …
+    expect(folds.map((f) => f.oosRange.fromIndex)).toEqual([50, 60, 70, 80, 90]);
+    expect(folds.map((f) => f.oosSlice.length)).toEqual([10, 10, 10, 10, 10]);
+  });
+
+  it("returns exactly 1 fold when candles.length === isBars + oosBars", () => {
+    const cfg: FoldConfig = { isBars: 30, oosBars: 10, step: 10, anchored: false };
+    const folds = split(makeCandles(40), cfg);
+
+    expect(folds).toHaveLength(1);
+    expect(folds[0].isRange).toMatchObject({ fromIndex: 0, toIndex: 30 });
+    expect(folds[0].oosRange).toMatchObject({ fromIndex: 30, toIndex: 40 });
+  });
+
+  it("throws when isBars + oosBars > candles.length", () => {
+    const cfg: FoldConfig = { isBars: 80, oosBars: 30, step: 10, anchored: false };
+    expect(() => split(makeCandles(100), cfg)).toThrow(/candles\.length/);
+  });
+
+  it("throws on non-positive isBars / oosBars / step", () => {
+    expect(() =>
+      split(makeCandles(100), { isBars: 0, oosBars: 10, step: 10, anchored: false }),
+    ).toThrow(/isBars/);
+    expect(() =>
+      split(makeCandles(100), { isBars: 10, oosBars: -1, step: 10, anchored: false }),
+    ).toThrow(/oosBars/);
+    expect(() =>
+      split(makeCandles(100), { isBars: 10, oosBars: 10, step: 0, anchored: false }),
+    ).toThrow(/step/);
+  });
+
+  it("populates isRange.fromTsMs / toTsMs from Candle.openTime", () => {
+    const candles = makeCandles(20);
+    const folds = split(candles, { isBars: 10, oosBars: 5, step: 5, anchored: false });
+
+    expect(folds[0].isRange.fromTsMs).toBe(candles[0].openTime);
+    // toTsMs is inclusive — last index is toIndex - 1.
+    expect(folds[0].isRange.toTsMs).toBe(candles[9].openTime);
+    expect(folds[0].oosRange.fromTsMs).toBe(candles[10].openTime);
+    expect(folds[0].oosRange.toTsMs).toBe(candles[14].openTime);
+  });
+
+  it("does not mutate the input candle array", () => {
+    const candles = makeCandles(60);
+    const before = JSON.parse(JSON.stringify(candles));
+    split(candles, { isBars: 30, oosBars: 10, step: 10, anchored: false });
+    expect(candles).toEqual(before);
+  });
+
+  it("is deterministic — repeated calls produce identical output", () => {
+    const candles = makeCandles(100);
+    const cfg: FoldConfig = { isBars: 50, oosBars: 10, step: 10, anchored: false };
+    const a = split(candles, cfg);
+    const b = split(candles, cfg);
+    expect(a).toEqual(b);
+  });
+
+  it("permits step < oosBars (overlapping OOS) — pure split has no warning channel", () => {
+    // step=5, oosBars=10 → adjacent OOS blocks overlap by 5 bars.
+    const folds = split(
+      makeCandles(60),
+      { isBars: 30, oosBars: 10, step: 5, anchored: false },
+    );
+    expect(folds.length).toBeGreaterThan(1);
+    // OOS of fold 0 ends at index 40; OOS of fold 1 starts at 35 → overlap.
+    expect(folds[0].oosRange.toIndex).toBe(40);
+    expect(folds[1].oosRange.fromIndex).toBe(35);
+  });
+});


### PR DESCRIPTION
Реализация задачи **48-T1** из `docs/48-walk-forward-plan.md`. Открывает направление «4. Walk-forward validation» из `docs/44`.

## Что сделано

Создан pure-модуль `apps/api/src/lib/walkForward/`:

| Файл | Назначение |
|---|---|
| `types.ts` | `FoldConfig`, `FoldRange`, `Fold` |
| `split.ts` | `split(candles, cfg) → Fold[]` |

### `split(candles, cfg: FoldConfig): Fold[]`

Чисто-функциональный fold-генератор. Поддерживает оба режима:

```
rolling  (anchored=false):  IS  = [i*step, i*step + isBars)
                            OOS = [i*step + isBars, i*step + isBars + oosBars)
                            длина IS фиксирована = isBars

anchored (anchored=true):   IS  = [0, isBars + i*step)
                            OOS = [isBars + i*step, isBars + i*step + oosBars)
                            IS всегда от 0, растёт на step
```

Прекращает генерацию когда следующий OOS-блок выходит за `candles.length`.

### Валидация

- `isBars`, `oosBars`, `step` — должны быть положительными числами; `Error` иначе.
- `candles.length >= isBars + oosBars`; иначе `Error` с понятным сообщением.
- `step < oosBars` (overlapping OOS) **разрешён** — методологический warning живёт в HTTP-слое (48-T5), а не в pure split. Зафиксировано в JSDoc.

### Иммутабельность + детерминизм

- `Array.prototype.slice` для срезов — input candles не мутируются (deep-equality check в тесте).
- Repeated call с теми же входами даёт identical output (отдельный тест).

## Тесты (9 кейсов)

`apps/api/tests/lib/walkForward/split.test.ts`:

1. **rolling** на 100 свечах с `isBars=50/oosBars=10/step=10` → 5 fold-ов, sliding IS (`[0..50)/[50..60)`, …, `[40..90)/[90..100)`).
2. **anchored** на тех же параметрах → 5 fold-ов, growing IS (`[0..50)`, `[0..60)`, …, `[0..90)`).
3. **Exact fit**: `candles.length === isBars + oosBars` → ровно 1 fold.
4. **Throw** на `isBars + oosBars > candles.length`.
5. **Throw** на non-positive `isBars`/`oosBars`/`step` (по случаю на параметр).
6. **FoldRange.fromTsMs/toTsMs** заполнены из `Candle.openTime`, `toTsMs` inclusive на высоком конце.
7. **Иммутабельность** — input `candles` не модифицируется.
8. **Детерминизм** — `split(c, cfg)` равен `split(c, cfg)`.
9. **Overlapping OOS** разрешён (`step=5, oosBars=10`) — split не знает про warning-канал.

## Backward compatibility

- ✅ Полностью новый модуль. Никакой production-код не тронут.
- ✅ Никаких импортов из `dslEvaluator`, `runBacktest`, БД, Express — pure функция.
- ✅ Существующие 104 файла / 1810 тестов проходят без правок.

## Не входит в задачу (per docs/48 § «Не входит в задачу»)

- `runWalkForward` (per-fold backtest без агрегации) — задача **48-T2**.
- `aggregate` метрики — задача **48-T3** (использует утилиты из `docs/49`, уже закрытого ✅).
- Prisma модель `WalkForwardRun` — задача **48-T4**.
- HTTP эндпоинты — задача **48-T5**.
- UI `WalkForwardPanel` — задача **48-T6**.
- e2e тесты — задача **48-T7**.

## Критерии готовности (из docs/48-T1)

- [x] `tsc --noEmit` проходит.
- [x] Все unit-тесты зелёные (105 файлов / 1819 тестов, +9 vs main).
- [x] Никаких импортов из `dslEvaluator`, `runBacktest`, БД, Express.

## Тест-план для ревьюера

```bash
cd apps/api
npx prisma generate
npx tsc --noEmit
npx vitest run tests/lib/walkForward/   # 1 file, 9 tests
npx vitest run                          # full suite — 105 files, 1819 tests
```

Branch: `claude/48-t1-walkforward-split` · 3 files added (+249) · commit `5c340db`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmfV8BXGWUJSFNGArYKe9k)_