### PR TITLE
feat(dslSweepParam): add multi-param applyDslSweepParams (47-T2)

### DIFF
--- a/apps/api/src/lib/dslSweepParam.ts
+++ b/apps/api/src/lib/dslSweepParam.ts
@@ -1,19 +1,26 @@
 /**
- * DSL sweep parameter injection utility.
+ * DSL sweep parameter injection utilities.
  *
- * Clones a compiled DSL and sets `paramName = paramValue` on every object
- * whose `nodeId` matches the sweep `blockId`.
+ * `applyDslSweepParams` clones a compiled DSL once and then walks the tree
+ * exactly once, applying every matching `{ blockId, paramName, value }` to
+ * objects whose `nodeId` matches. The same nodeId may appear in multiple
+ * locations (e.g. `entry.signal.fast` AND `entry.indicators[]`), so every
+ * occurrence is patched.
  *
- * Compiled DSL blocks carry a `nodeId` field (from the graph compiler) that
- * corresponds to the sweep's `blockId`.  The same nodeId may appear in
- * multiple locations (e.g. entry.signal.fast AND entry.indicators[]), so we
- * walk the entire tree and patch every occurrence.
+ * `applyDslSweepParam` is a thin single-param wrapper preserved for
+ * backward compatibility — existing call sites keep working unchanged.
+ *
+ * Determinism:
+ *   - Order of application = order of `params` array. If two entries
+ *     target the same `(blockId, paramName)`, the LAST one wins. The HTTP
+ *     layer (47-T1) rejects duplicate (blockId, paramName) tuples up front,
+ *     so this is only a defensive contract.
+ *   - The input DSL is never mutated; `structuredClone` produces a deep
+ *     copy, then patches happen in place on the clone.
  */
