### PR TITLE
feat(lab-ui): multi-param sweep rows + dynamic param columns (47-T5)

### DIFF
--- a/apps/web/src/app/lab/test/OptimisePanel.tsx
+++ b/apps/web/src/app/lab/test/OptimisePanel.tsx
@@ -25,6 +25,9 @@ interface SweepParam {
 
 interface SweepRow {
   paramValue: number;
+  /** 47-T3 multi-param values keyed by `${blockId}.${paramName}`. Optional —
+   *  legacy server responses (pre-47-T3) carry only `paramValue`. */
+  paramValues?: Record<string, number>;
   backtestResultId: string;
   pnlPct: number;
   winRate: number;
@@ -38,6 +41,12 @@ interface SweepResult {
   status: "pending" | "running" | "done" | "failed";
   progress: number;
   runCount: number;
+  /** 47-T1 multi-param echo. Old servers return only `sweepParam` (singular). */
+  sweepParams?: SweepParam[];
+  sweepParam?: SweepParam;
+  rankBy?: RankBy;
+  bestParamValue?: number | null;
+  bestParamValuesJson?: Record<string, number> | null;
   results: SweepRow[];
   bestRow?: SweepRow;
   createdAt: string;
@@ -64,10 +73,33 @@ interface StrategyVersionItem {
   strategy: { id: string; name: string; symbol: string };
 }
 
-type SortKey = "paramValue" | "pnlPct" | "winRate" | "maxDrawdownPct" | "tradeCount" | "sharpe";
+// 47-T5: SortKey is a union of fixed metric columns plus dynamic
+// `param:${blockId}.${paramName}` entries (one per sweep param) and the
+// legacy `paramValue` literal used when the server response predates 47-T3.
+type FixedSortKey = "pnlPct" | "winRate" | "maxDrawdownPct" | "tradeCount" | "sharpe";
+type ParamSortKey = `param:${string}`;
+type SortKey = FixedSortKey | ParamSortKey | "paramValue";
 type SortDir = "asc" | "desc";
 
 type OptimiseMetric = "pnl" | "winRate" | "sharpe" | "maxDrawdown";
+
+/** Server-side rankBy values accepted by POST /lab/backtest/sweep (47-T4). */
+type RankBy = "pnlPct" | "winRate" | "sharpe" | "profitFactor" | "expectancy";
+
+/** Map UI `OptimiseMetric` to the server `rankBy` parameter. Missing entries
+ *  signal "client-side sort only" — the server keeps its `pnlPct` default. */
+const METRIC_TO_RANK_BY: Partial<Record<OptimiseMetric, RankBy>> = {
+  pnl: "pnlPct",
+  sharpe: "sharpe",
+};
+
+interface SweepParamForm {
+  blockId: string;
+  paramName: string;
+  from: number;
+  to: number;
+  step: number;
+}
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -75,6 +107,7 @@ type OptimiseMetric = "pnl" | "winRate" | "sharpe" | "maxDrawdown";
 
 const POLL_INTERVAL_MS = 2000;
 const MAX_RUNS = 20;
+const MAX_PARAMS = 3;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -112,14 +145,13 @@ export default function OptimisePanel({
   const readyDatasets = datasets.filter((d) => d.status === "READY" || d.status === "PARTIAL");
   const [datasetId, setDatasetId] = useState(activeDatasetId ?? readyDatasets[0]?.datasetId ?? "");
   const [versionId, setVersionId] = useState(lastCompileVersionId ?? strategyVersions[0]?.id ?? "");
-  const [selectedBlockId, setSelectedBlockId] = useState("");
-  const [selectedParamName, setSelectedParamName] = useState("");
-  const [rangeFrom, setRangeFrom] = useState(5);
-  const [rangeTo, setRangeTo] = useState(50);
-  const [rangeStep, setRangeStep] = useState(5);
+  // 47-T5: multi-param grid state. `sweepParams.length` ∈ [1, MAX_PARAMS].
+  const [sweepParams, setSweepParams] = useState<SweepParamForm[]>([
+    { blockId: "", paramName: "", from: 5, to: 50, step: 5 },
+  ]);
   const [feeBps, setFeeBps] = useState(10);
   const [slippageBps, setSlippageBps] = useState(5);
-  const [_metric, setMetric] = useState<OptimiseMetric>("pnl");
+  const [metric, setMetric] = useState<OptimiseMetric>("pnl");
 
   // ── Sweep state ─────────────────────────────────────────────────────────
   const [submitting, setSubmitting] = useState(false);
@@ -153,31 +185,58 @@ export default function OptimisePanel({
   // Nodes with numeric params (blocks user can sweep)
   const sweepableNodes = nodes.filter((n) => getNumericParams(n).length > 0);
 
-  // Params for selected block
-  const selectedNode = sweepableNodes.find((n) => n.id === selectedBlockId);
-  const numericParams = selectedNode ? getNumericParams(selectedNode) : [];
+  // Numeric params for a given block id (helper used per row)
+  const numericParamsFor = useCallback((blockId: string) => {
+    const node = sweepableNodes.find((n) => n.id === blockId);
+    return node ? getNumericParams(node) : [];
+  }, [sweepableNodes]);
 
-  // Auto-select first block/param
+  // Auto-fill the first row when sweepable blocks become available.
   useEffect(() => {
-    if (!selectedBlockId && sweepableNodes.length > 0) {
-      setSelectedBlockId(sweepableNodes[0].id);
-    }
+    if (sweepableNodes.length === 0) return;
+    setSweepParams((prev) => {
+      const first = prev[0];
+      if (first.blockId && first.paramName) return prev;
+      const node = sweepableNodes[0];
+      const param = getNumericParams(node)[0];
+      if (!param) return prev;
+      return prev.map((p, i) => i === 0 ? { ...p, blockId: node.id, paramName: param.id } : p);
+    });
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sweepableNodes.length]);
 
+  // Keep paramName valid when the row's block changes or its block is removed.
   useEffect(() => {
-    if (numericParams.length > 0 && !numericParams.find((p) => p.id === selectedParamName)) {
-      setSelectedParamName(numericParams[0].id);
-    }
+    setSweepParams((prev) => prev.map((p) => {
+      const params = numericParamsFor(p.blockId);
+      if (params.length === 0) return p;
+      if (params.find((np) => np.id === p.paramName)) return p;
+      return { ...p, paramName: params[0].id };
+    }));
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedBlockId, numericParams.length]);
+  }, [sweepableNodes.length]);
 
   // ── Computed ────────────────────────────────────────────────────────────
-  const runCount = rangeStep > 0 && rangeTo > rangeFrom
-    ? Math.floor((rangeTo - rangeFrom) / rangeStep) + 1
-    : 0;
-  const runCountValid = runCount > 0 && runCount <= MAX_RUNS;
-  const canSubmit = !!datasetId && !!versionId && !!selectedBlockId && !!selectedParamName && runCountValid && !submitting && !activeSweep;
+  // Per-row run counts (0 marks an invalid row).
+  const runCounts = sweepParams.map((p) =>
+    p.step > 0 && p.to > p.from ? Math.floor((p.to - p.from) / p.step) + 1 : 0,
+  );
+  const everyRowValid = runCounts.every((c) => c >= 2);
+  const totalRunCount = everyRowValid ? runCounts.reduce((a, b) => a * b, 1) : 0;
+  const runCountValid = everyRowValid && totalRunCount > 0 && totalRunCount <= MAX_RUNS;
+  const allRowsFilled = sweepParams.every((p) => p.blockId && p.paramName);
+  // Reject duplicate (blockId, paramName) tuples client-side as well —
+  // server does the same in 47-T1.
+  const duplicateRow = (() => {
+    const seen = new Set<string>();
+    for (const p of sweepParams) {
+      const key = `${p.blockId}.${p.paramName}`;
+      if (seen.has(key)) return key;
+      seen.add(key);
+    }
+    return null;
+  })();
+  const canSubmit = !!datasetId && !!versionId && allRowsFilled && runCountValid && !duplicateRow && !submitting && !activeSweep;
 
   // ── Polling ─────────────────────────────────────────────────────────────
   const pollSweep = useCallback(async (sweepId: string) => {
@@ -220,19 +279,19 @@ export default function OptimisePanel({
     setSubmitting(true);
     setSubmitError(null);
 
-    const body = {
+    // 47-T5: send the full sweepParams array. `rankBy` is forwarded only
+    // for metrics the server supports natively (pnl, sharpe). Win-rate /
+    // max-drawdown remain UI-only sorts; the server keeps its `pnlPct`
+    // default for best-row selection.
+    const rankBy = METRIC_TO_RANK_BY[metric];
+    const body: Record<string, unknown> = {
       datasetId,
       strategyVersionId: versionId,
-      sweepParam: {
-        blockId: selectedBlockId,
-        paramName: selectedParamName,
-        from: rangeFrom,
-        to: rangeTo,
-        step: rangeStep,
-      },
+      sweepParams,
       feeBps,
       slippageBps,
     };
+    if (rankBy) body.rankBy = rankBy;
 
     const res = await apiFetch<{ sweepId: string; runCount: number; estimatedSeconds: number }>(
       "/lab/backtest/sweep",
@@ -247,6 +306,7 @@ export default function OptimisePanel({
         status: "pending",
         progress: 0,
         runCount: res.data.runCount,
+        sweepParams,
         results: [],
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
@@ -255,7 +315,7 @@ export default function OptimisePanel({
       setSubmitError(res.problem.detail ?? res.problem.title ?? "Unknown error");
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [datasetId, versionId, selectedBlockId, selectedParamName, rangeFrom, rangeTo, rangeStep, feeBps, slippageBps]);
+  }, [datasetId, versionId, sweepParams, feeBps, slippageBps, metric]);
 
   // ── Sort results ────────────────────────────────────────────────────────
   const handleSort = (key: SortKey) => {
@@ -267,15 +327,69 @@ export default function OptimisePanel({
     }
   };
 
+  // 47-T5: param-column sort reads from `paramValues[`${blockId}.${paramName}`]`.
+  // Legacy "paramValue" sort still works against the singular field.
+  const readSortValue = (row: SweepRow, key: SortKey): number => {
+    if (key === "paramValue") return row.paramValue ?? 0;
+    if (typeof key === "string" && key.startsWith("param:")) {
+      const k = key.slice("param:".length);
+      return row.paramValues?.[k] ?? row.paramValue ?? 0;
+    }
+    const v = (row as unknown as Record<string, unknown>)[key];
+    return typeof v === "number" ? v : 0;
+  };
+
   const sortedResults = activeSweep?.results
     ? [...activeSweep.results].sort((a, b) => {
-        const aVal = a[sortKey] ?? 0;
-        const bVal = b[sortKey] ?? 0;
-        return sortDir === "asc" ? (aVal as number) - (bVal as number) : (bVal as number) - (aVal as number);
+        const aVal = readSortValue(a, sortKey);
+        const bVal = readSortValue(b, sortKey);
+        return sortDir === "asc" ? aVal - bVal : bVal - aVal;
       })
     : [];
 
   const bestId = activeSweep?.bestRow?.backtestResultId;
+
+  // ── Param-column metadata for the results table ───────────────────────
+  // Prefer `sweepParams` from the server response (47-T1 echo). Fall back
+  // to the keys present on the first row's `paramValues`. If neither is
+  // available (legacy server), the table falls back to a single Param
+  // column reading `paramValue`.
+  const responseSweepParams: SweepParam[] | null = (() => {
+    if (activeSweep?.sweepParams && activeSweep.sweepParams.length > 0) {
+      return activeSweep.sweepParams;
+    }
+    const firstRow = activeSweep?.results?.[0];
+    if (firstRow?.paramValues) {
+      const keys = Object.keys(firstRow.paramValues);
+      if (keys.length > 0) {
+        return keys.map((k) => {
+          const dot = k.indexOf(".");
+          return {
+            blockId: dot >= 0 ? k.slice(0, dot) : k,
+            paramName: dot >= 0 ? k.slice(dot + 1) : "",
+            from: 0, to: 0, step: 0,
+          };
+        });
+      }
+    }
+    return null;
+  })();
+  const useLegacyParamColumn = responseSweepParams === null;
+
+  const paramColumnLabel = (p: SweepParam): string => {
+    const node = nodes.find((n) => n.id === p.blockId);
+    if (!node) return `${p.blockId.slice(0, 6)}.${p.paramName}`;
+    const def = BLOCK_DEF_MAP[node.data.blockType];
+    if (!def) return `${node.id.slice(0, 6)}.${p.paramName}`;
+    const paramDef = def.params.find((pd) => pd.id === p.paramName);
+    return `${def.label} · ${paramDef?.label ?? p.paramName}`;
+  };
+
+  const paramColumnValue = (row: SweepRow, p: SweepParam): number | undefined => {
+    const key = `${p.blockId}.${p.paramName}`;
+    if (row.paramValues && key in row.paramValues) return row.paramValues[key];
+    return row.paramValue;
+  };
 
   // Per-metric best/worst for highlighting
   const metricExtremes = (() => {
@@ -334,7 +448,25 @@ export default function OptimisePanel({
 
           {activeSweep.status === "done" && (
             <div style={doneBannerStyle}>
-              Sweep complete — {activeSweep.runCount} runs. Best param: {activeSweep.bestRow?.paramValue ?? "—"}
+              Sweep complete — {activeSweep.runCount} runs. Best params:{" "}
+              {(() => {
+                // Multi-param: render as `label1=v1, label2=v2`. Falls back
+                // to the single legacy `paramValue` if no `paramValues` map
+                // is available on either bestRow or bestParamValuesJson.
+                const map =
+                  activeSweep.bestRow?.paramValues
+                  ?? activeSweep.bestParamValuesJson
+                  ?? null;
+                if (map && Object.keys(map).length > 0 && responseSweepParams) {
+                  return responseSweepParams
+                    .map((p) => {
+                      const v = map[`${p.blockId}.${p.paramName}`];
+                      return `${paramColumnLabel(p)}=${v ?? "—"}`;
+                    })
+                    .join(", ");
+                }
+                return activeSweep.bestRow?.paramValue ?? activeSweep.bestParamValue ?? "—";
+              })()}
             </div>
           )}
 
@@ -348,15 +480,38 @@ export default function OptimisePanel({
               <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 12 }}>
                 <thead>
                   <tr style={theadRowStyle}>
+                    {/* 47-T5: dynamic param columns. Falls back to a single
+                        `paramValue` column when the response is from a
+                        legacy server that doesn't return `sweepParams`. */}
+                    {useLegacyParamColumn ? (
+                      <th
+                        style={{ ...thStyle, cursor: "pointer" }}
+                        onClick={() => handleSort("paramValue")}
+                      >
+                        Param {sortKey === "paramValue" ? (sortDir === "asc" ? "▲" : "▼") : ""}
+                      </th>
+                    ) : (
+                      responseSweepParams!.map((p) => {
+                        const key: ParamSortKey = `param:${p.blockId}.${p.paramName}`;
+                        return (
+                          <th
+                            key={key}
+                            style={{ ...thStyle, cursor: "pointer" }}
+                            onClick={() => handleSort(key)}
+                          >
+                            {paramColumnLabel(p)} {sortKey === key ? (sortDir === "asc" ? "▲" : "▼") : ""}
+                          </th>
+                        );
+                      })
+                    )}
                     {(
                       [
-                        ["paramValue", "Param"],
                         ["pnlPct", "PnL %"],
                         ["winRate", "Win Rate"],
                         ["maxDrawdownPct", "Max DD %"],
                         ["tradeCount", "Trades"],
                         ["sharpe", "Sharpe"],
-                      ] as [SortKey, string][]
+                      ] as [FixedSortKey, string][]
                     ).map(([key, label]) => (
                       <th
                         key={key}
@@ -373,7 +528,7 @@ export default function OptimisePanel({
                     const isBest = r.backtestResultId === bestId;
                     return (
                       <tr
-                        key={r.paramValue}
+                        key={r.backtestResultId}
                         style={{
                           borderBottom: "1px solid rgba(255,255,255,0.04)",
                           background: isBest ? "rgba(212,164,76,0.08)" : "transparent",
@@ -383,7 +538,15 @@ export default function OptimisePanel({
                         onClick={() => onSelectBacktest?.(r.backtestResultId)}
                         title={onSelectBacktest ? "Click to view backtest detail" : undefined}
                       >
-                        <td style={tdStyle}>{r.paramValue}</td>
+                        {useLegacyParamColumn ? (
+                          <td style={tdStyle}>{r.paramValue}</td>
+                        ) : (
+                          responseSweepParams!.map((p) => (
+                            <td key={`${p.blockId}.${p.paramName}`} style={tdStyle}>
+                              {paramColumnValue(r, p) ?? "—"}
+                            </td>
+                          ))
+                        )}
                         <td style={{ ...tdStyle, color: cellColor("pnlPct", r.pnlPct) ?? (r.pnlPct >= 0 ? "#3fb950" : "#f85149"), fontWeight: 600 }}>{fmtPnl(r.pnlPct)}</td>
                         <td style={{ ...tdStyle, color: cellColor("winRate", r.winRate) }}>{(r.winRate * 100).toFixed(1)}%</td>
                         <td style={{ ...tdStyle, color: cellColor("maxDrawdownPct", r.maxDrawdownPct) }}>{r.maxDrawdownPct.toFixed(2)}%</td>
@@ -412,51 +575,142 @@ export default function OptimisePanel({
       {/* Form — shown when no active sweep */}
       {!activeSweep && (
         <>
-          {/* Block selector */}
-          <FormRow label="Target block">
-            {sweepableNodes.length === 0 ? (
-              <div style={emptyHintStyle}>No blocks with numeric parameters in the graph.</div>
-            ) : (
-              <select style={selectStyle} value={selectedBlockId} onChange={(e) => setSelectedBlockId(e.target.value)}>
-                {sweepableNodes.map((n) => (
-                  <option key={n.id} value={n.id}>{blockLabel(n)}</option>
-                ))}
-              </select>
-            )}
-          </FormRow>
+          {/* Sweep param rows (1..MAX_PARAMS) */}
+          {sweepableNodes.length === 0 ? (
+            <div style={emptyHintStyle}>No blocks with numeric parameters in the graph.</div>
+          ) : (
+            sweepParams.map((row, idx) => {
+              const rowParams = numericParamsFor(row.blockId);
+              const rowRuns = runCounts[idx];
+              return (
+                <div key={idx} style={paramRowCardStyle}>
+                  <div style={paramRowHeaderStyle}>
+                    <span style={paramRowTitleStyle}>Parameter {idx + 1}</span>
+                    {sweepParams.length > 1 && (
+                      <button
+                        type="button"
+                        style={removeBtnStyle}
+                        onClick={() =>
+                          setSweepParams((prev) => prev.filter((_, i) => i !== idx))
+                        }
+                      >
+                        Remove
+                      </button>
+                    )}
+                  </div>
+                  <FormRow label="Target block">
+                    <select
+                      style={selectStyle}
+                      value={row.blockId}
+                      onChange={(e) =>
+                        setSweepParams((prev) =>
+                          prev.map((p, i) => (i === idx ? { ...p, blockId: e.target.value } : p)),
+                        )
+                      }
+                    >
+                      {sweepableNodes.map((n) => (
+                        <option key={n.id} value={n.id}>{blockLabel(n)}</option>
+                      ))}
+                    </select>
+                  </FormRow>
+                  <FormRow label="Parameter">
+                    {rowParams.length === 0 ? (
+                      <div style={emptyHintStyle}>Select a block with numeric parameters.</div>
+                    ) : (
+                      <select
+                        style={selectStyle}
+                        value={row.paramName}
+                        onChange={(e) =>
+                          setSweepParams((prev) =>
+                            prev.map((p, i) => (i === idx ? { ...p, paramName: e.target.value } : p)),
+                          )
+                        }
+                      >
+                        {rowParams.map((p) => (
+                          <option key={p.id} value={p.id}>{p.label} (default: {String(p.defaultValue)})</option>
+                        ))}
+                      </select>
+                    )}
+                  </FormRow>
+                  <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 12 }}>
+                    <FormRow label="From">
+                      <input
+                        type="number"
+                        style={inputStyle}
+                        value={row.from}
+                        onChange={(e) =>
+                          setSweepParams((prev) =>
+                            prev.map((p, i) => (i === idx ? { ...p, from: Number(e.target.value) } : p)),
+                          )
+                        }
+                      />
+                    </FormRow>
+                    <FormRow label="To">
+                      <input
+                        type="number"
+                        style={inputStyle}
+                        value={row.to}
+                        onChange={(e) =>
+                          setSweepParams((prev) =>
+                            prev.map((p, i) => (i === idx ? { ...p, to: Number(e.target.value) } : p)),
+                          )
+                        }
+                      />
+                    </FormRow>
+                    <FormRow label="Step">
+                      <input
+                        type="number"
+                        style={inputStyle}
+                        value={row.step}
+                        min={0.01}
+                        onChange={(e) =>
+                          setSweepParams((prev) =>
+                            prev.map((p, i) => (i === idx ? { ...p, step: Number(e.target.value) } : p)),
+                          )
+                        }
+                      />
+                    </FormRow>
+                  </div>
+                  <div style={paramRowFooterStyle}>
+                    {rowRuns >= 2
+                      ? `${rowRuns} values`
+                      : "Invalid range — ensure from < to and step > 0 (≥ 2 values)."}
+                  </div>
+                </div>
+              );
+            })
+          )}
 
-          {/* Param selector */}
-          <FormRow label="Parameter">
-            {numericParams.length === 0 ? (
-              <div style={emptyHintStyle}>Select a block with numeric parameters.</div>
-            ) : (
-              <select style={selectStyle} value={selectedParamName} onChange={(e) => setSelectedParamName(e.target.value)}>
-                {numericParams.map((p) => (
-                  <option key={p.id} value={p.id}>{p.label} (default: {String(p.defaultValue)})</option>
-                ))}
-              </select>
-            )}
-          </FormRow>
-
-          {/* Range */}
-          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 12 }}>
-            <FormRow label="From">
-              <input type="number" style={inputStyle} value={rangeFrom} onChange={(e) => setRangeFrom(Number(e.target.value))} />
-            </FormRow>
-            <FormRow label="To">
-              <input type="number" style={inputStyle} value={rangeTo} onChange={(e) => setRangeTo(Number(e.target.value))} />
-            </FormRow>
-            <FormRow label="Step">
-              <input type="number" style={inputStyle} value={rangeStep} min={0.01} onChange={(e) => setRangeStep(Number(e.target.value))} />
-            </FormRow>
-          </div>
+          {sweepableNodes.length > 0 && (
+            <button
+              type="button"
+              style={{
+                ...addParamBtnStyle,
+                opacity: sweepParams.length >= MAX_PARAMS ? 0.4 : 1,
+                cursor: sweepParams.length >= MAX_PARAMS ? "not-allowed" : "pointer",
+              }}
+              disabled={sweepParams.length >= MAX_PARAMS}
+              onClick={() => {
+                const node = sweepableNodes[0];
+                const param = node ? getNumericParams(node)[0] : null;
+                setSweepParams((prev) => [
+                  ...prev,
+                  { blockId: node?.id ?? "", paramName: param?.id ?? "", from: 5, to: 50, step: 5 },
+                ]);
+              }}
+            >
+              + Add parameter ({sweepParams.length}/{MAX_PARAMS})
+            </button>
+          )}
 
           <div style={hintStyle}>
-            {runCountValid
-              ? `${runCount} runs will be executed sequentially.`
-              : runCount > MAX_RUNS
-                ? `Too many runs (${runCount}). Max is ${MAX_RUNS}. Increase the step or narrow the range.`
-                : "Invalid range. Ensure from < to and step > 0."}
+            {duplicateRow
+              ? `Duplicate parameter ${duplicateRow}. Each (block, param) pair must be unique.`
+              : runCountValid
+                ? `${totalRunCount} runs (Π of per-row counts) will be executed sequentially.`
+                : everyRowValid && totalRunCount > MAX_RUNS
+                  ? `Too many runs (${totalRunCount}). Max ${MAX_RUNS} (product of run-counts across all parameters). Narrow ranges or raise step.`
+                  : "Set a valid range for each parameter (from < to, step > 0, ≥ 2 values per row)."}
           </div>
 
           {/* Dataset */}
@@ -499,13 +753,14 @@ export default function OptimisePanel({
             </FormRow>
           </div>
 
-          {/* Metric */}
+          {/* Metric — `pnl`/`sharpe` are forwarded to the server as
+              `rankBy`; `winRate`/`maxDrawdown` remain UI-only sorts. */}
           <FormRow label="Optimise for">
-            <select style={selectStyle} value={_metric} onChange={(e) => setMetric(e.target.value as OptimiseMetric)}>
+            <select style={selectStyle} value={metric} onChange={(e) => setMetric(e.target.value as OptimiseMetric)}>
               <option value="pnl">Total PnL %</option>
-              <option value="winRate">Win Rate</option>
+              <option value="winRate">Win Rate (UI sort only)</option>
               <option value="sharpe">Sharpe Ratio</option>
-              <option value="maxDrawdown">Min Drawdown</option>
+              <option value="maxDrawdown">Min Drawdown (UI sort only)</option>
             </select>
           </FormRow>
 
@@ -516,7 +771,7 @@ export default function OptimisePanel({
             disabled={!canSubmit}
             onClick={handleSubmit}
           >
-            {submitting ? "Starting sweep…" : `Run Sweep (${runCount} runs)`}
+            {submitting ? "Starting sweep…" : `Run Sweep (${totalRunCount || 0} runs)`}
           </button>
         </>
       )}
@@ -678,4 +933,57 @@ const tdStyle: React.CSSProperties = {
   whiteSpace: "nowrap",
   fontFamily: "monospace",
   fontSize: 12,
+};
+
+const paramRowCardStyle: React.CSSProperties = {
+  border: "1px solid rgba(255,255,255,0.08)",
+  borderRadius: 6,
+  padding: "12px 14px 4px",
+  marginBottom: 10,
+  background: "rgba(255,255,255,0.02)",
+};
+
+const paramRowHeaderStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  marginBottom: 8,
+};
+
+const paramRowTitleStyle: React.CSSProperties = {
+  fontSize: 11,
+  fontWeight: 700,
+  textTransform: "uppercase",
+  letterSpacing: "0.06em",
+  color: "rgba(255,255,255,0.5)",
+};
+
+const removeBtnStyle: React.CSSProperties = {
+  background: "transparent",
+  border: "1px solid rgba(248,81,73,0.35)",
+  borderRadius: 4,
+  padding: "3px 9px",
+  fontSize: 11,
+  color: "#f85149",
+  cursor: "pointer",
+  fontFamily: "inherit",
+};
+
+const paramRowFooterStyle: React.CSSProperties = {
+  fontSize: 11,
+  color: "rgba(255,255,255,0.35)",
+  marginTop: 2,
+  marginBottom: 6,
+};
+
+const addParamBtnStyle: React.CSSProperties = {
+  background: "rgba(59,130,246,0.12)",
+  border: "1px dashed rgba(59,130,246,0.35)",
+  borderRadius: 6,
+  padding: "8px 12px",
+  fontSize: 12,
+  color: "rgba(255,255,255,0.85)",
+  fontFamily: "inherit",
+  width: "100%",
+  marginBottom: 12,
 };


### PR DESCRIPTION
## Summary

Wire the Lab Optimise panel to the multi-parameter grid sweep landed in 47-T1..T4.

- **Form**: replaces the single block/param/range editor with a list of 1..3 parameter rows, each with its own block selector, param selector and from/to/step inputs. `+ Add parameter` is disabled at 3 rows; `Remove` is hidden when a single row remains. Local guard rejects `Π runs > 20` and duplicate `(blockId, paramName)` tuples before the request hits the server.
- **Submit**: sends `sweepParams: SweepParam[]`. The "Optimise for" dropdown is mapped to the server `rankBy`: `pnl→pnlPct`, `sharpe→sharpe`. `winRate` and `maxDrawdown` stay UI-only sorts (no `rankBy` in the body, server keeps its `pnlPct` default), per the plan.
- **Results table**: renders one column per `sweepParams[i]` with a `Block · Param` label, sortable via a new `param:${blockId}.${paramName}` `SortKey` variant (paired with the existing fixed columns and a legacy `paramValue` literal). Cells read from `row.paramValues[key]` and fall back to the legacy `row.paramValue` when the response predates 47-T3 (single column shown).
- **Best-row banner**: shows `label1=v1, label2=v2` from `bestRow.paramValues` / `bestParamValuesJson`, falling back to `paramValue` for legacy responses.

Backward compat: a legacy server response (only `paramValue`, no `sweepParams`/`paramValues`) renders a single Param column unchanged.

## Test plan

- [ ] Manual smoke (Lab → Test → Optimise):
  - 1 parameter — legacy scenario still works end-to-end.
  - 2 parameters 2×3 = 6 runs — table shows two param columns and 6 rows.
  - 3 parameters 2×2×3 = 12 — runs.
  - 3 parameters 3×3×3 = 27 — submit disabled with the "Max 20" hint.
- [ ] `rankBy=pnl` → server best matches the highest PnL row in the table.
- [ ] `rankBy=winRate` / `maxDrawdown` → no `rankBy` sent; server best stays on `pnlPct`; client-side sort works.
- [ ] tsc green on `apps/web` (only the two pre-existing CSS-import warnings remain).

Vitest is not configured for the web app, so the only automated check here is `tsc --noEmit`.

https://claude.ai/code/session_01A3U7JnuJPZdytgZUGW4bC6

---
_Generated by [Claude Code](https://claude.ai/code/session_01A3U7JnuJPZdytgZUGW4bC6)_