### PR TITLE
feat(lab): accept sweepParams[] (1..3) with backward-compat alias (47-T1)

### DIFF
--- a/apps/api/src/routes/lab.ts
+++ b/apps/api/src/routes/lab.ts
@@ -891,40 +891,77 @@ export async function labRoutes(app: FastifyInstance) {
       datasetId,
       strategyVersionId,
       sweepParam,
+      sweepParams: sweepParamsBody,
       feeBps = 0,
       slippageBps = 0,
       fillAt = "CLOSE",
     } = request.body ?? {};
 
+    // ── 47-T1 normalization ────────────────────────────────────────────
+    // Accept either `sweepParams: SweepParam[]` (new) or `sweepParam: {...}`
+    // (legacy alias). When both are present, the array wins; the singular
+    // form is logged as ignored for visibility.
+    let sweepParams: SweepParam[] | undefined;
+    if (sweepParamsBody && Array.isArray(sweepParamsBody)) {
+      sweepParams = sweepParamsBody;
+      if (sweepParam) {
+        logger.warn(
+          { workspaceId: workspace.id },
+          "POST /lab/backtest/sweep: both sweepParams and sweepParam given; using sweepParams",
+        );
+      }
+    } else if (sweepParam) {
+      sweepParams = [sweepParam];
+    }
+
     // ── Validation ──────────────────────────────────────────────────────────