-export function applyDslSweepParam(
+export function applyDslSweepParams(
   dsl: Record<string, unknown>,
-  blockId: string,
-  paramName: string,
-  paramValue: number,
+  params: Array<{ blockId: string; paramName: string; value: number }>,
 ): Record<string, unknown> {
   const cloned = structuredClone(dsl);
 
@@ -24,12 +31,30 @@ export function applyDslSweepParam(
       return;
     }
     const rec = obj as Record<string, unknown>;
-    if (rec.nodeId === blockId && paramName in rec) {
-      rec[paramName] = paramValue;
+    // Apply every matching param at this node before recursing. Iteration
+    // order matches `params` so duplicates resolve last-wins.
+    for (const p of params) {
+      if (rec.nodeId === p.blockId && p.paramName in rec) {
+        rec[p.paramName] = p.value;
+      }
     }
     for (const val of Object.values(rec)) walk(val);
   }
 
   walk(cloned);
   return cloned;
+}
+
+/**
+ * Single-parameter sweep mutation. Equivalent to
+ * `applyDslSweepParams(dsl, [{ blockId, paramName, value: paramValue }])`.
+ * Retained as the legacy entry point so existing callers keep working.
+ */
+export function applyDslSweepParam(
+  dsl: Record<string, unknown>,
+  blockId: string,
+  paramName: string,
+  paramValue: number,
+): Record<string, unknown> {
+  return applyDslSweepParams(dsl, [{ blockId, paramName, value: paramValue }]);
 }

--- a/apps/api/tests/lib/applyDslSweepParam.test.ts
+++ b/apps/api/tests/lib/applyDslSweepParam.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { applyDslSweepParam } from "../../src/lib/dslSweepParam.js";
+import { applyDslSweepParam, applyDslSweepParams } from "../../src/lib/dslSweepParam.js";
 
 describe("applyDslSweepParam", () => {
   it("patches the matching nodeId block with the new param value", () => {
@@ -103,5 +103,136 @@ describe("applyDslSweepParam", () => {
     const indicators = entry.indicators as Record<string, unknown>[];
     expect(indicators[0].multiplier).toBe(2.5);
     expect(indicators[0].atrPeriod).toBe(10); // unchanged
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 47-T2: multi-parameter mutation
+// ---------------------------------------------------------------------------
+
+describe("applyDslSweepParams (47-T2)", () => {
+  it("with one entry produces the same result as applyDslSweepParam", () => {
+    const dsl = {
+      entry: {
+        signal: {
+          fast: { blockType: "SMA", nodeId: "n2", length: 10 },
+          slow: { blockType: "SMA", nodeId: "n3", length: 20 },
+        },
+      },
+    };
+
+    const single = applyDslSweepParam(dsl, "n2", "length", 15);
+    const multi = applyDslSweepParams(dsl, [{ blockId: "n2", paramName: "length", value: 15 }]);
+
+    expect(multi).toEqual(single);
+  });
+
+  it("patches two parameters in different blocks", () => {
+    const dsl = {
+      entry: {
+        signal: {
+          fast: { blockType: "SMA", nodeId: "n2", length: 10 },
+          slow: { blockType: "SMA", nodeId: "n3", length: 20 },
+        },
+      },
+    };
+
+    const result = applyDslSweepParams(dsl, [
+      { blockId: "n2", paramName: "length", value: 5 },
+      { blockId: "n3", paramName: "length", value: 30 },
+    ]);
+
+    const fast = (result.entry as { signal: { fast: { length: number } } }).signal.fast;
+    const slow = (result.entry as { signal: { slow: { length: number } } }).signal.slow;
+    expect(fast.length).toBe(5);
+    expect(slow.length).toBe(30);
+  });
+
+  it("patches two distinct paramNames on the same block", () => {
+    const dsl = {
+      entry: {
+        indicators: [
+          { type: "supertrend", nodeId: "n7", atrPeriod: 10, multiplier: 3 },
+        ],
+      },
+    };
+
+    const result = applyDslSweepParams(dsl, [
+      { blockId: "n7", paramName: "atrPeriod", value: 14 },
+      { blockId: "n7", paramName: "multiplier", value: 2.5 },
+    ]);
+
+    const ind = (result.entry as { indicators: Array<Record<string, number>> }).indicators[0];
+    expect(ind.atrPeriod).toBe(14);
+    expect(ind.multiplier).toBe(2.5);
+  });
+
+  it("last entry wins when two entries target the same (blockId, paramName)", () => {
+    const dsl = {
+      entry: {
+        signal: { fast: { blockType: "SMA", nodeId: "n2", length: 10 } },
+      },
+    };
+
+    const result = applyDslSweepParams(dsl, [
+      { blockId: "n2", paramName: "length", value: 5 },
+      { blockId: "n2", paramName: "length", value: 8 },
+    ]);
+
+    const fast = (result.entry as { signal: { fast: { length: number } } }).signal.fast;
+    expect(fast.length).toBe(8);
+  });
+
+  it("silently skips a non-existent blockId (matches single-param behavior)", () => {
+    const dsl = {
+      entry: {
+        signal: { fast: { blockType: "SMA", nodeId: "n2", length: 10 } },
+      },
+    };
+
+    expect(() =>
+      applyDslSweepParams(dsl, [
+        { blockId: "n2", paramName: "length", value: 5 },
+        { blockId: "n-missing", paramName: "length", value: 99 },
+      ]),
+    ).not.toThrow();
+
+    const result = applyDslSweepParams(dsl, [
+      { blockId: "n2", paramName: "length", value: 5 },
+      { blockId: "n-missing", paramName: "length", value: 99 },
+    ]);
+    const fast = (result.entry as { signal: { fast: { length: number } } }).signal.fast;
+    expect(fast.length).toBe(5);
+  });
+
+  it("does not mutate the input DSL", () => {
+    const dsl = {
+      entry: {
+        signal: {
+          fast: { blockType: "SMA", nodeId: "n2", length: 10 },
+          slow: { blockType: "SMA", nodeId: "n3", length: 20 },
+        },
+      },
+    };
+    const before = JSON.parse(JSON.stringify(dsl));
+
+    applyDslSweepParams(dsl, [
+      { blockId: "n2", paramName: "length", value: 99 },
+      { blockId: "n3", paramName: "length", value: 99 },
+    ]);
+
+    expect(dsl).toEqual(before);
+  });
+
+  it("handles an empty params array as identity (returns a deep clone)", () => {
+    const dsl = {
+      entry: {
+        signal: { fast: { blockType: "SMA", nodeId: "n2", length: 10 } },
+      },
+    };
+    const result = applyDslSweepParams(dsl, []);
+    expect(result).toEqual(dsl);
+    // Still a clone, not the same reference.
+    expect(result).not.toBe(dsl);
   });
 });


### PR DESCRIPTION
Реализация задачи **47-T2** из `docs/47-strategy-optimizer-plan.md`. Продолжение направления «Strategy optimizer» после 47-T1 (#314).

## Что сделано

### `apps/api/src/lib/dslSweepParam.ts`

Файл реорганизован под **multi-param primitive + single-param wrapper**:

```ts
applyDslSweepParams(dsl, params: Array<{ blockId, paramName, value }>): DslJson
applyDslSweepParam(dsl, blockId, paramName, value): DslJson  // legacy alias
```

- `applyDslSweepParams` делает **один** `structuredClone` и **один** обход дерева, применяя на каждом совпадающем узле ВСЕ matching params. Это O(N) регардлесс от `params.length` — дешевле, чем вызывать singular в цикле (который делал бы N клонов + N обходов).
- `applyDslSweepParam` стал тонкой обёрткой `applyDslSweepParams(dsl, [{ blockId, paramName, value: paramValue }])`. Сигнатура и поведение **идентичны** существующему — все 5 legacy-тестов проходят без правок.

### Семантика

- **Order of application** = order of `params` array. При дубликате `(blockId, paramName)` LAST wins.
- HTTP-слой (47-T1) уже отклоняет duplicate tuples → defensive contract на уровне функции.
- **Empty `params`** → identity (deep clone без модификаций).
- **Non-existent blockId** → silently skipped (mirrors singular behavior; T2 explicitly preserved this — plan §2 говорит «Если блок не найден ... выбросить ту же ошибку, что и в одиночной версии», а одиночная не бросает).
- **Input DSL** никогда не мутируется (verified by deep-equality test).

## Тесты (12 = 5 legacy + 7 новых T2)

В `applyDslSweepParam.test.ts`:

**Legacy (без правок, всё ещё зелёные):**
- patches matching nodeId
- does not mutate original
- nonexistent blockId → no-op
- nested exit block params
- different param names

**Новые T2 (`describe("applyDslSweepParams (47-T2)")`):**
1. **single-entry call equivalence** — `applyDslSweepParams(dsl, [one])` равен `applyDslSweepParam(dsl, ...)`.
2. **2 params, different blocks** — оба узла мутированы.
3. **2 params, same block, different paramNames** — оба применены.
4. **last-wins semantics** — duplicate `(n2, "length")` с разными values → последний выигрывает.
5. **non-existent blockId** — не throws; остальные params применяются.
6. **Input не мутируется** (deep equality before/after).
7. **Empty `params` array** — identity (deep clone, не same reference).

## Backward compatibility

- ✅ Все 5 legacy `applyDslSweepParam` тестов — без правок и зелёные.
- ✅ Все импортёры `applyDslSweepParam` (включая `routes/lab.ts:runSweepAsync`) работают без изменений.
- ✅ Никаких миграций.

## Не входит в задачу (per docs/47 § «Не входит в задачу»)

- N-D grid generation в `runSweepAsync` (использование `applyDslSweepParams` для multi-param iteration) → задача **47-T3**.
- Server-side `rankBy` → задача **47-T4**.
- UI multi-param → задача **47-T5**.

## Критерии готовности (из docs/47-T2)

- [x] `tsc --noEmit` проходит.
- [x] Все существующие импортёры `applyDslSweepParam` работают без изменений.
- [x] `applyDslSweepParams` экспортируется из `dslSweepParam.ts`.
- [x] Покрытие тестами включает single-param, multi-param и ошибочные сценарии (107 файлов / 1862 теста, +7 vs T1).

## Тест-план для ревьюера

```bash
cd apps/api
npx prisma generate
npx tsc --noEmit
npx vitest run tests/lib/applyDslSweepParam.test.ts   # 12 tests
npx vitest run                                        # full suite — 107 files, 1862 tests
```

Branch: `claude/47-t2-multi-param-mutation` · 2 files (+170/−14) · commit `5814cd1`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmfV8BXGWUJSFNGArYKe9k)_