### PR TITLE
feat(lab): expose walk-forward via POST/GET endpoints (48-T5)

### DIFF
--- a/apps/api/src/routes/lab.ts
+++ b/apps/api/src/routes/lab.ts
@@ -4,6 +4,12 @@ import { problem } from "../lib/problem.js";
 import { logger } from "../lib/logger.js";
 import { resolveWorkspace } from "../lib/workspace.js";
 import { runBacktest } from "../lib/backtest.js";
+import {
+  runWalkForward,
+  WalkForwardMtfNotSupportedError,
+} from "../lib/walkForward/run.js";
+import { split as splitFolds } from "../lib/walkForward/split.js";
+import type { FoldConfig } from "../lib/walkForward/types.js";
 import { validateDsl } from "../lib/dslValidator.js";
 import { applyDslSweepParam } from "../lib/dslSweepParam.js";
 import { compileGraph } from "../lib/graphCompiler.js";
@@ -1026,6 +1032,160 @@ export async function labRoutes(app: FastifyInstance) {
   });
 
   // -------------------------------------------------------------------------
+  // Walk-forward validation (docs/48)
+  // -------------------------------------------------------------------------
+
+  // ── POST /lab/backtest/walk-forward ──────────────────────────────────────
+  app.post<{ Body: WalkForwardRequestBody }>("/lab/backtest/walk-forward", {
+    config: { rateLimit: { max: 5, timeWindow: "1 minute" } },
+    onRequest: [app.authenticate],
+  }, async (request, reply) => {
+    const workspace = await resolveWorkspace(request, reply);
+    if (!workspace) return;
+
+    const {
+      datasetId,
+      strategyVersionId,
+      fold,
+      feeBps = 0,
+      slippageBps = 0,
+      fillAt = "CLOSE",
+    } = request.body ?? {};
+
+    // ── Validation — required fields ──────────────────────────────────────
+    if (!datasetId || !strategyVersionId || !fold) {
+      return problem(reply, 400, "Validation Error", "datasetId, strategyVersionId, and fold are required");
+    }
+    if (
+      !Number.isFinite(fold.isBars) || fold.isBars <= 0
+      || !Number.isFinite(fold.oosBars) || fold.oosBars <= 0
+      || !Number.isFinite(fold.step) || fold.step <= 0
+      || typeof fold.anchored !== "boolean"
+    ) {
+      return problem(reply, 400, "Validation Error", "fold.{isBars, oosBars, step} must be positive numbers and fold.anchored must be boolean");
+    }
+    if (!ALLOWED_FILL_AT.includes(fillAt as FillAt)) {
+      return problem(reply, 400, "Validation Error", `fillAt must be one of: ${ALLOWED_FILL_AT.join(", ")}`);
+    }
+
+    // ── Resolve StrategyVersion + Dataset (workspace isolation) ───────────
+    const strategyVersion = await prisma.strategyVersion.findUnique({
+      where: { id: strategyVersionId },
+      include: { strategy: true },
+    });
+    if (!strategyVersion || strategyVersion.strategy.workspaceId !== workspace.id) {
+      return problem(reply, 404, "Not Found", "StrategyVersion not found");
+    }
+    const dataset = await prisma.marketDataset.findUnique({ where: { id: datasetId } });
+    if (!dataset || dataset.workspaceId !== workspace.id) {
+      return problem(reply, 404, "Not Found", "Dataset not found");
+    }
+
+    // ── Pre-flight: load candles + run split() to compute foldCount ───────
+    const dbCandles = await prisma.marketCandle.findMany({
+      where: {
+        exchange: dataset.exchange,
+        symbol: dataset.symbol,
+        interval: dataset.interval,
+        openTimeMs: { gte: dataset.fromTsMs, lte: dataset.toTsMs },
+      },
+      orderBy: { openTimeMs: "asc" },
+    });
+    const candles = dbCandles.map((c) => ({
+      openTime: Number(c.openTimeMs),
+      open: Number(c.open),
+      high: Number(c.high),
+      low: Number(c.low),
+      close: Number(c.close),
+      volume: Number(c.volume),
+    }));
+
+    const cfg: FoldConfig = {
+      isBars: fold.isBars,
+      oosBars: fold.oosBars,
+      step: fold.step,
+      anchored: fold.anchored,
+    };
+
+    let foldCount: number;
+    const warnings: string[] = [];
+    try {
+      const folds = splitFolds(candles, cfg);
+      foldCount = folds.length;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return problem(reply, 400, "Validation Error", msg);
+    }
+    if (foldCount < 1 || foldCount > 20) {
+      return problem(reply, 400, "Validation Error", `foldCount=${foldCount} out of bounds [1, 20]`);
+    }
+    if (cfg.step < cfg.oosBars) {
+      // Methodologically suboptimal but allowed — surfaced as a warning.
+      warnings.push("step < oosBars — adjacent OOS blocks overlap; aggregate metrics may double-count trades");
+    }
+
+    // ── Concurrency guard: shared with sweep (per workspace) ──────────────
+    const activeSweeps = await prisma.backtestSweep.count({
+      where: { workspaceId: workspace.id, status: { in: ["PENDING", "RUNNING"] } },
+    });
+    const activeWf = await prisma.walkForwardRun.count({
+      where: { workspaceId: workspace.id, status: { in: ["PENDING", "RUNNING"] } },
+    });
+    if (activeSweeps + activeWf >= 2) {
+      return problem(reply, 429, "Too Many Backtest Jobs", "max 2 concurrent backtest jobs (sweep+walk-forward) per workspace");
+    }
+
+    // ── Create PENDING WalkForwardRun ─────────────────────────────────────
+    const run = await prisma.walkForwardRun.create({
+      data: {
+        workspaceId: workspace.id,
+        strategyVersionId: strategyVersion.id,
+        datasetId: dataset.id,
+        status: "PENDING",
+        foldConfigJson: cfg as object,
+        foldCount,
+      },
+    });
+
+    runWalkForwardAsync(run.id, candles, strategyVersion.dslJson, {
+      feeBps, slippageBps, fillAt: fillAt as FillAt,
+    }, cfg).catch(() => {});
+
+    return reply.status(202).send({
+      id: run.id,
+      foldCount,
+      status: "pending",
+      warnings,
+    });
+  });
+
+  // ── GET /lab/backtest/walk-forward/:id ───────────────────────────────────
+  app.get<{ Params: { id: string } }>("/lab/backtest/walk-forward/:id", {
+    onRequest: [app.authenticate],
+  }, async (request, reply) => {
+    const workspace = await resolveWorkspace(request, reply);
+    if (!workspace) return;
+
+    const run = await prisma.walkForwardRun.findUnique({ where: { id: request.params.id } });
+    if (!run || run.workspaceId !== workspace.id) {
+      return problem(reply, 404, "Not Found", "WalkForwardRun not found");
+    }
+
+    return reply.send({
+      id: run.id,
+      status: run.status.toLowerCase(),
+      progress: run.progress,
+      foldCount: run.foldCount,
+      foldConfig: run.foldConfigJson,
+      folds: run.foldsJson,
+      aggregate: run.aggregateJson,
+      error: run.error,
+      createdAt: run.createdAt.toISOString(),
+      updatedAt: run.updatedAt.toISOString(),
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Research Journal — CRUD (Task 28)
   // -------------------------------------------------------------------------
 
@@ -1270,6 +1430,15 @@ export async function labRoutes(app: FastifyInstance) {
 // ---------------------------------------------------------------------------
 // Sweep request / response types (Phase C1)
 // ---------------------------------------------------------------------------
+
+interface WalkForwardRequestBody {
+  datasetId: string;
+  strategyVersionId: string;
+  fold: { isBars: number; oosBars: number; step: number; anchored: boolean };
+  feeBps?: number;
+  slippageBps?: number;
+  fillAt?: FillAt;
+}
 
 interface SweepRequestBody {
   datasetId: string;
@@ -1542,6 +1711,92 @@ async function runBacktestAsync(
     await prisma.backtestResult.update({
       where: { id: btId },
       data: { status: "FAILED", errorMessage: msg },
+    }).catch(() => undefined);
+  }
+}
+
+async function runWalkForwardAsync(
+  runId: string,
+  candles: Array<{ openTime: number; open: number; high: number; low: number; close: number; volume: number }>,
+  dslJson: unknown,
+  opts: { feeBps: number; slippageBps: number; fillAt: FillAt },
+  cfg: FoldConfig,
+): Promise<void> {
+  try {
+    await prisma.walkForwardRun.update({
+      where: { id: runId },
+      data: { status: "RUNNING" },
+    });
+
+    // Throttle progress writes — at most one DB update per fold completion,
+    // but coalesce when foldCount is large (ceil(total/10)). For walk-
+    // forward foldCount ≤ 20, so simply write on every fold is fine.
+    const onProgress = async (done: number, total: number) => {
+      try {
+        await prisma.walkForwardRun.update({
+          where: { id: runId },
+          data: { progress: total > 0 ? done / total : 0 },
+        });
+      } catch {
+        // progress updates are best-effort — never fail the run because of them.
+      }
+    };
+
+    const report = runWalkForward(candles, dslJson, opts, cfg, (done, total) => {
+      // fire-and-forget so the runner is not awaited
+      onProgress(done, total).catch(() => {});
+    });
+
+    // Store a truncated FoldReport[] without per-fold tradeLog (size discipline,
+    // docs/48-T4 §4). The full tradeLog only existed in memory during the run.
+    const foldsTruncated = report.folds.map((f) => ({
+      foldIndex: f.foldIndex,
+      isRange: f.isRange,
+      oosRange: f.oosRange,
+      isReport: {
+        trades: f.isReport.trades,
+        wins: f.isReport.wins,
+        winrate: f.isReport.winrate,
+        totalPnlPct: f.isReport.totalPnlPct,
+        maxDrawdownPct: f.isReport.maxDrawdownPct,
+        candles: f.isReport.candles,
+        sharpe: f.isReport.sharpe,
+        profitFactor: f.isReport.profitFactor,
+        expectancy: f.isReport.expectancy,
+      },
+      oosReport: {
+        trades: f.oosReport.trades,
+        wins: f.oosReport.wins,
+        winrate: f.oosReport.winrate,
+        totalPnlPct: f.oosReport.totalPnlPct,
+        maxDrawdownPct: f.oosReport.maxDrawdownPct,
+        candles: f.oosReport.candles,
+        sharpe: f.oosReport.sharpe,
+        profitFactor: f.oosReport.profitFactor,
+        expectancy: f.oosReport.expectancy,
+      },
+    }));
+
+    await prisma.walkForwardRun.update({
+      where: { id: runId },
+      data: {
+        status: "DONE",
+        progress: 1,
+        foldsJson: foldsTruncated as unknown as object,
+        aggregateJson: report.aggregate as unknown as object,
+      },
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    // Pre-flight MTF rejection arrives here too — we keep the same record
+    // shape (status=FAILED + error) so the UI surfaces the message uniformly.
+    const wfMtf = err instanceof WalkForwardMtfNotSupportedError;
+    if (!wfMtf) {
+      logger.error({ runId, err: msg }, "walkForward run failed");
+    }
+    await prisma.walkForwardRun.update({
+      where: { id: runId },
+      data: { status: "FAILED", error: msg },
     }).catch(() => undefined);
   }
 }

--- a/apps/api/tests/routes/lab.test.ts
+++ b/apps/api/tests/routes/lab.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from "vites
 const mockGraphs: Record<string, unknown> = {};
 const mockBacktests: Record<string, unknown> = {};
 const mockSweeps: Record<string, unknown> = {};
+const mockWalkForwardRuns: Record<string, Record<string, unknown>> = {};
 const mockStrategyVersions: Record<string, unknown> = {};
 const mockStrategies: Record<string, unknown> = {};
 const mockDatasets: Record<string, unknown> = {};
@@ -153,6 +154,33 @@ vi.mock("../../src/lib/prisma.js", () => ({
       count: vi.fn().mockResolvedValue(0),
       update: vi.fn().mockResolvedValue({}),
     },
+    walkForwardRun: {
+      create: vi.fn().mockImplementation(({ data }: { data: Record<string, unknown> }) => {
+        const id = `wf-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+        const record: Record<string, unknown> = {
+          id,
+          ...data,
+          progress: 0,
+          foldsJson: null,
+          aggregateJson: null,
+          error: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        };
+        mockWalkForwardRuns[id] = record;
+        return Promise.resolve(record);
+      }),
+      findUnique: vi.fn().mockImplementation(({ where }: { where: { id: string } }) => {
+        return Promise.resolve(mockWalkForwardRuns[where.id] ?? null);
+      }),
+      count: vi.fn().mockResolvedValue(0),
+      update: vi.fn().mockImplementation(({ where, data }: { where: { id: string }; data: Record<string, unknown> }) => {
+        const cur = mockWalkForwardRuns[where.id];
+        if (!cur) return Promise.resolve(null);
+        Object.assign(cur, data, { updatedAt: new Date() });
+        return Promise.resolve(cur);
+      }),
+    },
     marketDataset: {
       findUnique: vi.fn().mockImplementation(({ where }: { where: { id: string } }) => {
         return Promise.resolve(mockDatasets[where.id] ?? null);
@@ -236,6 +264,7 @@ beforeEach(() => {
   Object.keys(mockGraphs).forEach((k) => delete mockGraphs[k]);
   Object.keys(mockBacktests).forEach((k) => delete mockBacktests[k]);
   Object.keys(mockSweeps).forEach((k) => delete mockSweeps[k]);
+  Object.keys(mockWalkForwardRuns).forEach((k) => delete mockWalkForwardRuns[k]);
   Object.keys(mockStrategyVersions).forEach((k) => delete mockStrategyVersions[k]);
   Object.keys(mockStrategies).forEach((k) => delete mockStrategies[k]);
   Object.keys(mockDatasets).forEach((k) => delete mockDatasets[k]);
@@ -1145,3 +1174,214 @@ describe("POST /api/v1/lab/preview", () => {
     expect(res.json().errors[0].message).toContain("mutually exclusive");
   });
 });
+
+
+// ── POST /lab/backtest/walk-forward + GET (48-T5) ─────────────────────────────
+
+describe("POST /api/v1/lab/backtest/walk-forward", () => {
+  const prismaMock = previewPrisma as unknown as {
+    marketCandle: { findMany: ReturnType<typeof vi.fn> };
+  };
+
+  function makeCandles(n: number) {
+    const nowMs = Date.now();
+    return Array.from({ length: n }, (_, i) => ({
+      openTimeMs: BigInt(nowMs - (n - i) * 15 * 60_000),
+      open: 100, high: 101, low: 99, close: 100.5, volume: 10,
+    }));
+  }
+
+  let ipCounter = 0;
+  function wfHeaders() {
+    ipCounter += 1;
+    const oct = 11 + (ipCounter % 240);
+    return { ...authHeaders(), "x-forwarded-for": `10.48.5.${oct}` };
+  }
+
+  it("returns 400 when required fields are missing", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/lab/backtest/walk-forward",
+      headers: wfHeaders(),
+      payload: {},
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 400 when fold has non-positive params", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/lab/backtest/walk-forward",
+      headers: wfHeaders(),
+      payload: {
+        datasetId: "ds-1", strategyVersionId: "sv-1",
+        fold: { isBars: 0, oosBars: 10, step: 5, anchored: false },
+      },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 400 when fillAt is invalid", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/lab/backtest/walk-forward",
+      headers: wfHeaders(),
+      payload: {
+        datasetId: "ds-1", strategyVersionId: "sv-1",
+        fold: { isBars: 30, oosBars: 10, step: 10, anchored: false },
+        fillAt: "BOGUS",
+      },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 404 when StrategyVersion is missing or in another workspace", async () => {
+    mockDatasets["ds-wf-1"] = { id: "ds-wf-1", workspaceId: WS_ID, exchange: "bybit", symbol: "BTCUSDT", interval: "M15", fromTsMs: BigInt(0), toTsMs: BigInt(1), datasetHash: "h" };
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/lab/backtest/walk-forward",
+      headers: wfHeaders(),
+      payload: {
+        datasetId: "ds-wf-1", strategyVersionId: "sv-missing",
+        fold: { isBars: 30, oosBars: 10, step: 10, anchored: false },
+      },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 400 when foldCount is below 1 (not enough candles)", async () => {
+    mockStrategyVersions["sv-wf"] = { id: "sv-wf", strategyId: "strat-wf", strategy: { workspaceId: WS_ID }, dslJson: {} };
+    mockDatasets["ds-wf-2"] = { id: "ds-wf-2", workspaceId: WS_ID, exchange: "bybit", symbol: "BTCUSDT", interval: "M15", fromTsMs: BigInt(0), toTsMs: BigInt(1), datasetHash: "h" };
+    prismaMock.marketCandle.findMany.mockResolvedValueOnce(makeCandles(20));
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/lab/backtest/walk-forward",
+      headers: wfHeaders(),
+      payload: {
+        datasetId: "ds-wf-2", strategyVersionId: "sv-wf",
+        fold: { isBars: 30, oosBars: 10, step: 10, anchored: false }, // requires >= 40 candles
+      },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 400 when foldCount exceeds 20", async () => {
+    mockStrategyVersions["sv-wf"] = { id: "sv-wf", strategyId: "strat-wf", strategy: { workspaceId: WS_ID }, dslJson: {} };
+    mockDatasets["ds-wf-3"] = { id: "ds-wf-3", workspaceId: WS_ID, exchange: "bybit", symbol: "BTCUSDT", interval: "M15", fromTsMs: BigInt(0), toTsMs: BigInt(1), datasetHash: "h" };
+    // 100 candles, isBars=10/oosBars=1/step=1 → ~90 folds (way over 20)
+    prismaMock.marketCandle.findMany.mockResolvedValueOnce(makeCandles(100));
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/lab/backtest/walk-forward",
+      headers: wfHeaders(),
+      payload: {
+        datasetId: "ds-wf-3", strategyVersionId: "sv-wf",
+        fold: { isBars: 10, oosBars: 1, step: 1, anchored: false },
+      },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().detail).toContain("foldCount");
+  });
+
+  it("returns 202 with id + foldCount on a valid request", async () => {
+    mockStrategyVersions["sv-wf"] = { id: "sv-wf", strategyId: "strat-wf", strategy: { workspaceId: WS_ID }, dslJson: {} };
+    mockDatasets["ds-wf-4"] = { id: "ds-wf-4", workspaceId: WS_ID, exchange: "bybit", symbol: "BTCUSDT", interval: "M15", fromTsMs: BigInt(0), toTsMs: BigInt(1), datasetHash: "h" };
+    // 100 candles, isBars=30/oosBars=10/step=10 → 7 folds (within [1, 20])
+    prismaMock.marketCandle.findMany.mockResolvedValueOnce(makeCandles(100));
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/lab/backtest/walk-forward",
+      headers: wfHeaders(),
+      payload: {
+        datasetId: "ds-wf-4", strategyVersionId: "sv-wf",
+        fold: { isBars: 30, oosBars: 10, step: 10, anchored: false },
+      },
+    });
+    expect(res.statusCode).toBe(202);
+    const body = res.json();
+    expect(body.id).toMatch(/^wf-/);
+    expect(body.foldCount).toBe(7);
+    expect(body.status).toBe("pending");
+    expect(Array.isArray(body.warnings)).toBe(true);
+  });
+
+  it("attaches a warning when step < oosBars (overlapping OOS)", async () => {
+    mockStrategyVersions["sv-wf"] = { id: "sv-wf", strategyId: "strat-wf", strategy: { workspaceId: WS_ID }, dslJson: {} };
+    mockDatasets["ds-wf-5"] = { id: "ds-wf-5", workspaceId: WS_ID, exchange: "bybit", symbol: "BTCUSDT", interval: "M15", fromTsMs: BigInt(0), toTsMs: BigInt(1), datasetHash: "h" };
+    prismaMock.marketCandle.findMany.mockResolvedValueOnce(makeCandles(80));
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/lab/backtest/walk-forward",
+      headers: wfHeaders(),
+      payload: {
+        datasetId: "ds-wf-5", strategyVersionId: "sv-wf",
+        fold: { isBars: 30, oosBars: 10, step: 5, anchored: false }, // step < oosBars → overlap
+      },
+    });
+    expect(res.statusCode).toBe(202);
+    expect(res.json().warnings).toContain(
+      "step < oosBars — adjacent OOS blocks overlap; aggregate metrics may double-count trades",
+    );
+  });
+});
+
+describe("GET /api/v1/lab/backtest/walk-forward/:id", () => {
+  it("returns 404 when run is missing", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/lab/backtest/walk-forward/missing",
+      headers: authHeaders(),
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 404 when run belongs to another workspace", async () => {
+    mockWalkForwardRuns["wf-other"] = {
+      id: "wf-other",
+      workspaceId: "ws-other",
+      status: "DONE",
+      progress: 1,
+      foldCount: 3,
+      foldConfigJson: {},
+      foldsJson: null,
+      aggregateJson: null,
+      error: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/lab/backtest/walk-forward/wf-other",
+      headers: authHeaders(),
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns the run when it belongs to the workspace", async () => {
+    mockWalkForwardRuns["wf-mine"] = {
+      id: "wf-mine",
+      workspaceId: WS_ID,
+      status: "DONE",
+      progress: 1,
+      foldCount: 5,
+      foldConfigJson: { isBars: 50, oosBars: 10, step: 10, anchored: false },
+      foldsJson: [{ foldIndex: 0 }],
+      aggregateJson: { foldCount: 5, avgIsPnlPct: 1.5, avgOosPnlPct: 0.7 },
+      error: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/lab/backtest/walk-forward/wf-mine",
+      headers: authHeaders(),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.id).toBe("wf-mine");
+    expect(body.status).toBe("done");
+    expect(body.foldCount).toBe(5);
+    expect(body.aggregate.avgIsPnlPct).toBe(1.5);
+  });
+});
+


### PR DESCRIPTION
Реализация задачи **48-T5** из `docs/48-walk-forward-plan.md`. Продолжение направления «Walk-forward validation» после 48-T1 (#307) → 48-T2 (#308) → 48-T3 (#309) → 48-T4 (#310).

## Что сделано

Два новых endpoint'а в `apps/api/src/routes/lab.ts`, структурно отзеркаленные с существующих sweep endpoint'ов.

### `POST /lab/backtest/walk-forward`

**Body:**
```ts
{
  datasetId: string;
  strategyVersionId: string;
  fold: { isBars: number; oosBars: number; step: number; anchored: boolean };
  feeBps?: number;
  slippageBps?: number;
  fillAt?: "OPEN" | "CLOSE" | "NEXT_OPEN";  // 46-T1
}
```

**Pipeline:**
1. **Rate-limit** `5/min` (per-route, отдельный bucket от sweep).
2. **Validation**: `fold.{isBars,oosBars,step}` — позитивные числа, `fold.anchored` — boolean, `fillAt` — валидный.
3. **Resolve** `StrategyVersion` + `Dataset` с workspace-isolation (404 на cross-workspace).
4. **Load candles** один раз — тот же `marketCandle.findMany` паттерн, что у sweep'а.
5. **Pre-flight split()** для `foldCount`. Если `split` бросает или `foldCount ∉ [1, 20]` → 400 с понятным сообщением.
6. **Warnings**: если `step < oosBars` (overlapping OOS, методологически suboptimal) — добавить в response `warnings: ["step < oosBars — adjacent OOS blocks overlap..."]`. Сам split разрешает overlap (T1), но HTTP-слой surf'ит warning.
7. **Concurrency guard, shared со sweep**: `count(PENDING|RUNNING in BacktestSweep) + count(PENDING|RUNNING in WalkForwardRun) ≥ 2 → 429` с сообщением `"max 2 concurrent backtest jobs (sweep+walk-forward) per workspace"`. Это намеренно — оба heavy in-process job'а конкурируют за event loop.
8. **Create** PENDING `WalkForwardRun` с `foldCount`, kick `runWalkForwardAsync(...)` через fire-and-forget.
9. **Return** `202 { id, foldCount, status: "pending", warnings }`.

### `runWalkForwardAsync`

- Set `status: RUNNING`, run `runWalkForward(candles, dslJson, opts, cfg, onProgress)` где `onProgress(done, total)` инкрементально обновляет `progress = done/total` в БД (best-effort, не падает если update failed).
- Persist **truncated** `FoldReport[]` (без per-fold `tradeLog` — size discipline 48-T4 §4) в `foldsJson` + `aggregate` в `aggregateJson` + `status: DONE`.
- `WalkForwardMtfNotSupportedError` (от 48-T2) и любая другая ошибка → `status: FAILED, error: <message>`. Никогда не throws caller'у.

### `GET /lab/backtest/walk-forward/:id`

- Workspace-isolated (404 на cross-workspace).
- Возвращает полный объект записи: `{ id, status, progress, foldCount, foldConfig, folds, aggregate, error, createdAt, updatedAt }` для UI polling'а.

## E2E тесты (11 кейсов)

`apps/api/tests/routes/lab.test.ts`:

**POST validation/auth (8):**
1. Missing required fields → 400.
2. Non-positive `fold.isBars` → 400.
3. Invalid `fillAt` → 400.
4. Missing StrategyVersion → 404.
5. `foldCount < 1` (мало свечей) → 400.
6. `foldCount > 20` → 400 с `detail: "foldCount=…"`.
7. **Happy path**: 100 свечей, `isBars=30/oosBars=10/step=10` → `foldCount=7`, `status: "pending"`, `warnings: []`.
8. **Overlapping OOS warning**: `step=5, oosBars=10` → 202 с `warnings` содержащим overlap-нотис.

**GET (3):**
9. Missing run → 404.
10. Cross-workspace → 404.
11. Own workspace → 200 с `aggregate.avgIsPnlPct`.

Каждый POST использует уникальный `X-Forwarded-For` (`10.48.5.X`) для свежего rate-limit bucket'а — тот же паттерн, что у sweep/preview тестов.

## Backward compatibility

- ✅ Существующие 83 lab.test.ts теста и 105 других файлов проходят без правок.
- ✅ Никаких изменений в существующих endpoint'ах.
- ✅ Новый endpoint не влияет на sweep concurrency бюджет напрямую (но участвует в общем счёте 2 jobs/workspace, как и спроектировано).

## Не входит в задачу

- UI `WalkForwardPanel` → задача **48-T6**.
- Дополнительные unit/e2e тесты (golden-таблицы, full happy path с DONE) → задача **48-T7**.
- `_localSharpe.ts` cleanup — не нужен (49-T2 закрыт).

## Критерии готовности (из docs/48-T5)

- [x] `tsc --noEmit` проходит.
- [x] e2e тесты зелёные (107 файлов / 1844 теста, +11 vs T4).
- [x] Rate-limit и concurrency делятся со sweep корректно.
- [x] Хэндлер не блокирует event loop (fire-and-forget через `runWalkForwardAsync(...).catch(() => {})`).

## Тест-план для ревьюера

```bash
cd apps/api
npx prisma generate
npx tsc --noEmit
npx vitest run tests/routes/lab.test.ts   # 94 tests
npx vitest run                            # full suite — 107 files, 1844 tests
```

Branch: `claude/48-t5-walkforward-endpoints` · 2 files (+495) · commit `b0eb1ba`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmfV8BXGWUJSFNGArYKe9k)_