### PR TITLE
feat(walkForward): per-fold runner with MTF pre-flight gate (48-T2)

### DIFF
--- a/apps/api/src/lib/walkForward/run.ts
+++ b/apps/api/src/lib/walkForward/run.ts
@@ -1,0 +1,113 @@
+/**
+ * Walk-forward runner — per-fold backtest without aggregation.
+ *
+ * Given a candle array, a compiled DSL, execution opts, and a FoldConfig,
+ * `runWalkForward` produces one (IS, OOS) backtest pair per fold by calling
+ * `runBacktest` twice on the slices returned by `split`. The function
+ * does not touch the database, has no HTTP layer, and only side-effects
+ * via the optional `onProgress` callback (used by the BD wrapper in 48-T5
+ * to surface progress to the client).
+ *
+ * Multi-timeframe gate: walk-forward for MTF strategies is not yet
+ * implemented (slicing the MTF context bundle in sync with the primary
+ * candles is non-trivial and out of scope for this version). The runner
+ * pre-flights the DSL and throws a `WalkForwardMtfNotSupportedError` when
+ * any indicator carries a `sourceTimeframe`. The HTTP layer (48-T5) maps
+ * that error to a 400.
+ *
+ * Determinism: mirrors the contracts of `split` (48-T1) and `runBacktest`
+ * (docs/44 §Детерминизм). Identical inputs always produce identical output.
+ */
+
+import type { Candle } from "../bybitCandles.js";
+import type { DslExecOpts } from "../dslEvaluator.js";
+import { runBacktest } from "../backtest.js";
+import { split } from "./split.js";
+import type {
+  FoldConfig,
+  FoldReport,
+  WalkForwardReport,
+} from "./types.js";
+
+/**
+ * Thrown when a DSL contains at least one indicator with a non-empty
+ * `sourceTimeframe`. The HTTP layer (48-T5) translates this into a 400
+ * with the prescribed user-facing message.
+ */
+export class WalkForwardMtfNotSupportedError extends Error {
+  constructor(public readonly indicatorType: string, public readonly sourceTimeframe: string) {
+    super(
+      `Walk-forward для MTF-стратегий не реализован: индикатор '${indicatorType}' использует sourceTimeframe='${sourceTimeframe}'. См. follow-up к docs/48.`,
+    );
+    this.name = "WalkForwardMtfNotSupportedError";
+  }
+}
+
+/**
+ * Recursively scan a JSON-shaped value for the first object that carries
+ * a non-empty `sourceTimeframe` key alongside an indicator-like `type`
+ * field. Returns `{ type, sourceTimeframe }` for the first match or `null`.
+ *
+ * The scanner walks plain objects and arrays; primitives are ignored.
+ * It does not interpret the DSL semantically — any JSON-shaped DSL is
+ * acceptable input. This is a structural pre-flight, not a semantic one.
+ */
+function findMtfIndicator(node: unknown): { type: string; sourceTimeframe: string } | null {
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      const hit = findMtfIndicator(item);
+      if (hit) return hit;
+    }
+    return null;
+  }
+  if (node && typeof node === "object") {
+    const obj = node as Record<string, unknown>;
+    const stf = obj.sourceTimeframe;
+    if (typeof stf === "string" && stf.length > 0) {
+      const t = typeof obj.type === "string" ? obj.type : "<unknown>";
+      return { type: t, sourceTimeframe: stf };
+    }
+    for (const v of Object.values(obj)) {
+      const hit = findMtfIndicator(v);
+      if (hit) return hit;
+    }
+  }
+  return null;
+}
+
+export function runWalkForward(
+  candles: Candle[],
+  dslJson: unknown,
+  opts: Partial<DslExecOpts>,
+  foldCfg: FoldConfig,
+  onProgress?: (done: number, total: number) => void,
+): WalkForwardReport {
+  // MTF pre-flight: walk-forward does not slice MTF contexts yet, so a
+  // strategy that references another timeframe would silently fall back
+  // to the primary TF and produce different signals. Reject up front.
+  const mtfHit = findMtfIndicator(dslJson);
+  if (mtfHit) {
+    throw new WalkForwardMtfNotSupportedError(mtfHit.type, mtfHit.sourceTimeframe);
+  }
+
+  const folds = split(candles, foldCfg);
+
+  const folded: FoldReport[] = folds.map((fold) => {
+    // Two independent runBacktest calls per fold — IS and OOS are
+    // evaluated as standalone backtests so each fold's report is
+    // self-contained. mtfContext is intentionally undefined; MTF is
+    // gated by the pre-flight above.
+    const isReport = runBacktest(fold.isSlice, dslJson, opts, undefined);
+    const oosReport = runBacktest(fold.oosSlice, dslJson, opts, undefined);
+    onProgress?.(fold.foldIndex + 1, folds.length);
+    return {
+      foldIndex: fold.foldIndex,
+      isReport,
+      oosReport,
+      isRange: fold.isRange,
+      oosRange: fold.oosRange,
+    };
+  });
+
+  return { folds: folded };
+}