-    if (!datasetId || !strategyVersionId || !sweepParam) {
-      return problem(reply, 400, "Validation Error", "datasetId, strategyVersionId, and sweepParam are required");
+    if (!datasetId || !strategyVersionId || !sweepParams) {
+      return problem(reply, 400, "Validation Error", "datasetId, strategyVersionId, and (sweepParam OR sweepParams) are required");
     }
     if (!ALLOWED_FILL_AT.includes(fillAt as FillAt)) {
       return problem(reply, 400, "Validation Error", `fillAt must be one of: ${ALLOWED_FILL_AT.join(", ")}`);
     }
-
-    if (!sweepParam.blockId || !sweepParam.paramName) {
-      return problem(reply, 400, "Validation Error", "sweepParam.blockId and sweepParam.paramName are required");
+    if (sweepParams.length < 1 || sweepParams.length > 3) {
+      return problem(reply, 400, "Validation Error", "sweepParams must contain 1 to 3 entries");
+    }
+    // Reject duplicate (blockId, paramName) tuples — mutating the same
+    // parameter twice with different values inside one combination is
+    // ambiguous and rejected up front.
+    const seenKeys = new Set<string>();
+    for (const p of sweepParams) {
+      const key = `${p.blockId}.${p.paramName}`;
+      if (seenKeys.has(key)) {
+        return problem(reply, 400, "Validation Error", `sweepParams contains duplicate (blockId, paramName): ${key}`);
+      }
+      seenKeys.add(key);
     }
 
-    const { from, to, step } = sweepParam;
-    if (typeof from !== "number" || typeof to !== "number" || typeof step !== "number") {
-      return problem(reply, 400, "Validation Error", "sweepParam.from, .to, .step must be numbers");
+    let totalRunCount = 1;
+    for (const p of sweepParams) {
+      if (!p.blockId || !p.paramName) {
+        return problem(reply, 400, "Validation Error", "each sweepParams entry needs blockId and paramName");
+      }
+      if (typeof p.from !== "number" || typeof p.to !== "number" || typeof p.step !== "number") {
+        return problem(reply, 400, "Validation Error", "each sweepParams entry needs numeric from/to/step");
+      }
+      if (p.from >= p.to) {
+        return problem(reply, 400, "Validation Error", "sweepParams.from must be less than sweepParams.to");
+      }
+      if (p.step <= 0) {
+        return problem(reply, 400, "Validation Error", "sweepParams.step must be greater than 0");
+      }
+      const runs = Math.floor((p.to - p.from) / p.step) + 1;
+      if (runs < 2) {
+        return problem(reply, 400, "Validation Error", "each sweepParams entry must yield at least 2 runs");
+      }
+      totalRunCount *= runs;
     }
-    if (from >= to) {
-      return problem(reply, 400, "Validation Error", "sweepParam.from must be less than sweepParam.to");
-    }
-    if (step <= 0) {
-      return problem(reply, 400, "Validation Error", "sweepParam.step must be greater than 0");
-    }
-
-    const runCount = Math.floor((to - from) / step) + 1;
 
     // ── Guard: max 20 runs (docs/24 §8.3) ────────────────────────────────
-    if (runCount > 20) {
-      return problem(reply, 422, "Sweep Too Large", "Sweep exceeds maximum of 20 runs. Narrow the range or increase the step.");
+    if (totalRunCount > 20) {
+      return problem(reply, 422, "Sweep Too Large", "Sweep exceeds maximum of 20 runs. Narrow the ranges or increase the step.");
     }
+    const runCount = totalRunCount;
 
     if (!Number.isInteger(feeBps) || feeBps < 0 || feeBps > MAX_BPS) {
       return problem(reply, 400, "Validation Error", `feeBps must be integer 0–${MAX_BPS}`);
@@ -962,7 +999,10 @@ export async function labRoutes(app: FastifyInstance) {
         workspaceId: workspace.id,
         strategyVersionId,
         datasetId,
-        sweepParamJson: sweepParam as object,
+        // 47-T1: persist as array. Single-param requests still produce a
+        // length-1 array; legacy rows that pre-date 47-T1 carry a single
+        // object — `normalizeSweepParams` reads both shapes uniformly.
+        sweepParamJson: sweepParams as unknown as object,
         feeBps,
         slippageBps,
         fillAt,
@@ -996,11 +1036,17 @@ export async function labRoutes(app: FastifyInstance) {
       ? results.reduce((best, r) => r.pnlPct > best.pnlPct ? r : best, results[0])
       : undefined;
 
+    // 47-T1: surface both shapes. Old clients keep reading `sweepParam`;
+    // new clients (47-T5) read `sweepParams` and ignore the singular alias.
+    const sweepParamsArr = normalizeSweepParams(sweep.sweepParamJson);
+
     return reply.send({
       id: sweep.id,
       status: sweep.status.toLowerCase(),
       progress: sweep.progress,
       runCount: sweep.runCount,
+      sweepParam: sweepParamsArr[0],
+      sweepParams: sweepParamsArr,
       results,
       bestRow,
       createdAt: sweep.createdAt.toISOString(),
@@ -1018,17 +1064,24 @@ export async function labRoutes(app: FastifyInstance) {
       orderBy: { createdAt: "desc" },
       take: 50,
     });
-    return reply.send(list.map((s) => ({
-      id: s.id,
-      status: s.status.toLowerCase(),
-      progress: s.progress,
-      runCount: s.runCount,
-      sweepParamJson: s.sweepParamJson,
-      resultsJson: s.resultsJson,
-      bestParamValue: s.bestParamValue,
-      createdAt: s.createdAt.toISOString(),
-      updatedAt: s.updatedAt.toISOString(),
-    })));
+    return reply.send(list.map((s) => {
+      const sweepParamsArr = normalizeSweepParams(s.sweepParamJson);
+      return {
+        id: s.id,
+        status: s.status.toLowerCase(),
+        progress: s.progress,
+        runCount: s.runCount,
+        // 47-T1: keep the legacy `sweepParamJson` for callers that already
+        // know how to handle either shape, plus expose normalized arrays.
+        sweepParamJson: s.sweepParamJson,
+        sweepParam: sweepParamsArr[0],
+        sweepParams: sweepParamsArr,
+        resultsJson: s.resultsJson,
+        bestParamValue: s.bestParamValue,
+        createdAt: s.createdAt.toISOString(),
+        updatedAt: s.updatedAt.toISOString(),
+      };
+    }));
   });
 
   // -------------------------------------------------------------------------
@@ -1440,19 +1493,37 @@ interface WalkForwardRequestBody {
   fillAt?: FillAt;
 }
 
+interface SweepParam {
+  blockId: string;
+  paramName: string;
+  from: number;
+  to: number;
+  step: number;
+}
+
 interface SweepRequestBody {
   datasetId: string;
   strategyVersionId: string;
-  sweepParam: {
-    blockId: string;
-    paramName: string;
-    from: number;
-    to: number;
-    step: number;
-  };
+  /** @deprecated Use {@link sweepParams}. Retained as a backward-compat
+   *  alias: when `sweepParams` is omitted, the singular form is wrapped
+   *  in a length-1 array. If both are present, `sweepParams` wins. */
+  sweepParam?: SweepParam;
+  /** Multi-parameter grid (1..3 elements). Cartesian product enforced
+   *  separately in 47-T3 against the runCount limit. */
+  sweepParams?: SweepParam[];
   feeBps?: number;
   slippageBps?: number;
   fillAt?: FillAt;
+}
+
+/**
+ * Normalize the persisted `BacktestSweep.sweepParamJson` value, which is
+ * `Json` and may carry either the legacy single-object shape or the new
+ * array shape introduced in 47-T1. Old rows are not backfilled.
+ */
+function normalizeSweepParams(json: unknown): SweepParam[] {
+  if (Array.isArray(json)) return json as SweepParam[];
+  return [json as SweepParam];
 }
 
 interface SweepRow {
@@ -1482,7 +1553,11 @@ async function runSweepAsync(sweepId: string): Promise<void> {
       data: { status: "RUNNING" },
     });
 
-    const sweepParam = sweep.sweepParamJson as { blockId: string; paramName: string; from: number; to: number; step: number };
+    // 47-T1: persisted shape is an array of params. Multi-param iteration
+    // arrives in 47-T3; until then the linear loop still walks the first
+    // entry, which keeps single-param sweeps bit-for-bit identical.
+    const sweepParamsAll = normalizeSweepParams(sweep.sweepParamJson);
+    const sweepParam = sweepParamsAll[0];
 
     // Resolve strategy version and dataset
     const strategyVersion = await prisma.strategyVersion.findUnique({

--- a/apps/api/tests/routes/lab.test.ts
+++ b/apps/api/tests/routes/lab.test.ts
@@ -605,6 +605,136 @@ describe("POST /api/v1/lab/backtest/sweep", () => {
     });
     expect(res.statusCode).toBe(400);
   });
+
+  // 47-T1: SweepRequestBody accepts sweepParams (1..3) with backward-compat
+  // alias on the singular sweepParam. Each test uses a distinct
+  // X-Forwarded-For so the per-route 5/min rate-limit bucket stays fresh.
+  const t1Headers = (ip: string) => ({ ...authHeaders(), "x-forwarded-for": ip });
+
+  it("47-T1: accepts sweepParams (length 1) and persists as array", async () => {
+    mockStrategyVersions["sv-47-1"] = { id: "sv-47-1", strategyId: "strat-47", strategy: { workspaceId: WS_ID }, dslJson: {} };
+    mockDatasets["ds-47-1"] = { id: "ds-47-1", workspaceId: WS_ID, exchange: "bybit", symbol: "BTCUSDT", interval: "M15", fromTsMs: BigInt(0), toTsMs: BigInt(1), datasetHash: "h" };
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/lab/backtest/sweep",
+      headers: t1Headers("10.47.1.1"),
+      payload: {
+        datasetId: "ds-47-1",
+        strategyVersionId: "sv-47-1",
+        sweepParams: [{ blockId: "b1", paramName: "p1", from: 1, to: 5, step: 1 }],
+      },
+    });
+    expect(res.statusCode).toBe(202);
+    expect(res.json().runCount).toBe(5);
+  });
+
+  it("47-T1: accepts 2-param sweepParams within the 20-run limit (3×3 = 9)", async () => {
+    mockStrategyVersions["sv-47-2"] = { id: "sv-47-2", strategyId: "strat-47", strategy: { workspaceId: WS_ID }, dslJson: {} };
+    mockDatasets["ds-47-2"] = { id: "ds-47-2", workspaceId: WS_ID, exchange: "bybit", symbol: "BTCUSDT", interval: "M15", fromTsMs: BigInt(0), toTsMs: BigInt(1), datasetHash: "h" };
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/lab/backtest/sweep",
+      headers: t1Headers("10.47.1.2"),
+      payload: {
+        datasetId: "ds-47-2",
+        strategyVersionId: "sv-47-2",
+        sweepParams: [
+          { blockId: "b1", paramName: "p1", from: 1, to: 3, step: 1 },
+          { blockId: "b2", paramName: "p2", from: 10, to: 30, step: 10 },
+        ],
+      },
+    });
+    expect(res.statusCode).toBe(202);
+    expect(res.json().runCount).toBe(9);
+  });
+
+  it("47-T1: rejects sweepParams with 4 entries (length > 3)", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/lab/backtest/sweep",
+      headers: t1Headers("10.47.1.3"),
+      payload: {
+        datasetId: "ds-1",
+        strategyVersionId: "sv-1",
+        sweepParams: [
+          { blockId: "b1", paramName: "p1", from: 1, to: 2, step: 1 },
+          { blockId: "b2", paramName: "p2", from: 1, to: 2, step: 1 },
+          { blockId: "b3", paramName: "p3", from: 1, to: 2, step: 1 },
+          { blockId: "b4", paramName: "p4", from: 1, to: 2, step: 1 },
+        ],
+      },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().detail).toContain("1 to 3 entries");
+  });
+
+  it("47-T1: rejects empty sweepParams array", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/lab/backtest/sweep",
+      headers: t1Headers("10.47.1.4"),
+      payload: { datasetId: "ds-1", strategyVersionId: "sv-1", sweepParams: [] },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("47-T1: sweepParams wins when both forms are provided", async () => {
+    mockStrategyVersions["sv-47-3"] = { id: "sv-47-3", strategyId: "strat-47", strategy: { workspaceId: WS_ID }, dslJson: {} };
+    mockDatasets["ds-47-3"] = { id: "ds-47-3", workspaceId: WS_ID, exchange: "bybit", symbol: "BTCUSDT", interval: "M15", fromTsMs: BigInt(0), toTsMs: BigInt(1), datasetHash: "h" };
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/lab/backtest/sweep",
+      headers: t1Headers("10.47.1.5"),
+      payload: {
+        datasetId: "ds-47-3",
+        strategyVersionId: "sv-47-3",
+        // The singular form would be 5 runs; sweepParams is the 9-run grid.
+        sweepParam: { blockId: "ignored", paramName: "x", from: 1, to: 5, step: 1 },
+        sweepParams: [
+          { blockId: "b1", paramName: "p1", from: 1, to: 3, step: 1 },
+          { blockId: "b2", paramName: "p2", from: 10, to: 30, step: 10 },
+        ],
+      },
+    });
+    expect(res.statusCode).toBe(202);
+    expect(res.json().runCount).toBe(9);
+  });
+
+  it("47-T1: rejects duplicate (blockId, paramName) inside sweepParams", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/lab/backtest/sweep",
+      headers: t1Headers("10.47.1.6"),
+      payload: {
+        datasetId: "ds-1",
+        strategyVersionId: "sv-1",
+        sweepParams: [
+          { blockId: "b1", paramName: "p1", from: 1, to: 3, step: 1 },
+          { blockId: "b1", paramName: "p1", from: 5, to: 7, step: 1 },
+        ],
+      },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().detail).toContain("duplicate");
+  });
+
+  it("47-T1: rejects cartesian product > 20", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/lab/backtest/sweep",
+      headers: t1Headers("10.47.1.7"),
+      payload: {
+        datasetId: "ds-1",
+        strategyVersionId: "sv-1",
+        // 5 × 5 = 25 → over the 20-run cap
+        sweepParams: [
+          { blockId: "b1", paramName: "p1", from: 1, to: 5, step: 1 },
+          { blockId: "b2", paramName: "p2", from: 1, to: 5, step: 1 },
+        ],
+      },
+    });
+    expect(res.statusCode).toBe(422);
+  });
 });
 
 // ── GET /lab/backtest/sweep/:id ─────────────────────────────────────────────
