### PR TITLE
feat(walkForward): aggregate metrics summary across folds (48-T3)

### DIFF
--- a/apps/api/src/lib/walkForward/aggregate.ts
+++ b/apps/api/src/lib/walkForward/aggregate.ts
@@ -1,0 +1,74 @@
+/**
+ * Walk-forward aggregate metrics — pure summary over FoldReport[].
+ *
+ * After docs/49-T2 (closed), `DslBacktestReport.sharpe` is populated
+ * directly by the engine, so the aggregate reads it straight from each
+ * fold's report — no local sharpe helper is needed.
+ *
+ * Limitation: `totalOosPnlPct` is a naive arithmetic sum of OOS pnl%
+ * across folds, not a compounded equity. Compounding requires a
+ * notional-tracking model that is out of scope for the first walk-
+ * forward version.
+ *
+ * Pure function — no I/O, no mutations.
+ */
+
+import type { FoldReport, WalkForwardAggregate } from "./types.js";
+
+/** Round a finite number to 2 decimal places (matches the engine's
+ *  totalPnlPct rounding, so aggregate fields read as "X.XX"). */
+function r2(x: number): number {
+  return Math.round(x * 100) / 100;
+}
+
+function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((s, v) => s + v, 0) / values.length;
+}
+
+function meanIgnoringNull(values: (number | null)[]): number | null {
+  const filtered = values.filter((v): v is number => v !== null);
+  if (filtered.length === 0) return null;
+  return mean(filtered);
+}
+
+export function aggregate(folds: FoldReport[]): WalkForwardAggregate {
+  const foldCount = folds.length;
+
+  if (foldCount === 0) {
+    return {
+      foldCount: 0,
+      avgIsPnlPct: 0,
+      avgOosPnlPct: 0,
+      totalOosPnlPct: 0,
+      avgIsSharpe: null,
+      avgOosSharpe: null,
+      isOosPnlRatio: null,
+      oosWinFoldShare: 0,
+    };
+  }
+
+  const isPnls = folds.map((f) => f.isReport.totalPnlPct);
+  const oosPnls = folds.map((f) => f.oosReport.totalPnlPct);
+
+  const avgIsPnlPct = mean(isPnls);
+  const avgOosPnlPct = mean(oosPnls);
+  const totalOosPnlPct = oosPnls.reduce((s, v) => s + v, 0);
+
+  const avgIsSharpeRaw = meanIgnoringNull(folds.map((f) => f.isReport.sharpe));
+  const avgOosSharpeRaw = meanIgnoringNull(folds.map((f) => f.oosReport.sharpe));
+
+  const isOosPnlRatio = avgIsPnlPct === 0 ? null : avgOosPnlPct / avgIsPnlPct;
+  const oosWinFoldShare = oosPnls.filter((v) => v > 0).length / foldCount;
+
+  return {
+    foldCount,
+    avgIsPnlPct: r2(avgIsPnlPct),
+    avgOosPnlPct: r2(avgOosPnlPct),
+    totalOosPnlPct: r2(totalOosPnlPct),
+    avgIsSharpe: avgIsSharpeRaw === null ? null : r2(avgIsSharpeRaw),
+    avgOosSharpe: avgOosSharpeRaw === null ? null : r2(avgOosSharpeRaw),
+    isOosPnlRatio: isOosPnlRatio === null ? null : r2(isOosPnlRatio),
+    oosWinFoldShare: r2(oosWinFoldShare),
+  };
+}

--- a/apps/api/src/lib/walkForward/run.ts
+++ b/apps/api/src/lib/walkForward/run.ts
@@ -23,6 +23,7 @@ import type { Candle } from "../bybitCandles.js";
 import type { DslExecOpts } from "../dslEvaluator.js";
 import { runBacktest } from "../backtest.js";
 import { split } from "./split.js";
+import { aggregate } from "./aggregate.js";
 import type {
   FoldConfig,
   FoldReport,
@@ -109,5 +110,5 @@ export function runWalkForward(
     };
   });
 
-  return { folds: folded };
+  return { folds: folded, aggregate: aggregate(folded) };
 }

