### PR TITLE
feat(prisma): add WalkForwardRun persistence model (48-T4)

### DIFF
--- a/apps/api/prisma/migrations/20260428100000_add_walk_forward_run/migration.sql
+++ b/apps/api/prisma/migrations/20260428100000_add_walk_forward_run/migration.sql
@@ -1,0 +1,38 @@
+-- 48-T4: walk-forward validation persistence layer.
+-- Additive only: one new enum, one new table, three indexes, one FK.
+-- Mirrors BacktestSweep structurally (workspace cascade, no inverse
+-- relations on strategyVersionId / datasetId).
+
+-- CreateEnum
+CREATE TYPE "WalkForwardStatus" AS ENUM ('PENDING', 'RUNNING', 'DONE', 'FAILED');
+
+-- CreateTable
+CREATE TABLE "WalkForwardRun" (
+    "id" TEXT NOT NULL,
+    "workspaceId" TEXT NOT NULL,
+    "strategyVersionId" TEXT NOT NULL,
+    "datasetId" TEXT NOT NULL,
+    "status" "WalkForwardStatus" NOT NULL DEFAULT 'PENDING',
+    "foldConfigJson" JSONB NOT NULL,
+    "foldCount" INTEGER NOT NULL DEFAULT 0,
+    "progress" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "foldsJson" JSONB,
+    "aggregateJson" JSONB,
+    "error" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "WalkForwardRun_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "WalkForwardRun_workspaceId_idx" ON "WalkForwardRun"("workspaceId");
+
+-- CreateIndex
+CREATE INDEX "WalkForwardRun_workspaceId_createdAt_idx" ON "WalkForwardRun"("workspaceId", "createdAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "WalkForwardRun_strategyVersionId_idx" ON "WalkForwardRun"("strategyVersionId");
+
+-- AddForeignKey
+ALTER TABLE "WalkForwardRun" ADD CONSTRAINT "WalkForwardRun_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "Workspace"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -59,6 +59,7 @@ model Workspace {
   datasets            MarketDataset[]
   strategyGraphs      StrategyGraph[]
   backtestSweeps      BacktestSweep[]
+  walkForwardRuns     WalkForwardRun[]
   journalEntries      LabJournalEntry[]
 }
 
@@ -708,6 +709,45 @@ model BacktestSweep {
 
   @@index([workspaceId])
   @@index([workspaceId, createdAt(sort: Desc)])
+}
+
+// ── Walk-forward validation (docs/48) ─────────────────────────────────────────
+
+enum WalkForwardStatus {
+  PENDING
+  RUNNING
+  DONE
+  FAILED
+}
+
+/// Stores a walk-forward validation run.
+/// Mirrors BacktestSweep structurally (workspace cascade, no inverse relations
+/// on strategyVersionId / datasetId — research logs survive parent deletion).
+/// Per-fold reports live in foldsJson without tradeLog (size discipline);
+/// aggregate summary lives in aggregateJson (see docs/48-T3).
+model WalkForwardRun {
+  id                 String            @id @default(cuid())
+  workspaceId        String
+  strategyVersionId  String
+  datasetId          String
+  status             WalkForwardStatus @default(PENDING)
+  /// { isBars, oosBars, step, anchored }
+  foldConfigJson     Json
+  foldCount          Int               @default(0)
+  /// 0..1 — fraction of folds completed
+  progress           Float             @default(0)
+  /// Truncated FoldReport[] (without per-fold tradeLog) — see docs/48-T4 §4
+  foldsJson          Json?
+  aggregateJson      Json?
+  error              String?
+  createdAt          DateTime          @default(now())
+  updatedAt          DateTime          @updatedAt
+
+  workspace Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+
+  @@index([workspaceId])
+  @@index([workspaceId, createdAt(sort: Desc)])
+  @@index([strategyVersionId])
 }
 
 // ── Stage 7: Funding Rate Arbitrage (#139, #140) ─────────────────────────────


### PR DESCRIPTION
Реализация задачи **48-T4** из `docs/48-walk-forward-plan.md`. Продолжение направления «Walk-forward validation» после 48-T1 (#307) → 48-T2 (#308) → 48-T3 (#309).

## Что сделано

### `apps/api/prisma/schema.prisma`

**Новый enum** рядом с `SweepStatus`:
```prisma
enum WalkForwardStatus { PENDING RUNNING DONE FAILED }
```

**Новая модель** `WalkForwardRun` — структурный аналог `BacktestSweep`:

| Поле | Тип | Назначение |
|---|---|---|
| `id` | `String @id @default(cuid())` | |
| `workspaceId` | `String` | FK → `Workspace` (cascade delete) |
| `strategyVersionId` | `String` | без `@relation` — research-логи переживают удаление родителя |
| `datasetId` | `String` | без `@relation` — то же |
| `status` | `WalkForwardStatus @default(PENDING)` | lifecycle PENDING → RUNNING → DONE/FAILED |
| `foldConfigJson` | `Json` | `{ isBars, oosBars, step, anchored }` |
| `foldCount` | `Int @default(0)` | заполняется после pre-flight `split()` |
| `progress` | `Float @default(0)` | 0..1 (отличается от sweep'ского `Int`-progress'а — у walk-forward fold-counts маленькие, дробное удобнее) |
| `foldsJson` | `Json?` | **truncated** `FoldReport[]` — **без** per-fold `tradeLog` (size discipline) |
| `aggregateJson` | `Json?` | `WalkForwardAggregate` (48-T3) |
| `error` | `String?` | для FAILED |
| `createdAt` / `updatedAt` | `DateTime` | стандартные |

**Связь** `walkForwardRuns: WalkForwardRun[]` добавлена в `Workspace` рядом с `backtestSweeps`.

**Индексы** (отзеркалены с `BacktestSweep`):
- `@@index([workspaceId])` — list-запросы по workspace
- `@@index([workspaceId, createdAt(sort: Desc)])` — recent-first list
- `@@index([strategyVersionId])` — поиск по стратегии

### Миграция `20260428100000_add_walk_forward_run/migration.sql`

**Полностью additive**:
- 1× `CREATE TYPE "WalkForwardStatus" AS ENUM (...)`
- 1× `CREATE TABLE "WalkForwardRun" (...)`
- 3× `CREATE INDEX`
- 1× `ALTER TABLE … ADD CONSTRAINT … FK ON DELETE CASCADE` (для `workspaceId`)

Никаких изменений существующих таблиц — применение миграции на populated БД безопасно.

## Решения по дизайну (per docs/48-T4)

- **Связи без inverse `@relation` для `strategyVersionId` / `datasetId`** — это намеренный выбор `BacktestSweep`'а, повторяемый здесь: удаление родительских записей не каскадится в research-логи. Walk-forward run остаётся доступен даже если стратегия/датасет были удалены.
- **`foldsJson` без `tradeLog`** — для 20 fold-ов с сотнями сделок per-fold tradeLog раздул бы JSONB до многих мегабайт. В первой версии храним только метрики per-fold (`pnlPct`, `winRate`, `maxDrawdownPct`, `tradeCount`, `sharpe`, ranges, foldIndex). Полный `tradeLog` доступен только в momentum исполнения.
- **`progress` как `Float` 0..1** — отличается от sweep'ского `Int`-progress'а (там `progress` это count of completed runs). Здесь fold-counts очень маленькие (≤20), дробное представление удобнее для UI прогрессбара.

## Backward compatibility

- ✅ Полностью новая таблица. Никаких существующих таблиц не изменяется.
- ✅ `prisma generate` без warnings.
- ✅ `tsc --noEmit` — clean (107 файлов).
- ✅ Существующие 1833 теста проходят без правок.

## Не входит в задачу

- HTTP-эндпоинты — задача **48-T5**.
- UI `WalkForwardPanel` — задача **48-T6**.
- e2e тесты — задача **48-T7**.
- Persisted per-fold candle slices — out of scope (хранится только foldsJson метрик).

## Критерии готовности (из docs/48-T4)

- [x] Миграция additive: только `CREATE TABLE`, `CREATE TYPE`, `CREATE INDEX`, `ADD CONSTRAINT FK` — никаких изменений существующих таблиц.
- [x] Schema проходит `prisma generate` без warnings.
- [x] Структура повторяет `BacktestSweep` (cascade workspace, no inverse relations on FKs, JSONB blobs).
- [x] `tsc --noEmit` clean.
- [x] Все существующие тесты зелёные.

## Тест-план для ревьюера

```bash
cd apps/api
npx prisma generate                # no warnings
npx prisma migrate deploy          # applies cleanly on a fresh + populated DB
npx tsc --noEmit
npx vitest run                     # full suite — 107 files, 1833 tests
```

Smoke (manual): `prisma.walkForwardRun.create({ data: { workspaceId, strategyVersionId, datasetId, foldConfigJson: { isBars: 50, oosBars: 10, step: 10, anchored: false } } })` — должен создать запись со `status: PENDING`, `progress: 0`, `foldCount: 0`.

Branch: `claude/48-t4-walkforward-prisma` · 2 files (+78) · commit `f3ef156`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmfV8BXGWUJSFNGArYKe9k)_