### PR TITLE
test(lab): cover bestParamValuesJson + legacy paramValues run-through (47-T6)

### DIFF
--- a/apps/api/tests/routes/lab.test.ts
+++ b/apps/api/tests/routes/lab.test.ts
@@ -879,6 +879,120 @@ describe("POST /api/v1/lab/backtest/sweep", () => {
     expect((first.paramValues as Record<string, number>)["b1.p1"]).toBe(1);
     expect((first.paramValues as Record<string, number>)["b2.p2"]).toBe(10);
   });
+
+  // 47-T6: assert that runSweepAsync persists the best-row aggregates
+  // (`bestParamValue` + `bestParamValuesJson`) at completion time, not just
+  // recomputes them in the GET handler. With the mocked `runBacktest`
+  // returning identical metrics on every iteration, the strict `>` left-fold
+  // selects the FIRST combination in lex order — `(1, 10)` for a 2×2 grid.
+  it("47-T6: 2-param sweep persists bestParamValue + bestParamValuesJson on completion", async () => {
+    mockStrategyVersions["sv-47-6-best"] = {
+      id: "sv-47-6-best",
+      strategyId: "strat-47-6",
+      strategy: { workspaceId: WS_ID },
+      dslJson: {},
+    };
+    mockDatasets["ds-47-6-best"] = {
+      id: "ds-47-6-best",
+      workspaceId: WS_ID,
+      exchange: "bybit",
+      symbol: "BTCUSDT",
+      interval: "M15",
+      fromTsMs: BigInt(0),
+      toTsMs: BigInt(1),
+      datasetHash: "h",
+    };
+
+    const post = await app.inject({
+      method: "POST",
+      url: "/api/v1/lab/backtest/sweep",
+      headers: t1Headers("10.47.6.1"),
+      payload: {
+        datasetId: "ds-47-6-best",
+        strategyVersionId: "sv-47-6-best",
+        sweepParams: [
+          { blockId: "b1", paramName: "p1", from: 1, to: 2, step: 1 },
+          { blockId: "b2", paramName: "p2", from: 10, to: 20, step: 10 },
+        ],
+      },
+    });
+    expect(post.statusCode).toBe(202);
+    const { sweepId } = post.json();
+
+    for (let i = 0; i < 30; i++) {
+      const cur = mockSweeps[sweepId] as Record<string, unknown> | undefined;
+      if (cur && (cur.status === "DONE" || cur.status === "FAILED")) break;
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    const finalRow = mockSweeps[sweepId] as Record<string, unknown> | undefined;
+    expect(finalRow).toBeTruthy();
+    expect(finalRow!.status).toBe("DONE");
+
+    const results = finalRow!.resultsJson as unknown[];
+    expect(results).toHaveLength(4);
+
+    expect(finalRow!.bestParamValue).toBe(1);
+    expect(finalRow!.bestParamValuesJson).toMatchObject({
+      "b1.p1": 1,
+      "b2.p2": 10,
+    });
+  });
+
+  // 47-T6: a legacy request that uses the singular `sweepParam` field still
+  // produces multi-param-aware rows: every row carries a `paramValues` map
+  // with a single entry, equal to the legacy `paramValue`. The persisted
+  // best-row aggregates also populate the new JSON field for older clients.
+  it("47-T6: legacy singular sweepParam runs through and populates paramValues map", async () => {
+    mockStrategyVersions["sv-47-6-legacy"] = {
+      id: "sv-47-6-legacy",
+      strategyId: "strat-47-6-legacy",
+      strategy: { workspaceId: WS_ID },
+      dslJson: {},
+    };
+    mockDatasets["ds-47-6-legacy"] = {
+      id: "ds-47-6-legacy",
+      workspaceId: WS_ID,
+      exchange: "bybit",
+      symbol: "BTCUSDT",
+      interval: "M15",
+      fromTsMs: BigInt(0),
+      toTsMs: BigInt(1),
+      datasetHash: "h",
+    };
+
+    const post = await app.inject({
+      method: "POST",
+      url: "/api/v1/lab/backtest/sweep",
+      headers: t1Headers("10.47.6.2"),
+      payload: {
+        datasetId: "ds-47-6-legacy",
+        strategyVersionId: "sv-47-6-legacy",
+        // Singular alias — server must accept it and run through.
+        sweepParam: { blockId: "bL", paramName: "pL", from: 5, to: 7, step: 1 },
+      },
+    });
+    expect(post.statusCode).toBe(202);
+    const { sweepId } = post.json();
+
+    for (let i = 0; i < 30; i++) {
+      const cur = mockSweeps[sweepId] as Record<string, unknown> | undefined;
+      if (cur && (cur.status === "DONE" || cur.status === "FAILED")) break;
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    const finalRow = mockSweeps[sweepId] as Record<string, unknown> | undefined;
+    expect(finalRow!.status).toBe("DONE");
+
+    const results = finalRow!.resultsJson as Array<Record<string, unknown>>;
+    expect(results).toHaveLength(3);
+    for (const r of results) {
+      const pv = r.paramValues as Record<string, number>;
+      expect(Object.keys(pv)).toEqual(["bL.pL"]);
+      expect(pv["bL.pL"]).toBe(r.paramValue);
+    }
+    // Best-row aggregates: first lex combination (paramValue=5).
+    expect(finalRow!.bestParamValue).toBe(5);
+    expect(finalRow!.bestParamValuesJson).toMatchObject({ "bL.pL": 5 });
+  });
 });
 
 // ── GET /lab/backtest/sweep/:id ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

T1–T4 already shipped most of the §47-T6 deliverables (the cartesian generator unit suite in `tests/lib/sweepGrid.test.ts`, multi-param `applyDslSweepParams` coverage in `tests/lib/applyDslSweepParam.test.ts`, all the POST validation + GET shape assertions). The remaining plan item is the persisted best-row check after `runSweepAsync` finishes — adding two focused e2e tests:

- **`47-T6: 2-param sweep persists bestParamValue + bestParamValuesJson on completion`** — runs a `2 × 2` grid through the live route, polls `mockSweeps[id]` until `DONE`, and asserts `bestParamValue` + `bestParamValuesJson` match the first lex combination (tie-break is locked by the strict-`>` left-fold on identical mocked metrics).
- **`47-T6: legacy singular sweepParam runs through and populates paramValues map`** — exercises the backward-compat alias end-to-end (not just at acceptance), verifies every row's `paramValues` map contains the single `{blockId}.{paramName}` key equal to `paramValue`, and that `bestParamValuesJson` is populated for older clients.

Both tests use distinct `X-Forwarded-For` IPs (`10.47.6.1` / `10.47.6.2`) for fresh per-route rate-limit buckets and the standard 30×10 ms polling pattern around `mockSweeps[id]`.

## Test plan

- [x] `npx vitest run tests/routes/lab.test.ts tests/lib/applyDslSweepParam.test.ts tests/lib/sweepGrid.test.ts` — 133/133 passed.
- [x] `npx tsc --noEmit` (apps/api) clean (after `npx prisma generate`).

https://claude.ai/code/session_01A3U7JnuJPZdytgZUGW4bC6

---
_Generated by [Claude Code](https://claude.ai/code/session_01A3U7JnuJPZdytgZUGW4bC6)_