--- a/apps/api/src/lib/walkForward/types.ts
+++ b/apps/api/src/lib/walkForward/types.ts
@@ -7,6 +7,7 @@
  */
 
 import type { Candle } from "../bybitCandles.js";
+import type { DslBacktestReport } from "../dslEvaluator.js";
 
 export type FoldConfig = {
   /** Length of the in-sample window (bars). Must be > 0. */
@@ -39,4 +40,21 @@ export type Fold = {
   oosSlice: Candle[];
   isRange: FoldRange;
   oosRange: FoldRange;
+};
+
+/** Per-fold backtest reports paired with the slice ranges they were run on. */
+export type FoldReport = {
+  foldIndex: number;
+  isReport: DslBacktestReport;
+  oosReport: DslBacktestReport;
+  isRange: FoldRange;
+  oosRange: FoldRange;
+};
+
+/**
+ * Walk-forward run output. `aggregate` is added in 48-T3; until then the
+ * field is intentionally absent.
+ */
+export type WalkForwardReport = {
+  folds: FoldReport[];
 };

--- a/apps/api/tests/lib/walkForward/run.test.ts
+++ b/apps/api/tests/lib/walkForward/run.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  runWalkForward,
+  WalkForwardMtfNotSupportedError,
+} from "../../../src/lib/walkForward/run.js";
+import { runBacktest } from "../../../src/lib/backtest.js";
+import { makeFlatThenUp } from "../../fixtures/candles.js";
+
+function makeSmaLongDsl(fastLen = 5, slowLen = 20, slPct = 2, tpPct = 4) {
+  return {
+    id: "wf-test-sma",
+    name: "Walk-forward SMA Long",
+    dslVersion: 1,
+    enabled: true,
+    market: { exchange: "bybit", env: "demo", category: "linear", symbol: "BTCUSDT" },
+    entry: {
+      side: "Buy",
+      signal: {
+        type: "crossover",
+        fast: { blockType: "SMA", length: fastLen },
+        slow: { blockType: "SMA", length: slowLen },
+      },
+      stopLoss: { type: "fixed_pct", value: slPct },
+      takeProfit: { type: "fixed_pct", value: tpPct },
+    },
+    risk: { maxPositionSizeUsd: 100, riskPerTradePct: slPct, cooldownSeconds: 0 },
+    execution: { orderType: "Market", clientOrderIdPrefix: "test_" },
+    guards: { maxOpenPositions: 1, maxOrdersPerMinute: 10, pauseOnError: true },
+  };
+}
+
+describe("walkForward.runWalkForward", () => {
+  it("smoke: 100 candles + isBars=50/oosBars=10/step=10 → 5 folds with non-empty reports", () => {
+    const candles = makeFlatThenUp(100, 25, 100, 2);
+    const report = runWalkForward(
+      candles,
+      makeSmaLongDsl(),
+      { feeBps: 0, slippageBps: 0 },
+      { isBars: 50, oosBars: 10, step: 10, anchored: false },
+    );
+
+    expect(report.folds).toHaveLength(5);
+    for (const f of report.folds) {
+      // The reports always have these fields, even if no trades fire on a slice.
+      expect(f.isReport).toHaveProperty("trades");
+      expect(f.oosReport).toHaveProperty("trades");
+      expect(f.isReport).toHaveProperty("totalPnlPct");
+      expect(f.oosReport).toHaveProperty("totalPnlPct");
+    }
+  });
+
+  it("does not mutate the input candles or dslJson", () => {
+    const candles = makeFlatThenUp(80, 20, 100, 2);
+    const dsl = makeSmaLongDsl();
+    const candlesBefore = JSON.parse(JSON.stringify(candles));
+    const dslBefore = JSON.parse(JSON.stringify(dsl));
+
+    runWalkForward(
+      candles,
+      dsl,
+      { feeBps: 0, slippageBps: 0 },
+      { isBars: 30, oosBars: 10, step: 10, anchored: false },
+    );
+
+    expect(candles).toEqual(candlesBefore);
+    expect(dsl).toEqual(dslBefore);
+  });
+
+  it("invokes onProgress once per fold with (done, total)", () => {
+    const candles = makeFlatThenUp(100, 25, 100, 2);
+    const onProgress = vi.fn();
+
+    runWalkForward(
+      candles,
+      makeSmaLongDsl(),
+      { feeBps: 0, slippageBps: 0 },
+      { isBars: 50, oosBars: 10, step: 10, anchored: false },
+      onProgress,
+    );
+
+    expect(onProgress).toHaveBeenCalledTimes(5);
+    expect(onProgress.mock.calls).toEqual([
+      [1, 5],
+      [2, 5],
+      [3, 5],
+      [4, 5],
+      [5, 5],
+    ]);
+  });
+
+  it("each fold's reports equal direct runBacktest on the same slice", () => {
+    const candles = makeFlatThenUp(100, 25, 100, 2);
+    const opts = { feeBps: 0, slippageBps: 0 };
+    const cfg = { isBars: 50, oosBars: 10, step: 10, anchored: false } as const;
+    const dsl = makeSmaLongDsl();
+
+    const wf = runWalkForward(candles, dsl, opts, cfg);
+
+    // Direct slice — must match runWalkForward's per-fold output bit-for-bit.
+    const isSlice0 = candles.slice(0, 50);
+    const oosSlice0 = candles.slice(50, 60);
+    const directIs = runBacktest(isSlice0, dsl, opts);
+    const directOos = runBacktest(oosSlice0, dsl, opts);
+
+    expect(wf.folds[0].isReport).toEqual(directIs);
+    expect(wf.folds[0].oosReport).toEqual(directOos);
+  });
+
+  it("rejects MTF strategies with WalkForwardMtfNotSupportedError", () => {
+    const candles = makeFlatThenUp(80, 20, 100, 2);
+    const mtfDsl = {
+      ...makeSmaLongDsl(),
+      entry: {
+        side: "Buy",
+        signal: {
+          type: "crossover",
+          fast: { blockType: "SMA", length: 5, sourceTimeframe: "1h" },
+          slow: { blockType: "SMA", length: 20 },
+        },
+        stopLoss: { type: "fixed_pct", value: 2 },
+        takeProfit: { type: "fixed_pct", value: 4 },
+      },
+    };
+
+    expect(() =>
+      runWalkForward(
+        candles,
+        mtfDsl,
+        { feeBps: 0, slippageBps: 0 },
+        { isBars: 30, oosBars: 10, step: 10, anchored: false },
+      ),
+    ).toThrow(WalkForwardMtfNotSupportedError);
+
+    try {
+      runWalkForward(
+        candles,
+        mtfDsl,
+        { feeBps: 0, slippageBps: 0 },
+        { isBars: 30, oosBars: 10, step: 10, anchored: false },
+      );
+    } catch (err) {
+      expect(err).toBeInstanceOf(WalkForwardMtfNotSupportedError);
+      expect((err as Error).message).toContain("MTF-стратегий");
+      expect((err as Error).message).toContain("sourceTimeframe='1h'");
+    }
+  });
+
+  it("anchored layout produces growing IS reports", () => {
+    const candles = makeFlatThenUp(100, 25, 100, 2);
+    const wf = runWalkForward(
+      candles,
+      makeSmaLongDsl(),
+      { feeBps: 0, slippageBps: 0 },
+      { isBars: 50, oosBars: 10, step: 10, anchored: true },
+    );
+
+    expect(wf.folds).toHaveLength(5);
+    // Anchored: isReport.candles should grow by step each fold.
+    expect(wf.folds.map((f) => f.isReport.candles)).toEqual([50, 60, 70, 80, 90]);
+    // OOS length stays constant.
+    expect(wf.folds.map((f) => f.oosReport.candles)).toEqual([10, 10, 10, 10, 10]);
+  });
+});