--- a/apps/api/src/lib/walkForward/types.ts
+++ b/apps/api/src/lib/walkForward/types.ts
@@ -52,9 +52,31 @@ export type FoldReport = {
 };
 
 /**
- * Walk-forward run output. `aggregate` is added in 48-T3; until then the
- * field is intentionally absent.
+ * Aggregate metrics across all folds in a walk-forward run.
+ *
+ *   foldCount         — number of folds (FoldReport[] length).
+ *   avgIsPnlPct       — mean of isReport.totalPnlPct across folds.
+ *   avgOosPnlPct      — mean of oosReport.totalPnlPct across folds.
+ *   totalOosPnlPct    — naive sum of oosReport.totalPnlPct (no compounding;
+ *                       first-version limitation, documented in aggregate.ts).
+ *   avgIsSharpe       — mean of non-null isReport.sharpe; null if all null.
+ *   avgOosSharpe      — mean of non-null oosReport.sharpe; null if all null.
+ *   isOosPnlRatio     — avgOosPnlPct / avgIsPnlPct; null when avgIsPnlPct = 0.
+ *   oosWinFoldShare   — fraction of folds with oosReport.totalPnlPct > 0.
  */
+export type WalkForwardAggregate = {
+  foldCount: number;
+  avgIsPnlPct: number;
+  avgOosPnlPct: number;
+  totalOosPnlPct: number;
+  avgIsSharpe: number | null;
+  avgOosSharpe: number | null;
+  isOosPnlRatio: number | null;
+  oosWinFoldShare: number;
+};
+
+/** Walk-forward run output: per-fold reports plus an aggregate summary. */
 export type WalkForwardReport = {
   folds: FoldReport[];
+  aggregate: WalkForwardAggregate;
 };