@@ -620,6 +750,50 @@ describe("GET /api/v1/lab/backtest/sweep/:id", () => {
     const res = await app.inject({ method: "GET", url: "/api/v1/lab/backtest/sweep/sw-1", headers: authHeaders() });
     expect(res.statusCode).toBe(200);
     expect(res.json().status).toBe("done");
+  });
+
+  it("47-T1: surfaces both sweepParam and sweepParams for a legacy single-object row", async () => {
+    mockSweeps["sw-legacy"] = {
+      id: "sw-legacy",
+      workspaceId: WS_ID,
+      status: "DONE",
+      progress: 5,
+      runCount: 5,
+      // Pre-47-T1 shape: a single object, not an array.
+      sweepParamJson: { blockId: "b1", paramName: "p1", from: 1, to: 5, step: 1 },
+      resultsJson: [],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const res = await app.inject({ method: "GET", url: "/api/v1/lab/backtest/sweep/sw-legacy", headers: authHeaders() });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.sweepParam).toMatchObject({ blockId: "b1", paramName: "p1" });
+    expect(body.sweepParams).toHaveLength(1);
+    expect(body.sweepParams[0]).toMatchObject({ blockId: "b1", paramName: "p1" });
+  });
+
+  it("47-T1: surfaces both sweepParam and sweepParams for a new array-shaped row", async () => {
+    mockSweeps["sw-array"] = {
+      id: "sw-array",
+      workspaceId: WS_ID,
+      status: "DONE",
+      progress: 6,
+      runCount: 6,
+      // 47-T1 shape: persisted array.
+      sweepParamJson: [
+        { blockId: "b1", paramName: "p1", from: 1, to: 3, step: 1 },
+        { blockId: "b2", paramName: "p2", from: 10, to: 20, step: 10 },
+      ],
+      resultsJson: [],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const res = await app.inject({ method: "GET", url: "/api/v1/lab/backtest/sweep/sw-array", headers: authHeaders() });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.sweepParams).toHaveLength(2);
+    expect(body.sweepParam).toMatchObject({ blockId: "b1" });
   });
 });
 


