### PR TITLE
feat(lab): server-side rankBy for sweep best-row selection (47-T4)

### DIFF
--- a/apps/api/prisma/migrations/20260428200000_add_sweep_rankby_bestparams/migration.sql
+++ b/apps/api/prisma/migrations/20260428200000_add_sweep_rankby_bestparams/migration.sql
@@ -1,0 +1,9 @@
+-- 47-T4: server-side rankBy for sweep best-row selection.
+-- Additive: two new columns on BacktestSweep, both with safe defaults
+-- so existing rows interpret as the legacy "rank by pnlPct" behavior.
+
+-- Audit / replay echo for which metric chose the best row.
+ALTER TABLE "BacktestSweep" ADD COLUMN "rankBy" TEXT NOT NULL DEFAULT 'pnlPct';
+
+-- Multi-param best-row values: Record<`${blockId}.${paramName}`, number>.
+ALTER TABLE "BacktestSweep" ADD COLUMN "bestParamValuesJson" JSONB;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -696,12 +696,21 @@ model BacktestSweep {
   /// Fill price reference; persisted per sweep so each run replays with the
   /// same execution model (docs/46-T4). Existing rows default to "CLOSE".
   fillAt            String      @default("CLOSE")
+  /// Metric used to choose the best row (47-T4). One of pnlPct, winRate,
+  /// sharpe, profitFactor, expectancy. Existing rows default to "pnlPct".
+  rankBy            String      @default("pnlPct")
   status            SweepStatus @default(PENDING)
   progress          Int         @default(0)
   runCount          Int
   /// SweepRow[] — filled progressively as runs complete
   resultsJson       Json?
+  /// Legacy single-param best-row value (the FIRST param's value for
+  /// multi-param sweeps; multi-param-aware clients should read
+  /// bestParamValuesJson instead).
   bestParamValue    Float?
+  /// Multi-param best-row values (47-T4). Record<string, number> with key
+  /// = `${blockId}.${paramName}`. Null until the run completes.
+  bestParamValuesJson Json?
   createdAt         DateTime    @default(now())
   updatedAt         DateTime    @updatedAt
 

--- a/apps/api/src/routes/lab.ts
+++ b/apps/api/src/routes/lab.ts
@@ -896,6 +896,7 @@ export async function labRoutes(app: FastifyInstance) {
       feeBps = 0,
       slippageBps = 0,
       fillAt = "CLOSE",
+      rankBy = "pnlPct",
     } = request.body ?? {};
 
     // ── 47-T1 normalization ────────────────────────────────────────────
@@ -921,6 +922,9 @@ export async function labRoutes(app: FastifyInstance) {
     }
     if (!ALLOWED_FILL_AT.includes(fillAt as FillAt)) {
       return problem(reply, 400, "Validation Error", `fillAt must be one of: ${ALLOWED_FILL_AT.join(", ")}`);
+    }
+    if (!ALLOWED_RANK_BY.includes(rankBy as RankBy)) {
+      return problem(reply, 400, "Validation Error", `rankBy must be one of: ${ALLOWED_RANK_BY.join(", ")}`);
     }
     if (sweepParams.length < 1 || sweepParams.length > 3) {
       return problem(reply, 400, "Validation Error", "sweepParams must contain 1 to 3 entries");
@@ -1007,6 +1011,7 @@ export async function labRoutes(app: FastifyInstance) {
         feeBps,
         slippageBps,
         fillAt,
+        rankBy,
         runCount,
         status: "PENDING",
       },
@@ -1033,8 +1038,12 @@ export async function labRoutes(app: FastifyInstance) {
     }
 
     const results = (sweep.resultsJson as SweepRow[] | null) ?? [];
+    const rankBy = (sweep.rankBy ?? "pnlPct") as RankBy;
     const bestRow = results.length > 0
-      ? results.reduce((best, r) => r.pnlPct > best.pnlPct ? r : best, results[0])
+      ? results.reduce(
+          (best, r) => (compareByMetric(r, best, rankBy) > 0 ? r : best),
+          results[0],
+        )
       : undefined;
 
     // 47-T1: surface both shapes. Old clients keep reading `sweepParam`;
@@ -1048,6 +1057,9 @@ export async function labRoutes(app: FastifyInstance) {
       runCount: sweep.runCount,
       sweepParam: sweepParamsArr[0],
       sweepParams: sweepParamsArr,
+      rankBy,
+      bestParamValue: sweep.bestParamValue,
+      bestParamValuesJson: sweep.bestParamValuesJson,
       results,
       bestRow,
       createdAt: sweep.createdAt.toISOString(),
@@ -1502,6 +1514,10 @@ interface SweepParam {
   step: number;
 }
 
+/** Metrics by which the sweep best-row can be selected (47-T4). */
+const ALLOWED_RANK_BY = ["pnlPct", "winRate", "sharpe", "profitFactor", "expectancy"] as const;
+type RankBy = typeof ALLOWED_RANK_BY[number];
+
 interface SweepRequestBody {
   datasetId: string;
   strategyVersionId: string;
@@ -1515,6 +1531,8 @@ interface SweepRequestBody {
   feeBps?: number;
   slippageBps?: number;
   fillAt?: FillAt;
+  /** Metric by which the best row is chosen (47-T4). Default "pnlPct". */
+  rankBy?: RankBy;
 }
 
 /**
@@ -1525,6 +1543,41 @@ interface SweepRequestBody {
 function normalizeSweepParams(json: unknown): SweepParam[] {
   if (Array.isArray(json)) return json as SweepParam[];
   return [json as SweepParam];
+}
+
+/**
+ * Compare two SweepRow values by the configured rankBy metric (47-T4).
+ * Returns positive when `a` is strictly better than `b`, negative when
+ * worse, 0 on a true tie.
+ *
+ *   pnlPct, winRate, sharpe, expectancy: bigger is better; null is the
+ *     worst possible value (treated as -Infinity).
+ *   profitFactor: bigger is better; +Infinity (no losses) sorts above any
+ *     finite value; -Infinity (impossible) below.
+ *
+ * Callers use a strict `>` left-fold so the FIRST row in lexicographic
+ * order wins on a tie — deterministic per docs/44 §Детерминизм.
+ */
+function metricValue(row: { pnlPct: number; winRate: number; sharpe: number | null; profitFactor: number | null; expectancy: number | null }, metric: RankBy): number {
+  switch (metric) {
+    case "pnlPct":     return row.pnlPct;
+    case "winRate":    return row.winRate;
+    case "sharpe":     return row.sharpe ?? Number.NEGATIVE_INFINITY;
+    case "profitFactor": return row.profitFactor ?? Number.NEGATIVE_INFINITY;
+    case "expectancy": return row.expectancy ?? Number.NEGATIVE_INFINITY;
+  }
+}
+
+function compareByMetric(
+  a: { pnlPct: number; winRate: number; sharpe: number | null; profitFactor: number | null; expectancy: number | null },
+  b: { pnlPct: number; winRate: number; sharpe: number | null; profitFactor: number | null; expectancy: number | null },
+  metric: RankBy,
+): number {
+  const av = metricValue(a, metric);
+  const bv = metricValue(b, metric);
+  if (av > bv) return 1;
+  if (av < bv) return -1;
+  return 0;
 }
 
 interface SweepRow {
@@ -1713,8 +1766,16 @@ async function runSweepAsync(sweepId: string): Promise<void> {
       });
     }
 
-    // Find best param value by PnL
-    const bestRow = results.reduce((best, r) => r.pnlPct > best.pnlPct ? r : best, results[0]);
+    // 47-T4: pick best row by the chosen metric. Tie-break: smaller index
+    // wins. results[] is already in lex order (47-T3), so a left-fold with
+    // strict `>` naturally preserves "first wins on a tie" semantics.
+    const rankByValue = (sweep.rankBy ?? "pnlPct") as RankBy;
+    const bestRow = results.length > 0
+      ? results.reduce(
+          (best, r) => (compareByMetric(r, best, rankByValue) > 0 ? r : best),
+          results[0],
+        )
+      : undefined;
 
     await prisma.backtestSweep.update({
       where: { id: sweepId },
@@ -1723,6 +1784,7 @@ async function runSweepAsync(sweepId: string): Promise<void> {
         progress: results.length,
         resultsJson: results as unknown as object[],
         bestParamValue: bestRow?.paramValue ?? null,
+        bestParamValuesJson: (bestRow?.paramValues ?? null) as unknown as object,
       },
     });
   } catch (err: unknown) {

--- a/apps/api/tests/routes/lab.test.ts
+++ b/apps/api/tests/routes/lab.test.ts
@@ -741,6 +741,83 @@ describe("POST /api/v1/lab/backtest/sweep", () => {
     expect(res.statusCode).toBe(422);
   });
 
+  // 47-T4: rankBy validation + persistence.
+  it("47-T4: rejects unknown rankBy", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/lab/backtest/sweep",
+      headers: t1Headers("10.47.4.1"),
+      payload: {
+        datasetId: "ds-1",
+        strategyVersionId: "sv-1",
+        sweepParam: { blockId: "b1", paramName: "p1", from: 1, to: 5, step: 1 },
+        rankBy: "BOGUS",
+      },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().detail).toContain("rankBy");
+  });
+
+  it("47-T4: accepts rankBy=sharpe (and persists it)", async () => {
+    mockStrategyVersions["sv-47-4-sharpe"] = {
+      id: "sv-47-4-sharpe", strategyId: "strat-47-4", strategy: { workspaceId: WS_ID }, dslJson: {},
+    };
+    mockDatasets["ds-47-4-sharpe"] = {
+      id: "ds-47-4-sharpe", workspaceId: WS_ID, exchange: "bybit", symbol: "BTCUSDT",
+      interval: "M15", fromTsMs: BigInt(0), toTsMs: BigInt(1), datasetHash: "h",
+    };
+    const post = await app.inject({
+      method: "POST",
+      url: "/api/v1/lab/backtest/sweep",
+      headers: t1Headers("10.47.4.2"),
+      payload: {
+        datasetId: "ds-47-4-sharpe",
+        strategyVersionId: "sv-47-4-sharpe",
+        sweepParam: { blockId: "b1", paramName: "p1", from: 1, to: 3, step: 1 },
+        rankBy: "sharpe",
+      },
+    });
+    expect(post.statusCode).toBe(202);
+    const { sweepId } = post.json();
+    // Wait for async runner to settle.
+    for (let i = 0; i < 30; i++) {
+      const cur = mockSweeps[sweepId] as Record<string, unknown> | undefined;
+      if (cur && (cur.status === "DONE" || cur.status === "FAILED")) break;
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    const final = mockSweeps[sweepId] as Record<string, unknown>;
+    expect(final.rankBy).toBe("sharpe");
+  });
+
+  it("47-T4: defaults rankBy to pnlPct when omitted", async () => {
+    mockStrategyVersions["sv-47-4-default"] = {
+      id: "sv-47-4-default", strategyId: "strat-47-4", strategy: { workspaceId: WS_ID }, dslJson: {},
+    };
+    mockDatasets["ds-47-4-default"] = {
+      id: "ds-47-4-default", workspaceId: WS_ID, exchange: "bybit", symbol: "BTCUSDT",
+      interval: "M15", fromTsMs: BigInt(0), toTsMs: BigInt(1), datasetHash: "h",
+    };
+    const post = await app.inject({
+      method: "POST",
+      url: "/api/v1/lab/backtest/sweep",
+      headers: t1Headers("10.47.4.3"),
+      payload: {
+        datasetId: "ds-47-4-default",
+        strategyVersionId: "sv-47-4-default",
+        sweepParam: { blockId: "b1", paramName: "p1", from: 1, to: 3, step: 1 },
+      },
+    });
+    expect(post.statusCode).toBe(202);
+    const { sweepId } = post.json();
+    for (let i = 0; i < 30; i++) {
+      const cur = mockSweeps[sweepId] as Record<string, unknown> | undefined;
+      if (cur && (cur.status === "DONE" || cur.status === "FAILED")) break;
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    const final = mockSweeps[sweepId] as Record<string, unknown>;
+    expect(final.rankBy).toBe("pnlPct");
+  });
+
   // 47-T3: 2-param sweep happy path — 3×3 = 9 combinations, returned with
   // both `paramValue` (legacy) and `paramValues` (multi-param). The test
   // hits the live runSweepAsync with mocked Prisma + a small candle set.
@@ -817,6 +894,62 @@ describe("GET /api/v1/lab/backtest/sweep/:id", () => {
     const res = await app.inject({ method: "GET", url: "/api/v1/lab/backtest/sweep/sw-1", headers: authHeaders() });
     expect(res.statusCode).toBe(200);
     expect(res.json().status).toBe("done");
+  });
+
+  it("47-T4: GET returns rankBy + bestParamValuesJson echo", async () => {
+    mockSweeps["sw-47-4"] = {
+      id: "sw-47-4",
+      workspaceId: WS_ID,
+      status: "DONE",
+      progress: 3,
+      runCount: 3,
+      sweepParamJson: [{ blockId: "b1", paramName: "p1", from: 1, to: 3, step: 1 }],
+      rankBy: "sharpe",
+      bestParamValue: 2,
+      bestParamValuesJson: { "b1.p1": 2 },
+      resultsJson: [
+        { paramValue: 1, paramValues: { "b1.p1": 1 }, backtestResultId: "bt-a", pnlPct: 5,  winRate: 0.5, maxDrawdownPct: 1, tradeCount: 4, sharpe: 0.5, profitFactor: 1.2, expectancy: 0.1 },
+        { paramValue: 2, paramValues: { "b1.p1": 2 }, backtestResultId: "bt-b", pnlPct: 3,  winRate: 0.6, maxDrawdownPct: 1, tradeCount: 4, sharpe: 1.5, profitFactor: 1.0, expectancy: 0.2 },
+        { paramValue: 3, paramValues: { "b1.p1": 3 }, backtestResultId: "bt-c", pnlPct: 8,  winRate: 0.4, maxDrawdownPct: 1, tradeCount: 4, sharpe: 0.9, profitFactor: 1.5, expectancy: 0.3 },
+      ],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const res = await app.inject({ method: "GET", url: "/api/v1/lab/backtest/sweep/sw-47-4", headers: authHeaders() });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.rankBy).toBe("sharpe");
+    expect(body.bestParamValue).toBe(2);
+    expect(body.bestParamValuesJson).toMatchObject({ "b1.p1": 2 });
+    // The bestRow recomputed in-memory by sharpe descends to row 2 (sharpe 1.5),
+    // not row 3 (highest pnlPct).
+    expect(body.bestRow.sharpe).toBe(1.5);
+    expect(body.bestRow.paramValues["b1.p1"]).toBe(2);
+  });
+
+  it("47-T4: legacy sweep with no rankBy column → bestRow falls back to pnlPct", async () => {
+    mockSweeps["sw-47-4-legacy"] = {
+      id: "sw-47-4-legacy",
+      workspaceId: WS_ID,
+      status: "DONE",
+      progress: 3,
+      runCount: 3,
+      sweepParamJson: { blockId: "b1", paramName: "p1", from: 1, to: 3, step: 1 },
+      // rankBy column absent — pre-47-T4 row.
+      resultsJson: [
+        { paramValue: 1, backtestResultId: "bt-a", pnlPct: 5,  winRate: 0.5, maxDrawdownPct: 1, tradeCount: 4, sharpe: 0.5, profitFactor: 1.2, expectancy: 0.1 },
+        { paramValue: 2, backtestResultId: "bt-b", pnlPct: 3,  winRate: 0.6, maxDrawdownPct: 1, tradeCount: 4, sharpe: 1.5, profitFactor: 1.0, expectancy: 0.2 },
+        { paramValue: 3, backtestResultId: "bt-c", pnlPct: 8,  winRate: 0.4, maxDrawdownPct: 1, tradeCount: 4, sharpe: 0.9, profitFactor: 1.5, expectancy: 0.3 },
+      ],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const res = await app.inject({ method: "GET", url: "/api/v1/lab/backtest/sweep/sw-47-4-legacy", headers: authHeaders() });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.rankBy).toBe("pnlPct");
+    // BestRow by pnlPct → row 3.
+    expect(body.bestRow.pnlPct).toBe(8);
   });
 
   it("47-T1: surfaces both sweepParam and sweepParams for a legacy single-object row", async () => {


### PR DESCRIPTION
Реализация задачи **47-T4** из `docs/47-strategy-optimizer-plan.md`. Продолжение направления «Strategy optimizer» после 47-T1 (#314) → 47-T2 (#315) → 47-T3 (#316).

## Что сделано

### Server-side `rankBy`

- `ALLOWED_RANK_BY = ["pnlPct", "winRate", "sharpe", "profitFactor", "expectancy"]` — 5 метрик, все доступны прямо из `DslBacktestReport` после docs/49-T2 (#304).
- `SweepRequestBody.rankBy?: RankBy` — default `"pnlPct"` сохраняет существующий контракт.
- Server-side валидация против enum → 400 при unknown.
- `compareByMetric(a, b, rankBy)` helper:
  - `pnlPct`/`winRate`/`sharpe`/`expectancy` — bigger = better.
  - `profitFactor` — bigger = better; `+Infinity` (нет losses) sorts above any finite.
  - `null` → `-Infinity` (отсутствующая метрика никогда не выигрывает на tie).
- **Tie-break** per `docs/44 §Детерминизм`: `results[]` уже в lex-order (47-T3), strict `>` left-fold даёт «first-wins-on-tie» автоматически.
- `runSweepAsync` после прохода всех combinations выбирает best row через `compareByMetric` и persistит:
  - `bestParamValue` — legacy single value (= первый param выигрышной комбинации).
  - `bestParamValuesJson` — multi-param Record для новых клиентов.
- `GET /lab/backtest/sweep/:id` возвращает `rankBy` + `bestParamValuesJson` echo + **recomputed** `bestRow` через `compareByMetric` (legacy записи без `rankBy` колонки фоллбэчат на `pnlPct`).

### Prisma — additive миграция

`20260428200000_add_sweep_rankby_bestparams/migration.sql`:

```sql
ALTER TABLE "BacktestSweep" ADD COLUMN "rankBy" TEXT NOT NULL DEFAULT 'pnlPct';
ALTER TABLE "BacktestSweep" ADD COLUMN "bestParamValuesJson" JSONB;
```

- `rankBy` имеет safe default — старые записи интерпретируются как «rank by pnlPct».
- `bestParamValuesJson` nullable — старые записи остаются с `null`.

## Backward compatibility (per docs/47 §«Backward compatibility checklist»)

- ✅ Default `rankBy="pnlPct"` → bit-for-bit идентично pre-47-T4 поведению.
- ✅ `bestParamValue` для 1-param sweep с `rankBy="pnlPct"` совпадает со старым полем.
- ✅ Legacy записи без `rankBy` колонки → GET fallback'ит на `"pnlPct"`, recomputed bestRow корректен.
- ✅ Существующие 106 lab.test.ts тестов проходят без правок.
- ✅ docs/49-T2 закрыт → все 5 метрик действуют (никаких 400 для sharpe/PF/expectancy, гэйтинг из плана не нужен).

## Тесты (5 новых)

В `describe("POST /api/v1/lab/backtest/sweep")`:

1. **`rejects unknown rankBy`** → 400 с `detail: "rankBy"`.
2. **`accepts rankBy=sharpe and persists it`** — POST → polling → `mockSweeps[id].rankBy === "sharpe"`.
3. **`defaults rankBy to pnlPct when omitted`** — без поля → persisted `"pnlPct"`.

В `describe("GET /api/v1/lab/backtest/sweep/:id")`:

4. **`GET returns rankBy + bestParamValuesJson echo`** — фикстура с 3 row'ами; `rankBy="sharpe"` выбирает row 2 (`sharpe=1.5`), не row 3 (`pnl=8`).
5. **`legacy sweep with no rankBy column → bestRow falls back to pnlPct`** — фикстура без `rankBy` поля; `bestRow.pnlPct === 8` (выбран по дефолтной метрике).

Каждый POST использует distinct `X-Forwarded-For` (`10.47.4.X`) для свежего rate-limit bucket'а.

## Не входит в задачу

- UI multi-param + rank-by селектор → задача **47-T5**.
- Дополнительные unit-тесты + sweep golden → задача **47-T6**.

## Критерии готовности (из docs/47-T4)

- [x] `tsc --noEmit` проходит.
- [x] Default-поведение идентично текущему — старые клиенты не сломаны.
- [x] `bestParamValue` для 1-param случая совпадает со старым полем при `rankBy="pnlPct"`.
- [x] 400 для unknown rankBy с понятным сообщением.
- [x] **Все 5 метрик** доступны (docs/49-T2 закрыт; гэйтинг из плана не применяется).
- [x] 108 файлов / 1876 тестов (+5 vs T3).

## Тест-план для ревьюера

```bash
cd apps/api
npx prisma generate
npx prisma migrate deploy   # adds rankBy + bestParamValuesJson columns
npx tsc --noEmit
npx vitest run tests/routes/lab.test.ts   # 111 lab tests
npx vitest run                            # full suite — 108 files, 1876 tests
```

Branch: `claude/47-t4-rankby` · 4 files (+216/−3) · commit `e54e9a9`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmfV8BXGWUJSFNGArYKe9k)_