--- a/apps/api/tests/lib/walkForward/aggregate.test.ts
+++ b/apps/api/tests/lib/walkForward/aggregate.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import { aggregate } from "../../../src/lib/walkForward/aggregate.js";
+import type { FoldReport } from "../../../src/lib/walkForward/types.js";
+import type { DslBacktestReport } from "../../../src/lib/dslEvaluator.js";
+
+function fakeReport(totalPnlPct: number, sharpe: number | null = null): DslBacktestReport {
+  return {
+    trades: 0,
+    wins: 0,
+    winrate: 0,
+    totalPnlPct,
+    maxDrawdownPct: 0,
+    candles: 0,
+    tradeLog: [],
+    sharpe,
+    profitFactor: null,
+    expectancy: null,
+  };
+}
+
+function fold(
+  i: number,
+  isPnl: number,
+  oosPnl: number,
+  isSharpe: number | null = null,
+  oosSharpe: number | null = null,
+): FoldReport {
+  return {
+    foldIndex: i,
+    isReport: fakeReport(isPnl, isSharpe),
+    oosReport: fakeReport(oosPnl, oosSharpe),
+    isRange: { fromIndex: 0, toIndex: 0, fromTsMs: 0, toTsMs: 0 },
+    oosRange: { fromIndex: 0, toIndex: 0, fromTsMs: 0, toTsMs: 0 },
+  };
+}
+
+describe("walkForward.aggregate", () => {
+  it("hand-calculated reference: 3 folds with mixed pnl + sharpe", () => {
+    const folds = [
+      fold(0, 5,  3,  1.5, 0.8),
+      fold(1, 4, -1,  1.0, 0.4),
+      fold(2, 6,  2,  null, null),
+    ];
+    const agg = aggregate(folds);
+
+    // avgIsPnlPct = (5 + 4 + 6) / 3 = 5.0
+    // avgOosPnlPct = (3 + (-1) + 2) / 3 = 4/3 ≈ 1.33
+    // totalOosPnlPct = 4
+    // avgIsSharpe (skipping null): (1.5 + 1.0) / 2 = 1.25
+    // avgOosSharpe: (0.8 + 0.4) / 2 = 0.6
+    // isOosPnlRatio = 1.33 / 5 ≈ 0.267 → 0.27
+    // oosWinFoldShare = 2 wins / 3 folds = 0.67
+    expect(agg.foldCount).toBe(3);
+    expect(agg.avgIsPnlPct).toBe(5);
+    expect(agg.avgOosPnlPct).toBe(1.33);
+    expect(agg.totalOosPnlPct).toBe(4);
+    expect(agg.avgIsSharpe).toBe(1.25);
+    expect(agg.avgOosSharpe).toBe(0.6);
+    expect(agg.isOosPnlRatio).toBe(0.27);
+    expect(agg.oosWinFoldShare).toBe(0.67);
+  });
+
+  it("oosWinFoldShare = 0 when every fold's OOS pnl is 0 or negative", () => {
+    const folds = [fold(0, 1, 0), fold(1, 1, -2), fold(2, 1, 0)];
+    expect(aggregate(folds).oosWinFoldShare).toBe(0);
+  });
+
+  it("avgOosSharpe = null when every fold's OOS sharpe is null", () => {
+    const folds = [
+      fold(0, 1, 1, 0.5, null),
+      fold(1, 1, 1, 0.5, null),
+    ];
+    expect(aggregate(folds).avgOosSharpe).toBeNull();
+    // avgIsSharpe still defined because IS sharpes are present.
+    expect(aggregate(folds).avgIsSharpe).toBe(0.5);
+  });
+
+  it("isOosPnlRatio = null when avgIsPnlPct is exactly 0 (avoid division by 0)", () => {
+    const folds = [
+      fold(0,  5, 1),
+      fold(1, -5, 2),
+    ];
+    // avgIsPnlPct = 0
+    expect(aggregate(folds).isOosPnlRatio).toBeNull();
+  });
+
+  it("ignores null sharpes when computing the mean", () => {
+    // Three IS sharpes: 1.0, null, 3.0 → mean over non-null = 2.0
+    const folds = [
+      fold(0, 1, 1, 1.0, null),
+      fold(1, 1, 1, null, 1.5),
+      fold(2, 1, 1, 3.0, null),
+    ];
+    const agg = aggregate(folds);
+    expect(agg.avgIsSharpe).toBe(2);
+    expect(agg.avgOosSharpe).toBe(1.5);
+  });
+
+  it("empty folds array returns zero/null aggregate (degenerate case)", () => {
+    const agg = aggregate([]);
+    expect(agg).toEqual({
+      foldCount: 0,
+      avgIsPnlPct: 0,
+      avgOosPnlPct: 0,
+      totalOosPnlPct: 0,
+      avgIsSharpe: null,
+      avgOosSharpe: null,
+      isOosPnlRatio: null,
+      oosWinFoldShare: 0,
+    });
+  });
+
+  it("rounds avg / total / ratio fields to 2 decimal places", () => {
+    const folds = [
+      fold(0, 1.111, 2.222, 0.333, 0.444),
+      fold(1, 2.345, 1.005, 0.667, 0.556),
+    ];
+    const agg = aggregate(folds);
+    // Each field — Math.round(x * 100) / 100; just check shape, not exact math.
+    for (const k of ["avgIsPnlPct", "avgOosPnlPct", "totalOosPnlPct", "isOosPnlRatio", "avgIsSharpe", "avgOosSharpe"] as const) {
+      const v = agg[k];
+      if (v !== null) {
+        expect(Math.round(v * 100) / 100).toBe(v);
+      }
+    }
+  });
+
+  it("totalOosPnlPct is a naive sum, not a compound (documented limitation)", () => {
+    const folds = [fold(0, 0, 10), fold(1, 0, 10), fold(2, 0, 10)];
+    expect(aggregate(folds).totalOosPnlPct).toBe(30);
+  });
+});