### PR DESCRIPTION
Реализация задачи **47-T1** из `docs/47-strategy-optimizer-plan.md`. Открывает направление «5. Strategy optimizer» из `docs/44`.

## Что сделано

### `apps/api/src/routes/lab.ts`

- `SweepParam` interface вынесен на верхний уровень (был inline в `SweepRequestBody`).
- `SweepRequestBody`:
  - `sweepParam?: SweepParam` — JSDoc `@deprecated`, остаётся как backward-compat alias.
  - `sweepParams?: SweepParam[]` — новое каноничное поле, 1..3 элемента.
- Серверная нормализация в `POST /lab/backtest/sweep`:
  - Если есть `sweepParams` → используется он; если только `sweepParam` → оборачивается в массив длиной 1; если оба — `sweepParams` побеждает (singular logged как ignored).
  - Per-element валидация: `blockId`/`paramName` non-empty; `from<to`; `step>0`; numeric; `runs ≥ 2`.
  - Уникальность `(blockId, paramName)` — duplicates rejected с 400.
  - Cartesian total `Π runs_i ≤ 20` (защитная верификация уже сейчас, чтобы persisted state был консистентен; T3 добавит реальную multi-param итерацию).
- `normalizeSweepParams(json)` — общий helper для чтения. Принимает оба формата (legacy single-object и new array), возвращает `SweepParam[]`. Не делает backfill — старые записи остаются в исходном формате.
- `runSweepAsync` теперь читает через `normalizeSweepParams(...)[0]` — линейный 1-D цикл сохранён, единичный sweep работает bit-for-bit идентично.
- `GET /lab/backtest/sweep/:id` и `GET /lab/backtest/sweeps` отдают **оба** поля: `sweepParam` (legacy first entry) + `sweepParams` (full array). Старые клиенты продолжают читать `sweepParam`, новые — `sweepParams`.