### PR DESCRIPTION
Реализация задачи **48-T2** из `docs/48-walk-forward-plan.md`. Продолжение направления «Walk-forward validation» после 48-T1 (#307).

## Что сделано

### `apps/api/src/lib/walkForward/run.ts`

`runWalkForward(candles, dslJson, opts, foldCfg, onProgress?)` — in-memory executor:

```ts
const folds = split(candles, foldCfg);  // 48-T1

const folded = folds.map((fold) => {
  const isReport  = runBacktest(fold.isSlice, dslJson, opts);
  const oosReport = runBacktest(fold.oosSlice, dslJson, opts);
  onProgress?.(fold.foldIndex + 1, folds.length);
  return { foldIndex, isReport, oosReport, isRange, oosRange };
});

return { folds: folded };
```

- Никакой БД, никакого HTTP — только in-memory.
- `onProgress` опционален; используется wrapper'ом 48-T5 для обновления `WalkForwardRun.progress` в БД.
- `mtfContext` интенционально `undefined` в первой версии — поддержка MTF через walk-forward требует синхронной нарезки MTF-контекста и идёт отдельной follow-up задачей.

### MTF pre-flight (safety gate)

`WalkForwardMtfNotSupportedError` — типизированный exception, пробрасывается до начала split при обнаружении хотя бы одного индикатора с непустым `sourceTimeframe`. Сообщение полностью соответствует спеке docs/48-T2 step 4:

> `"Walk-forward для MTF-стратегий не реализован: индикатор '<type>' использует sourceTimeframe='<tf>'. См. follow-up к docs/48."`

Pre-flight реализован как **структурный** обход JSON-DSL (не семантический) — рекурсивно ищет первый объект с `sourceTimeframe: string` и возвращает его `type`. Работает на любой `dslVersion` без повторного парсинга. HTTP layer (48-T5) переведёт ошибку в 400.

### Расширение `walkForward/types.ts`

Добавлены `FoldReport` (per-fold reports + ranges) и `WalkForwardReport` (`{ folds: FoldReport[] }`). Поле `aggregate` будет добавлено в **48-T3** — пока интенционально отсутствует.

## Тесты (6 кейсов)

`apps/api/tests/lib/walkForward/run.test.ts`:

1. **Smoke** — 100 свечей `makeFlatThenUp`, rolling cfg → 5 fold-ов с непустыми отчётами.
2. **Иммутабельность** — `candles` и `dslJson` после `runWalkForward` не изменены (deep equality).
3. **`onProgress` callback** — вызван ровно `folds.length` раз с правильными `(done, total)` парами `[1,5], [2,5], …, [5,5]`.
4. **Bit-for-bit equality** — `wf.folds[0].isReport` ровно равен `runBacktest(candles.slice(0, 50), dsl, opts)` (per-fold вызов независим).
5. **MTF rejection** — `sourceTimeframe: '1h'` в индикаторе → `WalkForwardMtfNotSupportedError`; message содержит и `MTF-стратегий`, и `sourceTimeframe='1h'`.
6. **Anchored layout** — `isReport.candles` растёт `50 → 60 → 70 → 80 → 90`, `oosReport.candles` фиксирован = 10.

## Backward compatibility

- ✅ Никакой production-код не тронут. Только новый модуль и новые тесты.
- ✅ Никаких импортов из БД или Express.
- ✅ Существующие 105 файлов / 1819 тестов проходят без правок.

## Не входит в задачу (per docs/48 § «Не входит в задачу»)

- `aggregate` метрики на уровне report → задача **48-T3**.
- Prisma модель `WalkForwardRun` → задача **48-T4**.
- HTTP-эндпоинты → задача **48-T5**.
- UI `WalkForwardPanel` → задача **48-T6**.
- e2e тесты → задача **48-T7**.
- MTF support — отдельный follow-up; safety-gate в этом PR.

## Критерии готовности (из docs/48-T2)

- [x] `tsc --noEmit` проходит.
- [x] Unit-тесты зелёные (106 файлов / 1825 тестов, +6 vs T1).
- [x] Никаких side-effects кроме вызовов `runBacktest`.
- [x] Импорты: `split` (48-T1), `runBacktest`, типы из `dslEvaluator`. Без БД, без Express.

## Тест-план для ревьюера

```bash
cd apps/api
npx prisma generate
npx tsc --noEmit
npx vitest run tests/lib/walkForward/   # 2 files, 15 tests
npx vitest run                          # full suite — 106 files, 1825 tests
```

Branch: `claude/48-t2-walkforward-run` · 3 files added/modified (+294) · commit `ecb3a3b`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmfV8BXGWUJSFNGArYKe9k)_