### PR DESCRIPTION
Реализация задачи **48-T3** из `docs/48-walk-forward-plan.md`. Продолжение направления «Walk-forward validation» после 48-T1 (#307) → 48-T2 (#308).

## Что сделано

### `apps/api/src/lib/walkForward/aggregate.ts`

Pure функция `aggregate(folds: FoldReport[]) → WalkForwardAggregate`:

| Поле | Семантика |
|---|---|
| `foldCount` | `folds.length` |
| `avgIsPnlPct` | `mean(f.isReport.totalPnlPct)` |
| `avgOosPnlPct` | `mean(f.oosReport.totalPnlPct)` |
| `totalOosPnlPct` | naive sum (no compounding — first-version limitation) |
| `avgIsSharpe` | mean of non-null `isReport.sharpe`; `null` если все null |
| `avgOosSharpe` | mean of non-null `oosReport.sharpe`; `null` если все null |
| `isOosPnlRatio` | `avgOosPnlPct / avgIsPnlPct`; `null` при `avgIsPnlPct === 0` |
| `oosWinFoldShare` | `count(f => f.oosReport.totalPnlPct > 0) / foldCount` |

Все numeric-поля округлены до 2 знаков — соответствует convention'у `totalPnlPct` в `DslBacktestReport`.

### `runWalkForward` теперь возвращает `{ folds, aggregate }`

Один импорт + одна строка в `return`. Никаких изменений в side-effects или signature функции.

### Заметка про `_localSharpe.ts`

docs/48-T3 §3 предусматривал временный `_localSharpe.ts` helper на случай, если `docs/49-T2` ещё не закрыт. Поскольку **docs/49-T2 уже мёрджнут** (#304) — `DslBacktestReport.sharpe` заполняется ядром, и aggregate читает его напрямую через `f.isReport.sharpe` / `f.oosReport.sharpe`. Никакого временного helper'а не вводится, никакого follow-up cleanup PR не нужно.

## Тесты (8 кейсов)

`apps/api/tests/lib/walkForward/aggregate.test.ts`:

1. **Hand-calc reference** на 3-fold mixed series: проверяются все 8 полей с явными arithmetic-комментариями.
2. **`oosWinFoldShare = 0`** когда все OOS pnl ≤ 0.
3. **`avgOosSharpe = null`** когда все OOS sharpe null (и IS-сторона осталась defined — test independence per side).
4. **`isOosPnlRatio = null`** при `avgIsPnlPct = 0` (избежать деления на 0).
5. **Null-mixed sharpe** — 3 fold-а с mixed null pattern, mean считается только по non-null значениям.
6. **Empty folds array** → degenerate case: все pnl/share = 0, sharpe/ratio = null.
7. **Rounding shape** — каждое numeric-поле == `round(field*100)/100`.
8. **Naive sum** — три fold-а по +10% → `totalOosPnlPct = 30` (не compounded 33.1).

## Backward compatibility

- ✅ `WalkForwardReport` расширен новым required полем `aggregate` — но это новый тип в новом модуле, **внешних потребителей пока нет** (docs/48-T5 и -T6 пишутся вместе с этим PR).
- ✅ Существующие 106 файлов / 1825 тестов проходят без правок.
- ✅ Никаких side-effects, никаких миграций.

## Не входит в задачу (per docs/48 § «Не входит в задачу»)

- Prisma модель `WalkForwardRun` → задача **48-T4**.
- HTTP-эндпоинты → задача **48-T5**.
- UI `WalkForwardPanel` → задача **48-T6**.
- e2e тесты → задача **48-T7**.
- Sortino, Calmar и пр. — отдельный follow-up direction.

## Критерии готовности (из docs/48-T3)

- [x] `tsc --noEmit` проходит.
- [x] Unit-тесты зелёные (107 файлов / 1833 теста, +8 vs T2).
- [x] Aggregate чисто функционален (нет I/O).
- [x] **Нет** TODO про `_localSharpe.ts` — docs/49-T2 закрыт, `report.sharpe` доступен напрямую.

## Тест-план для ревьюера

```bash
cd apps/api
npx prisma generate
npx tsc --noEmit
npx vitest run tests/lib/walkForward/   # 3 files, 23 tests
npx vitest run                          # full suite — 107 files, 1833 tests
```

Branch: `claude/48-t3-walkforward-aggregate` · 4 files added/modified (+232/−3) · commit `5d530a3`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmfV8BXGWUJSFNGArYKe9k)_