## Backward compatibility (per docs/47 §«Backward compatibility checklist»)

- ✅ Старый `SweepRequestBody.sweepParam` (singular) → принимается, оборачивается в length-1 array.
- ✅ Существующие `BacktestSweep` записи с single-object `sweepParamJson` → корректно читаются через `normalizeSweepParams`. Никаких backfill-миграций.
- ✅ `runCount`, `progress`, `bestParamValue` — без изменений для 1-param случая.
- ✅ Frontend `OptimisePanel.tsx` (до 47-T5) продолжает работать без правок: читает `paramValue`/`sweepParam` из ответа.
- ✅ **Никакой Prisma-миграции** — поле уже `Json`.
- ✅ Существующие 96 lab.test.ts тестов проходят без правок.

## Тесты (9 новых кейсов)

В `describe("POST /api/v1/lab/backtest/sweep")`:

1. **`accepts sweepParams (length 1) and persists as array`** — 202 с `runCount=5`.
2. **`accepts 2-param sweepParams within the 20-run limit (3×3 = 9)`** — 202 с `runCount=9`.
3. **`rejects sweepParams with 4 entries`** — 400, detail содержит `"1 to 3 entries"`.
4. **`rejects empty sweepParams array`** — 400.
5. **`sweepParams wins when both forms are provided`** — single-form runCount=5, array-form runCount=9; ответ возвращает 9 → array выиграл.
6. **`rejects duplicate (blockId, paramName)`** — 400, detail содержит `"duplicate"`.
7. **`rejects cartesian product > 20`** — 5×5=25 → 422.

В `describe("GET /api/v1/lab/backtest/sweep/:id")`:

8. **`legacy single-object row`** — старая запись с object-shape `sweepParamJson` отдаёт `sweepParams` length=1 + `sweepParam` echo.
9. **`array-shaped row`** — новая запись с array-shape отдаёт `sweepParams` length=2 + `sweepParam[0]`.

Каждый новый POST использует distinct `X-Forwarded-For` (`10.47.1.X`) для свежего rate-limit bucket'a — тот же паттерн, что у 46-T4 и 48-T5 тестов.

## Не входит в задачу (per docs/47 § «Не входит в задачу»)

- Multi-param mutation `applyDslSweepParams` → задача **47-T2**.
- N-D grid generation в `runSweepAsync` + `SweepRow.paramValues` → задача **47-T3**.
- Server-side `rankBy` → задача **47-T4**.
- UI multi-param строки + rank-by селектор в `OptimisePanel.tsx` → задача **47-T5**.
- Дополнительные unit-тесты + sweep golden → задача **47-T6**.

## Критерии готовности (из docs/47-T1)

- [x] `tsc --noEmit` проходит.
- [x] Существующие тесты sweep зелёные **без правок** (старая single-form работает).
- [x] Новые тесты валидации зелёные.
- [x] Миграция Prisma не требуется (поле уже `Json`).
- [x] 107 файлов / 1855 тестов (+9 vs main).

## Тест-план для ревьюера

```bash
cd apps/api
npx prisma generate
npx tsc --noEmit
npx vitest run tests/routes/lab.test.ts   # 105 lab tests
npx vitest run                            # full suite — 107 files, 1855 tests
```

Branch: `claude/47-t1-sweepparams-array` · 2 files (+287/−38) · commit `c32202f`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmfV8BXGWUJSFNGArYKe9k)_