### PR TITLE
Flagship activation plan: docs 51-55

### DIFF
--- a/docs/51-strategy-preset-system.md
+++ b/docs/51-strategy-preset-system.md
@@ -1,0 +1,436 @@
+# 51. Strategy Preset System
+
+Статус: draft  
+Владелец: core trading / lab  
+Последнее обновление: 2026-04-30  
+Родительский документ: `docs/50-flagship-activation-plan.md`  
+Дорожка: A (research → trading workflow)
+
+## Контекст
+
+Текущее состояние (проверено по коду):
+
+- Создание стратегии и бота сегодня делается через Lab → Build → Compile → Backtest → POST `/bots`. Эндпоинт `POST /bots` (`apps/api/src/routes/bots.ts:58`, тип `CreateBotBody:22`) принимает уже подготовленные `strategyId` + `strategyVersionId` и создаёт `Bot` со статусом `DRAFT`.
+- Каталога «готовых стратегий» в продукте нет. Единственное приближение — `apps/api/src/routes/demo.ts` с двумя hardcoded breakout-presets для public landing page; это не reusable factory, а хак под лендинг.
+- Prisma-модели `StrategyPreset`, `PresetVisibility` enum, `Bot.templateSlug` — отсутствуют (`apps/api/prisma/schema.prisma`).
+- В Lab UI (`apps/web/src/app/lab/`) нет страницы Library / Gallery; есть только Build, Test, Optimise.
+- 4 не-Funding флагмана описаны в `docs/strategies/02-…` … `docs/strategies/06-…`, capability matrix — `docs/strategies/08-strategy-capability-matrix.md`. Все блоки, нужные для их DSL, уже `supported` в `apps/api/src/lib/compiler/supportMap.ts` (33 блока — см. `docs/50 §Контекст`).
+- Существующий `Strategy` имеет `templateSlug String?` — НЕТ, проверено: поле не объявлено. Связь preset→strategy будет добавляться в этом плане.
+
+## Цель
+
+- Ввести immutable JSON-шаблон `StrategyPreset` как «фабрику» `StrategyVersion`.
+- Один эндпоинт `POST /presets/:slug/instantiate` за одну Prisma-транзакцию создаёт `Strategy` + `StrategyVersion` + `Bot` (status=`DRAFT`) и возвращает `botId`. Дальнейший lifecycle бота — стандартный, никакой preset-специфичной runtime-семантики.
+- Каталог пресетов в Lab UI: страница `/lab/library`, карточки → один клик → бот.
+- Видимость управляется enum'ом `PresetVisibility { PRIVATE, PUBLIC }`. До прохождения acceptance gate (`docs/50 §A5`) пресет хранится с `PRIVATE`. Переход в `PUBLIC` — отдельная админская операция, не часть DoD данного документа.
+- Никаких изменений в существующем flow Lab → Build → Compile → Backtest → `POST /bots`. Это параллельный, additive путь.
+
+## Не входит в задачу
+
+- **AI-чат генерация preset'ов.** Существующий `apps/api/src/lib/ai/*` остаётся как есть; Lab Library — это куратор-курируемый каталог.
+- **Версионирование preset'ов с историей.** Preset считается immutable: при необходимости менять — создаём новый slug (`adaptive-regime-v2`). Никаких миграций instantiate-версий вслед за изменениями исходного preset'а — Bot уже привязан к собственной `StrategyVersion`.
+- **UI-редактор preset'ов.** Создание / правка пресетов на этом этапе делается миграцией / seed-скриптом (51-T6). Полноценный admin UI — отдельный документ.
+- **Marketplace, рейтинги, комментарии.** Только каталог + instantiate. Социальный слой — out of scope.
+- **Промо-флаги вроде `featured`, `recommended`.** Сортировка в gallery — детерминированная по slug или `updatedAt DESC`, без weighted ranking.
+- **Cross-workspace sharing.** Пресет либо `PRIVATE` для конкретного workspace, либо `PUBLIC` (виден всем). Гранулярные ACL — out of scope.
+- **Импорт / экспорт DSL JSON через UI.** Endpoint`POST /presets` принимает JSON, но UI-страницы для загрузки нет — admin использует API напрямую или seed.
+
+## Архитектурные решения
+
+### Решение 1: Preset — immutable factory, не runtime-сущность
+
+`StrategyPreset` хранит:
+
+- `slug String @id` — стабильный идентификатор (`adaptive-regime`, `dca-momentum`, `mtf-scalper`, `smc-liquidity-sweep`).
+- `name String`, `description String`, `category String` (`trend` | `dca` | `scalping` | `smc` | `arb`).
+- `dslJson Json` — DSL стратегии, тот же формат, что в `StrategyVersion.dslJson`.
+- `defaultBotConfigJson Json` — дефолтные параметры для `Bot` (`symbol`, `timeframe`, `quoteAmount`, `maxOpenPositions`, …).
+- `datasetBundleHintJson Json?` — рекомендованный multi-interval bundle (см. `docs/52`); опционально, single-TF пресеты не задают.
+- `visibility PresetVisibility @default(PRIVATE)` (enum `PRIVATE | PUBLIC`).
+- `createdAt`, `updatedAt`.
+
+Никакой backref `Bot.presetId` — связь только через `Bot.templateSlug` (`String?`, без FK), чтобы preset мог быть удалён / переименован без каскада на ботов. См. 51-T4.
+
+### Решение 2: Instantiate — одна транзакция, без частичных состояний
+
+`POST /presets/:slug/instantiate` принимает `{ workspaceId, overrides?: Partial<BotConfig> }`. В рамках одной `prisma.$transaction([…])`:
+
+1. `Strategy.create({ name: preset.name, workspaceId, templateSlug: preset.slug })` — каждый instantiate создаёт **новую** `Strategy`. Намеренно не переиспользуем существующую — чтобы один пользователь мог иметь несколько ботов от одного пресета с разной конфигурацией / параметрами без shared StrategyVersion.
+2. `StrategyVersion.create({ strategyId, dslJson: preset.dslJson, version: 1, status: "compiled" })` — компиляция DSL уже в момент create; если падает — вся транзакция откатывается.
+3. `Bot.create({ strategyId, strategyVersionId, status: "DRAFT", templateSlug: preset.slug, ...mergedConfig })`.
+
+Возвращается `{ botId, strategyId, strategyVersionId }`. Дальнейшие действия — стандартные: `PATCH /bots/:id`, `POST /bots/:id/start`.
+
+### Решение 3: Visibility-gate — preset публикуется только после acceptance
+
+Acceptance из `docs/50 §A5` (golden DSL fixture + walk-forward + 30-мин demo smoke) — обязательное условие для перевода `visibility` в `PUBLIC`. До тех пор пресет существует в БД с `PRIVATE` и виден только в админ-панели (51-T5). Это даёт возможность раскатывать пресеты по одному (`docs/53` → `docs/54`) без изменения каталога для конечных пользователей.
+
+### Решение 4: Composite signal types — переписываются через примитивы
+
+См. `docs/50 §Решение 3`. Никаких новых типов сигналов в evaluator не вводится: каждый `dslJson` пресета составляется из 33 уже supported блоков (`apps/api/src/lib/compiler/supportMap.ts`). Если конкретный флагман потребует семантики, не выражаемой через существующие блоки — это блокер, фиксируется как отдельная T-задача в `docs/53`/`docs/54`, не как escape-hatch внутри preset'а.
+
+---
+
+## Задачи
+
+### 51-T1: Prisma модель `StrategyPreset` + миграция
+
+**Цель:** ввести Prisma-модель `StrategyPreset` и enum `PresetVisibility`. Чисто схема + миграция, без endpoint'ов.
+
+**Файлы для изменения:**
+- `apps/api/prisma/schema.prisma` — добавить модель и enum.
+- `apps/api/prisma/migrations/<timestamp>_strategy_preset/migration.sql` — additive миграция.
+- `apps/api/tests/prisma/strategyPreset.test.ts` (создать) — sanity-чек create/findUnique.
+
+**Шаги реализации:**
+1. В `schema.prisma` рядом с `Strategy` (примерно строка 230, источник истинности — текущий файл) добавить:
+   ```prisma
+   enum PresetVisibility {
+     PRIVATE
+     PUBLIC
+   }
+
+   model StrategyPreset {
+     slug                  String           @id
+     name                  String
+     description           String
+     category              String
+     dslJson               Json
+     defaultBotConfigJson  Json
+     datasetBundleHintJson Json?
+     visibility            PresetVisibility @default(PRIVATE)
+     createdAt             DateTime         @default(now())
+     updatedAt             DateTime         @updatedAt
+
+     @@index([visibility])
+     @@index([category])
+   }
+   ```
+2. `npx prisma migrate dev --name strategy_preset` — генерация миграции локально, ручная проверка SQL (additive `CREATE TABLE` + `CREATE TYPE`, не должно быть `ALTER` существующих таблиц).
+3. Никаких backfill'ов — таблица создаётся пустой.
+4. `npx prisma generate` обновляет client; убедиться, что новый тип доступен в `apps/api/src/lib/prisma.ts` потребителях.
+
+**Тест-план:**
+- `prisma.strategyPreset.create({ data: { slug: "test", name: "T", description: "x", category: "trend", dslJson: {}, defaultBotConfigJson: {}, visibility: "PRIVATE" } })` → успех.
+- `findUnique({ where: { slug: "test" } })` → возвращает запись.
+- Дублирующий create по тому же slug → ошибка уникальности.
+- `visibility` без value → дефолт `PRIVATE`.
+
+**Критерии готовности:**
+- `npx prisma migrate dev` проходит без ошибок.
+- `npx prisma generate` — client типизирован.
+- `tsc --noEmit` зелёный.
+- Существующие тесты Prisma (если есть) зелёные.
+- В schema.prisma нет изменений других моделей.
+
+---
+
+### 51-T2: CRUD-эндпоинты пресетов
+
+**Цель:** ввести `POST /presets`, `GET /presets`, `GET /presets/:slug`. UPDATE / DELETE на этом этапе не реализуются — пресеты иммутабельны, новый slug = новая запись.
+
+**Файлы для изменения:**
+- `apps/api/src/routes/presets.ts` (создать) — Fastify router, регистрация в `apps/api/src/server.ts`.
+- `apps/api/tests/routes/presets.test.ts` (создать).
+
+**Шаги реализации:**
+1. `POST /presets` (admin-only — гард по существующему `requireAdmin` middleware, тот же что у `/admin/*`). Body:
+   ```ts
+   type CreatePresetBody = {
+     slug: string;            // /^[a-z0-9-]{3,64}$/
+     name: string;            // 1..120
+     description: string;     // 1..500
+     category: "trend" | "dca" | "scalping" | "smc" | "arb";
+     dslJson: unknown;        // валидируется compileDsl ниже
+     defaultBotConfigJson: {
+       symbol: string;
+       timeframe: "M1" | "M5" | "M15" | "H1";
+       quoteAmount: number;
+       maxOpenPositions: number;
+       [k: string]: unknown;
+     };
+     datasetBundleHintJson?: Record<string, string | true> | null;
+     visibility?: "PRIVATE" | "PUBLIC"; // default PRIVATE
+   };
+   ```
+   До записи — прогнать `dslJson` через существующий `compileDsl` (`apps/api/src/lib/compiler/compile.ts`). Если компиляция падает — 400 с массивом ошибок. Это гарант, что preset технически валиден на момент создания.
+2. `GET /presets` — query: `?category=...&visibility=...`. Без авторизации возвращает только `visibility=PUBLIC`. С админ-токеном возвращает всё. Ответ — массив без `dslJson` (для каталога достаточно метаданных + `defaultBotConfigJson`); `dslJson` отдаётся только в `GET /presets/:slug`.
+3. `GET /presets/:slug` — полный объект с `dslJson`. Без авторизации недоступен для `PRIVATE` (404, не 403, чтобы не раскрывать существование).
+4. Регистрация роута в `server.ts` рядом с другими `/lab`/`/bots` роутерами; rate limit — стандартный (тот же, что у `/bots`).
+5. **Никаких** `PATCH` / `DELETE` пока: если потребуется поправить пресет — создаётся новый slug, старый помечается `visibility=PRIVATE` через прямой SQL / отдельный admin-tool. Это сознательное ограничение для иммутабельности; снимается в follow-up документе.
+
+**Тест-план:**
+- POST невалидного `slug` (uppercase / spaces) → 400.
+- POST с DSL, который не компилируется → 400, тело содержит компиляторные ошибки.
+- POST успешный → 201, `findUnique` возвращает запись.
+- POST дубль slug → 409.
+- GET list без auth: только `PUBLIC`.
+- GET list с admin: все.
+- GET `:slug` для `PRIVATE` без auth → 404.
+- GET `:slug` для `PUBLIC` без auth → 200 с `dslJson`.
+
+**Критерии готовности:**
+- Роут зарегистрирован, ручной curl проходит.
+- Все тесты зелёные.
+- В OpenAPI (если генерируется) появляются три новых эндпоинта.
+- `compileDsl` вызывается на POST — невалидные DSL не записываются.
+
+---
+
+### 51-T3: Instantiate-эндпоинт (транзакция Strategy + StrategyVersion + Bot)
+
+**Цель:** `POST /presets/:slug/instantiate` создаёт три сущности в одной транзакции и возвращает `{ botId, strategyId, strategyVersionId }`.
+
+**Файлы для изменения:**
+- `apps/api/src/routes/presets.ts` — добавить хендлер.
+- `apps/api/tests/routes/presets.test.ts` — расширить.
+
+**Шаги реализации:**
+1. Body:
+   ```ts
+   type InstantiateBody = {
+     workspaceId: string;
+     overrides?: Partial<{
+       symbol: string;
+       timeframe: "M1" | "M5" | "M15" | "H1";
+       quoteAmount: number;
+       maxOpenPositions: number;
+       name: string; // user-facing имя бота
+     }>;
+   };
+   ```
+2. Хендлер:
+   - Загрузить пресет (`findUnique({ where: { slug } })`); если `visibility=PRIVATE` и нет admin-токена — 404 (та же политика, что в T2).
+   - Слить `defaultBotConfigJson` с `overrides` (overrides приоритетнее). Валидировать `timeframe` против `VALID_TIMEFRAMES = ["M1","M5","M15","H1"]` из `apps/api/src/routes/bots.ts:22` (импорт не делать, чтобы избежать circular; продублировать литерал и добавить TODO-comment про централизацию в follow-up).
+   - В `prisma.$transaction`:
+     - `Strategy.create({ name: overrides?.name ?? preset.name, workspaceId, templateSlug: preset.slug })`.
+     - `StrategyVersion.create({ strategyId, dslJson: preset.dslJson, version: 1, status: "compiled" })`. Если в текущем коде `StrategyVersion.status` имеет другие значения — использовать существующий `compiled`/`ready`-эквивалент, проверить `schema.prisma`.
+     - `Bot.create({ strategyId, strategyVersionId, status: "DRAFT", templateSlug: preset.slug, ...mergedConfig })`.
+   - Транзакция целиком откатывается, если любой шаг падает (включая ошибку Prisma на FK / unique).
+3. Ответ: `{ botId, strategyId, strategyVersionId }`, status 201.
+4. Никаких side effects вне транзакции (никаких email / webhook / queue.publish). Создание бота — чистая операция БД.
+5. Авторизация: эндпоинт требует обычного user-токена (не admin). `workspaceId` валидируется на принадлежность пользователю — переиспользовать существующий guard из `routes/bots.ts` (см. `assertWorkspaceMembership` или эквивалент в текущем коде).
+6. Идемпотентности **нет**: повторный POST создаст вторую `Strategy`/`Bot`. Это явное решение — каждый instantiate = новый экземпляр. Дедуп ответственность клиента (например, double-click на карточке gallery → debounce на UI).
+
+**Тест-план:**
+- POST с невалидным `slug` → 404.
+- POST на `PRIVATE` без admin → 404.
+- POST успех: проверить, что в БД появились ровно одна `Strategy`, одна `StrategyVersion`, один `Bot`, все с `templateSlug = preset.slug`.
+- POST с `overrides.symbol` — `Bot.symbol` равен override'у, не дефолту.
+- POST с `overrides.timeframe="M30"` → 400 (не в `VALID_TIMEFRAMES`).
+- Симуляция падения `Bot.create` (например, через мок) → ни `Strategy`, ни `StrategyVersion` в БД не остаются (rollback).
+- 2 последовательных POST → создаются 2 независимых бота.
+
+**Критерии готовности:**
+- Транзакционная атомарность подтверждена тестом.
+- `Bot.status === "DRAFT"` в результате — старт отдельным вызовом `POST /bots/:id/start`.
+- Существующие тесты `/bots` зелёные без правок.
+- Ручной smoke: instantiate seed-пресета (после 51-T6) → `POST /bots/:id/start` → бот появляется в polling-loop.
+
+---
+
+### 51-T4: `Bot.templateSlug` для трекинга происхождения
+
+**Цель:** ввести nullable `templateSlug String?` в `Bot` и `Strategy` для трекинга, из какого пресета произведён экземпляр. Без FK на `StrategyPreset` — связь по строке.
+
+**Файлы для изменения:**
+- `apps/api/prisma/schema.prisma` — `Bot`, `Strategy`.
+- `apps/api/prisma/migrations/<timestamp>_template_slug/migration.sql` — additive.
+- `apps/api/src/routes/bots.ts` — расширить `CreateBotBody:22` опциональным `templateSlug`.
+- `apps/api/src/routes/presets.ts` — instantiate (51-T3) уже пишет `templateSlug`.
+- `apps/api/tests/routes/bots.test.ts` — добавить кейс с `templateSlug`.
+
+**Шаги реализации:**
+1. В `Bot` модель добавить:
+   ```prisma
+   templateSlug String?
+   @@index([templateSlug])
+   ```
+   Аналогично — в `Strategy`. Без relation block, чтобы preset мог быть удалён без каскада.
+2. Миграция: `ALTER TABLE "Bot" ADD COLUMN "templateSlug" TEXT; CREATE INDEX "Bot_templateSlug_idx" ON "Bot"("templateSlug");` — идентично для `Strategy`. Existing rows получают `NULL`.
+3. `CreateBotBody` (`bots.ts:22`): добавить optional `templateSlug?: string` (regex `/^[a-z0-9-]{3,64}$/`). Если присутствует — кладётся в `Bot.create({ ... templateSlug })`. Не валидировать существование preset'а с таким slug — это просто метка, не FK.
+4. В UI Bot page (отдельно — в 51-T5) добавить badge "From preset: `<slug>`" если `templateSlug != null`. На этом этапе — только бэкенд.
+5. **Обратное чтение**: `GET /presets/:slug/usage` — НЕ реализуется в этом этапе (нет требований). Потенциальный count `prisma.bot.count({ where: { templateSlug } })` — оставить на follow-up.
+
+**Тест-план:**
+- `POST /bots` с `templateSlug` → создан бот, поле сохранено.
+- `POST /bots` без `templateSlug` → создан бот с `templateSlug = null` (backward-compat).
+- `POST /presets/:slug/instantiate` → `Bot.templateSlug === preset.slug` и `Strategy.templateSlug === preset.slug` (повторная проверка из 51-T3 на уровне БД).
+- Удаление preset'а (через прямой SQL) → существующий бот живёт, его `templateSlug` остаётся валидной строкой, но при попытке загрузить preset через `GET /presets/:slug` будет 404. Это ожидаемое поведение; UI должен корректно скрывать badge.
+
+**Критерии готовности:**
+- Миграция additive, существующие row'ы целы.
+- `tsc --noEmit` зелёный.
+- `POST /bots` без `templateSlug` работает идентично текущему поведению (нет регрессий в `bots.test.ts`).
+
+---
+
+### 51-T5: UI Lab Library (gallery)
+
+**Цель:** страница `/lab/library` со списком карточек `PUBLIC` пресетов; клик «Use preset» → diaglog с конфигурацией → POST `/presets/:slug/instantiate` → редирект на страницу созданного бота.
+
+**Файлы для изменения:**
+- `apps/web/src/app/lab/library/page.tsx` (создать).
+- `apps/web/src/app/lab/library/PresetCard.tsx` (создать).
+- `apps/web/src/app/lab/library/InstantiateDialog.tsx` (создать).
+- `apps/web/src/app/lab/layout.tsx` — добавить пункт "Library" в навигацию рядом с Build/Test/Optimise.
+- `apps/web/src/lib/api/presets.ts` (создать) — типизированные клиенты `listPresets`, `getPreset`, `instantiatePreset`.
+
+**Шаги реализации:**
+1. `/lab/library` — серверный component, грузит `GET /presets?visibility=PUBLIC` и рендерит сетку карточек. Каждая карточка: name, описание (truncate 200 chars), category badge, кнопка "Use preset".
+2. Если list пустой (например, до 51-T6 / до публикации первого пресета) — показывается empty-state с подсказкой "No public presets yet. Build your own via Lab → Build."
+3. `InstantiateDialog`: форма с полями из `defaultBotConfigJson` (symbol / timeframe / quoteAmount / maxOpenPositions). Дефолты предзаполнены, пользователь может изменить → отправляет в `overrides`. Кнопка "Create bot" → `POST /presets/:slug/instantiate` → router.push(`/bots/${botId}`).
+4. Если preset имеет `datasetBundleHintJson != null` — показать info-бокс "This preset uses multi-interval data. Configure dataset bundle on the bot page after creation." Линк на гайд (плейсхолдер `docs/52`).
+5. Admin-режим: если у пользователя admin-токен, гruzить `GET /presets` без фильтра — карточки `PRIVATE` отображаются с серым бейджем "Private", "Use preset" работает идентично.
+6. Никаких новых глобальных стейт-сторов; локальный `useState` в страницах достаточно. Используем существующий `apiClient` обвязку из `apps/web/src/lib/api/`.
+7. На странице бота (`/bots/[id]`, существующая) добавить условный badge "From preset: `<slug>`" если `bot.templateSlug != null` — отдельный мини-PR в рамках T5.
+
+**Тест-план:**
+- Ручной smoke в браузере:
+  - Открыть `/lab/library` без пресетов в БД → empty-state.
+  - Создать через API один `PUBLIC` preset → перезагрузить страницу → карточка появилась.
+  - Кнопка "Use preset" → диалог открывается с дефолтами.
+  - Submit с overrides → `POST /presets/:slug/instantiate` → редирект на `/bots/<id>`, на странице видна badge "From preset".
+  - Submit от админа на `PRIVATE` preset → бот создаётся.
+- Регрессия: `/lab/build`, `/lab/test`, `/lab/optimise` продолжают работать без изменений.
+
+**Критерии готовности:**
+- TypeScript-проверка фронта зелёная.
+- E2E тест (если есть playwright-suite) проходит для goldenpath; иначе — ручной smoke задокументирован в PR.
+- Нет регрессий навигации Lab.
+
+---
+
+### 51-T6: Seed-пресеты для 4 флагманов в статусе PRIVATE
+
+**Цель:** добавить seed-скрипт, создающий 4 не-Funding пресета в `PRIVATE`. Это даёт реальные DSL-fixtures, на которых будут работать `docs/53` (Adaptive Regime) и `docs/54` (DCA / MTF Scalper / SMC). Funding Arb идёт отдельно в `docs/55-T6`.
+
+**Файлы для изменения:**
+- `apps/api/prisma/seed/presets/adaptive-regime.json` (создать) — DSL.
+- `apps/api/prisma/seed/presets/dca-momentum.json` (создать).
+- `apps/api/prisma/seed/presets/mtf-scalper.json` (создать).
+- `apps/api/prisma/seed/presets/smc-liquidity-sweep.json` (создать).
+- `apps/api/prisma/seed/seedPresets.ts` (создать) — upsert по slug.
+- `apps/api/prisma/seed/index.ts` — вызвать `seedPresets()` если ещё не вызван.
+- `apps/api/tests/prisma/seedPresets.test.ts` (создать).
+
+**Шаги реализации:**
+1. JSON-файлы с DSL — заглушки с минимальной валидной DSL-структурой (один блок `enter_when` через `compare`/`crosses`, один `exit_when`, корректный `defaultBotConfigJson`). Полные DSL для каждой стратегии оформляются в соответствующих документах (`docs/53` для Adaptive Regime — golden fixture; `docs/54` для остальных). На этапе T6 достаточно того, чтобы каждый JSON прогонялся через `compileDsl` без ошибок.
+2. `seedPresets.ts`:
+   ```ts
+   const presets = [
+     { slug: "adaptive-regime", file: "./presets/adaptive-regime.json", category: "trend" },
+     { slug: "dca-momentum",    file: "./presets/dca-momentum.json",    category: "dca" },
+     { slug: "mtf-scalper",     file: "./presets/mtf-scalper.json",     category: "scalping" },
+     { slug: "smc-liquidity-sweep", file: "./presets/smc-liquidity-sweep.json", category: "smc" },
+   ];
+
+   for (const p of presets) {
+     const data = JSON.parse(await fs.readFile(...));
+     await prisma.strategyPreset.upsert({
+       where: { slug: p.slug },
+       create: { slug: p.slug, ...data, category: p.category, visibility: "PRIVATE" },
+       update: { ...data, category: p.category }, // visibility НЕ обновляется через seed
+     });
+   }
+   ```
+3. `update`-ветка намеренно не трогает `visibility` — как только preset переведён в `PUBLIC` админом, повторный seed не откатит это.
+4. `seedPresets()` вызывается из `prisma/seed/index.ts` (стандартный hook `prisma db seed`).
+5. Каждый JSON-файл прогоняется через `compileDsl` в `seedPresets.test.ts`. Если хоть один не валиден — тест красный, seed не публикуется.
+
+**Тест-план:**
+- Запуск `npx prisma db seed` дважды подряд → идемпотентность (no-op на втором запуске за исключением `updatedAt`).
+- В тесте: `compileDsl(preset.dslJson)` для каждого slug — без ошибок.
+- В тесте: каждый preset имеет `visibility="PRIVATE"`.
+- В тесте: после ручного перевода preset'а в `PUBLIC` через прямой SQL и повторного seed — `visibility` остаётся `PUBLIC`.
+
+**Критерии готовности:**
+- Все 4 seed-пресета компилируются.
+- Идемпотентность подтверждена тестом.
+- В CI seed запускается на тестовой БД и не падает.
+- DSL-fixtures помечены как «черновики, финальный вид — в `docs/53/54`».
+
+---
+
+### 51-T7: Тесты — CRUD + instantiate + UI smoke
+
+**Цель:** довести покрытие preset-системы до уровня, при котором регрессии ловятся на CI. Объединяет тесты, описанные в T1..T6, и добавляет интеграционный e2e.
+
+**Файлы для изменения:**
+- `apps/api/tests/routes/presets.test.ts` — расширить.
+- `apps/api/tests/integration/presetInstantiateFlow.test.ts` (создать) — e2e.
+- `apps/web/tests/lab/library.spec.ts` (если есть playwright) — UI smoke.
+
+**Шаги реализации:**
+1. Объединить unit-тесты из T1 (Prisma model), T2 (CRUD), T3 (instantiate transaction), T4 (templateSlug), T6 (seed compileDsl) — убедиться, что они существуют как отдельные spec-файлы, без дублей.
+2. **Интеграционный e2e** в `presetInstantiateFlow.test.ts`:
+   - `prisma db seed` → 4 preset'а в БД (`PRIVATE`).
+   - Через прямой SQL установить `visibility="PUBLIC"` для `adaptive-regime`.
+   - `GET /presets` без auth → возвращает только `adaptive-regime`.
+   - `POST /presets/adaptive-regime/instantiate` с фейковым workspace → 201, `botId` в ответе.
+   - `GET /bots/:id` → `Bot.status === "DRAFT"`, `templateSlug === "adaptive-regime"`, есть `strategyVersionId`, в `StrategyVersion.dslJson` лежит DSL пресета (deep equal).
+   - `POST /bots/:id/start` → стандартный flow срабатывает (это тест на отсутствие preset-специфичной runtime-семантики; `botWorker.ts` не должен видеть никакой разницы между preset'овым и обычным ботом).
+3. UI-smoke (если playwright настроен): открыть `/lab/library`, кликнуть "Use preset" на `adaptive-regime`, заполнить форму, submit → ожидать редирект на `/bots/<id>` и наличие badge "From preset".
+4. Все новые тесты — детерминированы (фикстуры зашиты, рандом / `Date.now()` не используется в DSL-валидации). Полей с current time в моделях `StrategyPreset` нет проблематичных, но в ассертах сверяем `slug`/`name`/`dslJson`, а не `createdAt`.
+
+**Тест-план:**
+- `npm test` (`apps/api`) проходит локально и в CI.
+- Существующие тесты `/bots`, `/lab/*` остаются зелёными.
+- Покрытие новых файлов (`routes/presets.ts`, `seed/seedPresets.ts`) ≥ 80% по строкам (ориентир, не блокер).
+
+**Критерии готовности:**
+- Все новые тесты зелёные.
+- E2E `presetInstantiateFlow.test.ts` проходит на чистой тестовой БД.
+- В PR-описании отмечено, что preset-flow не трогает `botWorker.ts` / runtime — это инвариант проекта (`docs/50 §Решение 1`).
+
+---
+
+## Порядок выполнения задач
+
+```
+51-T1 ──→ 51-T2 ──→ 51-T3 ──→ 51-T6 ──→ 51-T5
+              ↘                  ↗
+               51-T4 ────────────
+                                 ↘
+                                  51-T7
+```
+
+- 51-T1 (Prisma модель) — первая, без неё ничего не работает.
+- 51-T2 (CRUD) и 51-T4 (`Bot.templateSlug`) можно делать параллельно после T1.
+- 51-T3 (instantiate) требует T1, T2 и T4 (использует `Bot.templateSlug`).
+- 51-T6 (seed) требует T1 + T2 (DSL валидируется через `compileDsl` тем же путём, что в `POST /presets`). Может идти параллельно с T3 после того, как T2 закрыта.
+- 51-T5 (UI) — самая последняя из «функциональных», требует T2 (list/get) и T3 (instantiate).
+- 51-T7 (тесты) — встраивается инкрементально в каждую из T1..T6, плюс отдельный финальный e2e-spec.
+
+Каждая задача — отдельный PR. T7 e2e-spec может ехать вместе с T6 или отдельным PR'ом.
+
+## Зависимости от других документов
+
+- `docs/50` — родительский overview. Никакая T-задача из 51 не противоречит решениям, зафиксированным там.
+- `docs/52-multi-interval-dataset-bundle.md` — независим. `datasetBundleHintJson` в `StrategyPreset` — необязательное поле; пресеты, которые не используют multi-interval, не зависят от 52.
+- `docs/53-adaptive-regime-bot-activation.md` — потребитель 51. Использует `POST /presets/:slug/instantiate` для one-click активации; финальный DSL для `adaptive-regime` пресета фиксируется в 53-T1 (golden fixture).
+- `docs/54-flagship-rollout.md` — потребитель 51. Аналогично 53, но для DCA / MTF Scalper / SMC.
+- `docs/47` / `docs/48` / `docs/49` — закрыты. Используются как инструменты валидации внутри acceptance gate (`docs/50 §A5`), не блокируют документ 51.
+- `docs/strategies/01-08` — концептуальные. Источник истинности по DSL-составу каждого флагмана.
+
+## Backward compatibility checklist
+
+- Никаких изменений в существующем `POST /bots` flow: `templateSlug` опционален, default `null`, поведение для клиентов без знаний о preset'ах идентично текущему.
+- `botWorker.ts`, `signalEngine.ts`, `exitEngine.ts`, `positionManager.ts` — не модифицируются. Preset-flow «выходит» из себя сразу после instantiate; runtime видит обычного `Bot` с обычной `StrategyVersion`.
+- Prisma миграции — только additive: новая таблица `StrategyPreset`, новый enum `PresetVisibility`, две новые nullable колонки `Bot.templateSlug`, `Strategy.templateSlug`.
+- Существующие `Strategy`, `StrategyVersion`, `Bot`-записи продолжают работать; `templateSlug=NULL` для всех.
+- `routes/demo.ts` (hardcoded breakout-presets для лендинга) остаётся как есть и не мигрирует на `StrategyPreset` в рамках этого документа — у него другая семантика (public lead-gen, без БД).
+- AI-чат / Lab Build / Lab Test / Lab Optimise — не затрагиваются.
+- Никаких изменений в `BotIntent`, `BotRunState`, `IntentType` enum'ах.
+- Removal preset'а через прямой SQL — не каскадирует на ботов: связь `Bot.templateSlug` без FK (см. 51-T4), badge "From preset" просто перестаёт показываться.
+
+## Ожидаемый результат
+
+После закрытия всех задач 51-T1..51-T7:
+
+- В Lab UI существует страница `/lab/library` со списком публичных пресетов; одна кнопка превращает карточку в живого бота (DRAFT) за <60 секунд.
+- БД хранит 4 не-Funding пресета как `PRIVATE` (заполнены seed'ом из 51-T6), готовых к публикации после прохождения acceptance gate в `docs/53` / `docs/54`.
+- API эндпоинты `GET /presets`, `GET /presets/:slug`, `POST /presets/:slug/instantiate` стабильны и покрыты тестами.
+- Существующий flow Lab → Build → Compile → Backtest → `POST /bots` работает без регрессий — preset является **дополнительным** входом в систему, а не заменой.
+- Каждый созданный из пресета бот несёт `templateSlug` для аналитики и будущего displayed-attribution.
+- DSL-evaluator, signal/exit/position engine, botWorker — не модифицированы; preset-флоу полностью локализован в `routes/presets.ts` + Prisma миграциях.

--- a/docs/52-multi-interval-dataset-bundle.md
+++ b/docs/52-multi-interval-dataset-bundle.md
@@ -1,0 +1,389 @@
+# 52. Multi-Interval Dataset Bundle
+
+Статус: draft  
+Владелец: core trading / lab  
+Последнее обновление: 2026-04-30  
+Родительский документ: `docs/50-flagship-activation-plan.md`  
+Дорожка: A (research → trading workflow)
+
+## Контекст
+
+Текущее состояние (проверено по коду):
+
+- `MarketDataset` — single-interval (поле `interval CandleInterval`, `apps/api/prisma/schema.prisma:497` enum `CandleInterval { M1 M5 M15 M30 H1 H4 D1 }`); один dataset = одна пара `(symbol, interval)`.
+- `MarketCandle` хранит свечи по полям `symbol`, `interval`, `openTime` (`schema.prisma`). Уникальность по `(datasetId, openTime)`.
+- `botWorker.ts:1467` — load свечей: `prisma.marketCandle.findMany({ where: { symbol } })` — **без фильтра по `interval`**. Это означает, что прямо сейчас runtime тянет свечи всех загруженных интервалов символа, а отбор на стороне применения индикаторов происходит post-factum / неявно. Для multi-TF стратегий это не работает: indicator должен видеть конкретный TF.
+- `apps/api/src/lib/mtf/intervalAlignment.ts` — содержит `CandleBundle` тип и helper'ы выравнивания (HTF свеча → набор LTF свечей в её окне). Это инфраструктура уже есть.
+- `apps/api/src/lib/mtf/mtfIndicatorResolver.ts` — резолвер индикатора по `sourceTimeframe`.
+- `apps/api/src/lib/dslEvaluator.ts:749` — `evaluateExpression` уже принимает `bundle?: CandleBundle` (опционально). DSL-узел `DslIndicatorRef.sourceTimeframe` (`apps/api/src/lib/dslEvaluator.ts:134`) — supported.
+- Иными словами: **MTF-инфраструктура в evaluator готова**, но runtime/backtest её не используют — они кормят evaluator одним массивом свечей.
+- `BacktestSweep` (`schema.prisma:686`) и `WalkForwardRun` принимают единственный `datasetId`. Lab UI Test/Optimise/Walk-Forward (`apps/web/src/app/lab/test/*`, `apps/web/src/app/lab/walk-forward/*`) — single-dataset селектор.
+- Spec MTF Scalper (`docs/strategies/05-mtf-scalper.md`) и Adaptive Regime (`docs/strategies/03-adaptive-regime-bot.md`) явно требуют 2-3 интервала.
+
+## Цель
+
+- Ввести `datasetBundleJson: Record<CandleInterval, datasetId | true>` как additive nullable колонку на `Bot`, `BacktestSweep`, `WalkForwardRun`. Значение `true` означает «использовать любой/первый dataset для этого symbol+interval» (для runtime, где dataset как объект не нужен — нужны просто свечи); явный `datasetId` обязателен для backtest/walk-forward (там ровно конкретные данные нужны).
+- Перевести runtime `botWorker.ts` на загрузку bundle (всех нужных TF), передачу `CandleBundle` в `dslEvaluator`. Сохранить старый single-TF режим как fallback, если `datasetBundleJson === null`.
+- Перевести backtest `runBacktest` на приём bundle, чтобы acceptance/walk-forward тесты могли запускаться на multi-TF фикстурах.
+- Расширить Lab UI селектор с одного dataset до набора (1..N выбранных интервалов из существующих datasets workspace'а).
+- Сохранить полную backward compatibility: все существующие single-interval вызовы остаются рабочими.
+
+## Не входит в задачу
+
+- **Введение модели `DatasetBundle` как Prisma-сущности.** Это первое, что напрашивается, и явно отвергается в `docs/50 §Решение 2`: bundle — логическая JSON-структура, не таблица. Меньше миграций, меньше двусторонних связей, меньше каскадных операций.
+- **Resampling «на лету».** Если для requested interval нет dataset'а — это ошибка (400 на backtest, runtime fallback на single-TF). Никаких автоматических `M1 → M5` агрегаций в этом документе.
+- **Cross-symbol bundles.** Bundle всегда — про один `symbol`. Корзины и портфели — отдельная архитектура.
+- **Изменения формата `MarketCandle` или `MarketDataset`.** Только additive поля на `Bot/BacktestSweep/WalkForwardRun`.
+- **Ускорение candle loader'а.** Текущий `findMany` остаётся; кэш — простой in-memory LRU (52-T2), без Redis/Bull.
+- **Изменение DSL-формата.** `sourceTimeframe` уже есть. Никаких новых DSL-узлов.
+- **Mixed-TF execution (open intent on M5, manage on M1).** Order management остаётся на основном TF бота; multi-TF используется только для **сигналов** и **фильтров**, не для exit timing.
+
+## Архитектурные решения
+
+### Решение 1: Bundle = Json field, не отдельная таблица
+
+`Bot.datasetBundleJson Json?` — формат:
+```ts
+type DatasetBundle = Partial<Record<CandleInterval, string | true>>;
+// например:
+//   { M5: "ds_abc", H1: "ds_def" }   — backtest / walk-forward (явные id)
+//   { M5: true, H1: true }           — runtime (просто список нужных интервалов)
+```
+
+Полу-структурированный JSON позволяет в одном поле выразить и режим runtime (где конкретный dataset не нужен — нужны свежие свечи из таблицы `MarketCandle`), и backtest-режим (где конкретные исторические данные обязательны). Альтернатива — два разных поля — делает схему шире без выгоды.
+
+### Решение 2: Bot имеет primary timeframe + bundle
+
+В `Bot.timeframe` остаётся «основной TF» (entry/exit timing). `datasetBundleJson` — **дополнительные** TF, которые подгружаются для evaluator'а, чтобы DSL-блоки с `sourceTimeframe` могли резолвить свои индикаторы. Если `datasetBundleJson` есть, `bot.timeframe` обязан в нём присутствовать.
+
+### Решение 3: `botWorker` не меняет state machine — расширяется только candle-loader
+
+`BotRunState` enum, polling cadence, intent emission — всё остаётся. Единственное изменение — в одном месте (`botWorker.ts:1467`) `findMany({ where: { symbol } })` заменяется на `loadCandleBundle(symbol, datasetBundleJson, lookbackBars)`, который возвращает `CandleBundle`. Дальше `evaluateDsl(dsl, latestCandle, bundle)` — bundle уже supported в evaluator (см. Контекст).
+
+### Решение 4: Backtest получает bundle опционально, default — single-TF
+
+`runBacktest(candles, dsl, opts)` остаётся как есть. Добавляется новая overload `runBacktest({ bundle, dsl, opts })`, где bundle — `Map<CandleInterval, MarketCandle[]>`. Внутри ядра выбирается primary TF (первый ключ или specified в opts.primaryInterval); итерация — по primary candles; в evaluator передаётся bundle с подкачкой LTF/HTF на каждом баре через уже существующий `intervalAlignment.ts` helper.
+
+### Решение 5: UI — pre-existing single-dataset select остаётся, добавляется «advanced»
+
+В Lab Test / Optimise / Walk-Forward панелях текущий dataset-select сохраняется как «primary». Появляется опциональная секция "+ Add timeframe" (раскрывающийся блок), где можно добавить ещё 1-2 интервала с явным `datasetId`. Минимум изменений UI; пользователь, не использующий MTF, не замечает разницы.
+
+---
+
+## Задачи
+
+### 52-T1: Поле `datasetBundleJson` в `Bot`, `BacktestSweep`, `WalkForwardRun`
+
+**Цель:** ввести nullable Json-колонку `datasetBundleJson` на трёх моделях. Чисто схема + миграция, без логики.
+
+**Файлы для изменения:**
+- `apps/api/prisma/schema.prisma` — модели `Bot`, `BacktestSweep`, `WalkForwardRun`.
+- `apps/api/prisma/migrations/<timestamp>_dataset_bundle/migration.sql`.
+- `apps/api/src/types/datasetBundle.ts` (создать) — общий TS-тип + zod-схема + helper-валидация.
+- `apps/api/tests/types/datasetBundle.test.ts`.
+
+**Шаги реализации:**
+1. В `schema.prisma` каждой из трёх моделей добавить:
+   ```prisma
+   datasetBundleJson Json?
+   ```
+2. Миграция: `ALTER TABLE "Bot" ADD COLUMN "datasetBundleJson" JSONB;` + аналогично для `BacktestSweep`, `WalkForwardRun`. Existing rows получают `NULL`.
+3. `types/datasetBundle.ts`:
+   ```ts
+   import { z } from "zod";
+   const CANDLE_INTERVALS = ["M1","M5","M15","M30","H1","H4","D1"] as const;
+   export const DatasetBundleSchema = z.record(
+     z.enum(CANDLE_INTERVALS),
+     z.union([z.string().min(1), z.literal(true)]),
+   ).refine(b => Object.keys(b).length >= 1 && Object.keys(b).length <= 4,
+     { message: "bundle must contain 1..4 intervals" });
+   export type DatasetBundle = z.infer<typeof DatasetBundleSchema>;
+   ```
+   Лимит 4 интервала — практический потолок (большинство TF combos из spec'ов: 2-3); защищает от потенциально дорогих join'ов в loader.
+4. Хелперы:
+   - `bundleHasInterval(b, i)`, `bundleIntervals(b)`, `bundlePrimaryDatasetId(b, primaryInterval)`.
+   - `validateBundleAgainstPrimary(b, primaryInterval)` — проверяет, что primary TF присутствует в bundle.
+5. **Никаких backfill'ов.** Все existing rows работают в legacy single-TF режиме.
+
+**Тест-план:**
+- `DatasetBundleSchema.parse({ M5: "ds_a", H1: "ds_b" })` → ok.
+- `parse({ M5: true })` → ok (runtime-форма).
+- `parse({})` → 0 keys, ошибка.
+- `parse({ M1:"a", M5:"b", M15:"c", M30:"d", H1:"e" })` → 5 keys, ошибка.
+- `parse({ X1: "ds" })` → unknown enum, ошибка.
+- `validateBundleAgainstPrimary({ M5: true }, "H1")` → ошибка (primary не в bundle).
+
+**Критерии готовности:**
+- Миграция additive, проходит на staging.
+- `tsc --noEmit` зелёный.
+- Existing тесты `Bot`/`BacktestSweep`/`WalkForwardRun` зелёные без правок.
+- Тип `DatasetBundle` экспортирован и используется во всех последующих T-задачах.
+
+---
+
+### 52-T2: Multi-interval candle loader + cache
+
+**Цель:** одна функция `loadCandleBundle(symbol, bundle, lookbackBars)`, возвращающая `CandleBundle` (`Map<CandleInterval, MarketCandle[]>`). Используется и runtime, и backtest.
+
+**Файлы для изменения:**
+- `apps/api/src/lib/mtf/loadCandleBundle.ts` (создать).
+- `apps/api/src/lib/mtf/intervalAlignment.ts` — экспортировать тип `CandleBundle` если ещё нет.
+- `apps/api/tests/lib/mtf/loadCandleBundle.test.ts`.
+
+**Шаги реализации:**
+1. Сигнатура:
+   ```ts
+   export async function loadCandleBundle(args: {
+     symbol: string;
+     bundle: DatasetBundle;
+     lookbackBars: number;          // сколько свечей на TF загрузить (head)
+     mode: "runtime" | "backtest";  // runtime → значения true OK; backtest → все ключи должны быть string
+     until?: Date;                   // для backtest — верхняя граница; runtime — undefined ⇒ now()
+   }): Promise<CandleBundle>;
+   ```
+2. Валидация: для `mode=backtest` каждое значение в bundle обязано быть string (datasetId). Для `mode=runtime` допустимы оба формата.
+3. Реализация:
+   - Для каждого `(interval, value) ∈ bundle`:
+     - `runtime` + `value=true`: `prisma.marketCandle.findMany({ where: { symbol, interval }, orderBy: { openTime: "desc" }, take: lookbackBars })`. Развернуть в ASC.
+     - `runtime` + `value=string`: то же + `datasetId: value`.
+     - `backtest`: `prisma.marketCandle.findMany({ where: { datasetId: value, openTime: { lte: until } }, orderBy: { openTime: "desc" }, take: lookbackBars })`.
+   - Параллельные запросы (`Promise.all`).
+4. **In-memory cache** (LRU, max 64 entries, TTL 30s для runtime; для backtest — без TTL, ключ включает `until` миллисекундами): защищает от спама на одну и ту же пару `(symbol, interval)` со множества ботов на одном symbol.
+5. Возврат: `Map<CandleInterval, MarketCandle[]>`. Для пустого результата интервала — пустой массив (downstream сам решит, fail-fast или skip).
+6. Лог-точка: `logger.debug({ symbol, intervals, totalCandles })` на каждый load — чтобы можно было увидеть в проде, что boтов реально использует MTF.
+
+**Тест-план:**
+- `runtime` + bundle `{M5: true, H1: true}` + symbol с свечами обоих интервалов → возвращает Map с двумя ключами, длины ≤ lookbackBars.
+- `backtest` + bundle `{M5: "ds_a", H1: "ds_b"}` → возвращает свечи именно из этих datasets, отсортированные ASC, верхняя граница `until` соблюдена.
+- `backtest` с bundle, где значение `true` → 400/throw.
+- Cache: два последовательных runtime-вызова с одинаковыми args в пределах 30s → вторая БД-операция не выполняется (mock prisma → assert call count).
+- Empty interval (нет свечей) → пустой массив, не throw.
+
+**Критерии готовности:**
+- Тесты зелёные.
+- Параллельные запросы реально параллельны (мок `findMany` с задержкой → суммарное время ≈ max, не sum).
+- Cache key корректно учитывает `until` для backtest.
+
+---
+
+### 52-T3: Runtime — `botWorker` загружает bundle и прокидывает в `dslEvaluator`
+
+**Цель:** `botWorker.ts` загружает `CandleBundle` (если `bot.datasetBundleJson != null`) и передаёт его в evaluator. Иначе — старое поведение.
+
+**Файлы для изменения:**
+- `apps/api/src/botWorker.ts` — заменить candle-load в районе строки 1467.
+- `apps/api/src/lib/signalEngine.ts`, `exitEngine.ts` — расширить вход `bundle?` если ещё не расширены.
+- `apps/api/src/lib/dslEvaluator.ts:749` — уже принимает bundle (см. Контекст), правок не требует.
+- `apps/api/tests/botWorker/multiTfBundle.test.ts` (создать) — integration.
+
+**Шаги реализации:**
+1. В `botWorker.ts` заменить:
+   ```ts
+   const candles = await prisma.marketCandle.findMany({ where: { symbol } });
+   ```
+   на:
+   ```ts
+   const bundle = bot.datasetBundleJson
+     ? await loadCandleBundle({
+         symbol: bot.symbol,
+         bundle: DatasetBundleSchema.parse(bot.datasetBundleJson),
+         lookbackBars: 500, // existing constant or config
+         mode: "runtime",
+       })
+     : null;
+
+   const primaryCandles = bundle
+     ? bundle.get(bot.timeframe) ?? []
+     : await prisma.marketCandle.findMany({ where: { symbol, interval: bot.timeframe }, orderBy: { openTime: "desc" }, take: 500 }).then(rows => rows.reverse());
+   ```
+   Заметка: ставим `interval: bot.timeframe` даже в legacy-ветке — это **bugfix** существующего поведения (текущий код не фильтрует по interval вообще, что уже неправильно). Bugfix локализован: behaviour single-TF ботов становится строже-корректным; в редких случаях, когда у symbol было несколько интервалов в `MarketCandle` и стратегия молча работала на смешанных данных, это начинает падать или возвращать пусто. Отметить отдельным риском в PR-описании, дать миграционную инструкцию (запустить datasource sync для нужного TF).
+2. Передача в evaluator: `signalEngine.evaluate({ candles: primaryCandles, bundle, dsl, ...rest })`. `bundle` — необязательный аргумент; если evaluator его не получает (старый вызов), DSL-узлы с `sourceTimeframe ≠ bot.timeframe` должны фейлить с явной ошибкой "indicator requires multi-TF bundle" (это уже должно быть в evaluator; если нет — добавить охранник).
+3. Аналогично — `exitEngine.evaluate(...)` и `positionManager` (если он трогает индикаторы).
+4. Polling cadence: bundle перезагружается каждый tick (current cadence); cache из 52-T2 предотвращает БД-нагрузку при множественных ботов.
+5. Если `loadCandleBundle` throws (например, нет свечей для одного из TF) — bot run помечается `ERRORED` через существующий `errorClassifier` flow; не падает безмолвно.
+
+**Тест-план:**
+- Bot без `datasetBundleJson` → legacy-ветка, поведение идентично текущему (после фикса interval-фильтра).
+- Bot с bundle `{M5: true, H1: true}`, `timeframe=M5` → evaluator получает bundle, MTF-индикаторы резолвятся корректно.
+- Bot с bundle, в котором нет `bot.timeframe` → ошибка валидации на старте (не запускается).
+- Bot с bundle, в котором отсутствуют свечи для H1 (например, H1-датасорс отключён) → bot run → ERRORED, понятный message.
+
+**Критерии готовности:**
+- `botWorker.ts` тесты зелёные.
+- Multi-TF integration test зелёный.
+- Legacy single-TF боты работают без изменений (одна оговорка про interval-фильтр выше).
+- В логах появляются bundle-метаданные (можно отключить с `LOG_LEVEL=info`).
+
+---
+
+### 52-T4: Backtest — `runBacktest` принимает bundle
+
+**Цель:** `runBacktest` поддерживает bundle-режим. Sweep / walk-forward / lab-test endpoints прокидывают bundle сквозь.
+
+**Файлы для изменения:**
+- `apps/api/src/lib/backtest/runBacktest.ts` — overload + новая ветка.
+- `apps/api/src/routes/lab.ts` — `POST /lab/backtest`, `POST /lab/backtest/sweep`, `POST /lab/walk-forward` принимают `datasetBundleJson` опционально.
+- `apps/api/tests/lib/backtest/multiTf.test.ts`.
+
+**Шаги реализации:**
+1. Сигнатура `runBacktest`:
+   ```ts
+   // legacy:
+   runBacktest(candles: MarketCandle[], dsl, opts): Promise<DslBacktestReport>
+   // new:
+   runBacktest({ bundle, primaryInterval, dsl, opts }: {
+     bundle: CandleBundle;
+     primaryInterval: CandleInterval;
+     dsl: DslJson;
+     opts: DslExecOpts;
+   }): Promise<DslBacktestReport>
+   ```
+   Различение через discriminated tuple (массив-аргумент = legacy; объект = new). Внутри новой ветки итерация — по `bundle.get(primaryInterval)`; для каждой primary-свечи в evaluator передаётся snapshot bundle, обрезанный по `openTime <= primary.openTime`. Реализация обрезки — через существующий `intervalAlignment.ts` helper (важно: HTF свеча может быть «незакрыта» относительно primary; правило закрытия HTF на момент primary-bar — `htf.openTime + htfDuration <= primary.openTime`; иначе берётся last closed HTF candle).
+2. **Look-ahead bias guard.** Каждый шаг evaluator должен видеть только закрытые HTF candles. Это критическая корректность для backtest и walk-forward; добавить unit-тест с фикстурой, где «открытая» HTF candle сознательно содержит «будущие» данные — evaluator не должен их видеть.
+3. `routes/lab.ts`:
+   - `POST /lab/backtest`: если body содержит `datasetBundleJson`, валидировать через `DatasetBundleSchema`, проверить `validateBundleAgainstPrimary(bundle, primaryInterval)`, загрузить через `loadCandleBundle(mode="backtest")` и вызвать новый overload. Если нет — старая ветка.
+   - `POST /lab/backtest/sweep` (`apps/api/src/routes/lab.ts:838`): сохранить `datasetBundleJson` в `BacktestSweep`. В `runSweepAsync` для каждой комбинации параметров — если bundle задан, `loadCandleBundle` один раз перед циклом (как сейчас делается для single dataset, см. `docs/47 §47-T3 шаг 1`), затем `runBacktest({ bundle, ... })`. Это ровно тот же паттерн, что у текущего кода — bundle-load заменяет single dataset-load.
+   - `POST /lab/walk-forward`: аналогично, `datasetBundleJson` передаётся в `WalkForwardRun.create`, fold-runner подгружает bundle с обрезанным `until` per-fold.
+4. Backward compat: ни один существующий клиент не ломается — `datasetBundleJson` опционален во всех body.
+
+**Тест-план:**
+- Single-TF backtest: legacy-вызов работает без правок.
+- Multi-TF backtest на готовой fixture (например, M5+H1 для AdaptiveRegime sample) → результат детерминирован, метрики совпадают с golden run.
+- Look-ahead guard: фикстура с «загрязнённой» HTF candle → evaluator не видит её, метрики совпадают с теми, что без загрязнения.
+- Sweep с bundle → все runs используют тот же bundle, результаты различны только по параметрам.
+- Walk-forward с bundle: каждый fold honors `until` boundary.
+
+**Критерии готовности:**
+- Multi-TF tests зелёные.
+- Существующие single-TF тесты `lab.test.ts` зелёные.
+- В `BacktestSweep` / `WalkForwardRun` записях `datasetBundleJson` корректно сохраняется и читается обратно.
+
+---
+
+### 52-T5: Lab UI — мульти-датасет селектор для Test / Optimise / Walk-Forward
+
+**Цель:** на страницах Lab Test / Optimise / Walk-Forward добавить опциональный multi-interval селектор поверх существующего single-dataset селекта.
+
+**Файлы для изменения:**
+- `apps/web/src/app/lab/test/TestPanel.tsx` (или эквивалент).
+- `apps/web/src/app/lab/test/OptimisePanel.tsx`.
+- `apps/web/src/app/lab/walk-forward/WalkForwardPanel.tsx` (см. `docs/48-T6`).
+- `apps/web/src/app/lab/_shared/DatasetBundleSelector.tsx` (создать) — переиспользуемый компонент.
+
+**Шаги реализации:**
+1. `DatasetBundleSelector`:
+   - Props: `primaryDatasetId: string`, `bundle: DatasetBundle | null`, `onChange(bundle: DatasetBundle | null): void`, `availableDatasets: { id, symbol, interval }[]`.
+   - Стандартное состояние: `bundle === null` (legacy single-TF).
+   - При клике "+ Add timeframe" появляется строка с двумя селектами: interval и dataset (отфильтрованный по `symbol === primaryDataset.symbol && interval === selected`).
+   - Максимум 3 строк дополнительных TF (4 total включая primary).
+   - При первом добавлении автоматически создаётся bundle: `{ [primary.interval]: primary.id, [newInterval]: newDatasetId }`.
+2. В `TestPanel` подключить selector рядом с существующим dataset-select. Кнопка "Run backtest" отправляет `datasetBundleJson` в body, если bundle != null; иначе — старый `datasetId`.
+3. В `OptimisePanel` — то же. Sweep с bundle сохраняется в `BacktestSweep.datasetBundleJson`, переотображается на load.
+4. В `WalkForwardPanel` — то же.
+5. UX-требования:
+   - Если у пользователя нет datasets для нужного `(symbol, interval)` — селектор интервалов помечает их disabled с подсказкой "No dataset available for this TF. Sync M5/H1/etc data first."
+   - Все `availableDatasets` грузятся через существующий API, без новых endpoints.
+6. Никаких изменений в Library page (51-T5) — там `datasetBundleHintJson` пресета используется чисто как информационная подсказка для пользователя, фактический bundle для бота настраивается на странице бота.
+
+**Тест-план:**
+- Ручной smoke: запустить backtest на single TF — поведение прежнее.
+- Добавить второй TF, dataset для него существует — backtest стартует, в logs API видно `loadCandleBundle` с двумя ключами.
+- Добавить второй TF, dataset не существует → кнопка disabled.
+- Walk-forward с bundle → folds корректно используют bundle (см. 52-T4 тесты).
+
+**Критерии готовности:**
+- TS-проверка фронта зелёная.
+- Существующие e2e (если есть) зелёные.
+- Smoke в браузере подтверждён в PR-описании.
+
+---
+
+### 52-T6: Тесты — unit + e2e на multi-TF strategy
+
+**Цель:** объединённое покрытие — unit для loader, evaluator с bundle, look-ahead guard; интеграционный e2e «реальная стратегия с MTF DSL → backtest → ожидаемые метрики».
+
+**Файлы для изменения:**
+- `apps/api/tests/lib/mtf/loadCandleBundle.test.ts` (создан в T2).
+- `apps/api/tests/lib/backtest/multiTf.test.ts` (создан в T4).
+- `apps/api/tests/integration/multiTfBacktestFlow.test.ts` (создать) — e2e через `POST /lab/backtest`.
+- `apps/api/tests/lib/dslEvaluator/bundleSourceTimeframe.test.ts` (создать или дополнить).
+
+**Шаги реализации:**
+1. **Look-ahead guard fixture.** Сгенерировать M5 свечи на 1 день (288 candles) и H1 (24). Для каждой пары (M5_i, H1_j) проверить: `evaluateExpression(...)` на M5_i видит только те H1_j, у которых `closeTime <= M5_i.openTime`. Тест-кейс — индикатор `RSI(14) on H1`: его значение в момент M5_42 должно совпадать с тем, что было бы посчитано на «обрезанном» H1-наборе.
+2. **MTF strategy e2e.** Минимальный DSL с двумя блоками:
+   ```json
+   {
+     "enter_when": {
+       "and_gate": [
+         { "compare": { "left": { "indicator": "rsi", "sourceTimeframe": "M5" }, "op": "<", "right": 30 } },
+         { "compare": { "left": { "indicator": "ema", "params": {"period": 200}, "sourceTimeframe": "H1" }, "op": "<", "right": { "candle": "close" } } }
+       ]
+     },
+     "exit_when": { "compare": { "left": { "indicator": "rsi", "sourceTimeframe": "M5" }, "op": ">", "right": 70 } }
+   }
+   ```
+   Backtest на фикстуре с известным числом сигналов → проверить `report.tradeCount` и сравнить с golden value.
+3. **Backward-compat suite.** Тот же DSL без `sourceTimeframe` (всё на primary TF) → backtest работает без bundle, метрики совпадают с pre-52 backtest того же DSL на тех же candles.
+4. Все фикстуры — статические JSON, в репо. Никаких HTTP-вызовов / времени выполнения.
+
+**Тест-план:**
+- `npm test` (apps/api) проходит локально и в CI.
+- Существующие тесты (`lab.test.ts`, `botWorker/*.test.ts`, `dslEvaluator/*.test.ts`) — зелёные.
+- Покрытие новых файлов ≥ 80%.
+
+**Критерии готовности:**
+- Все новые тесты зелёные.
+- Look-ahead guard — отдельный явный тест-кейс с комментарием, ссылающимся на этот документ.
+- E2E `multiTfBacktestFlow.test.ts` — golden numbers зашиты, регрессия сразу красит.
+
+---
+
+## Порядок выполнения задач
+
+```
+52-T1 ──→ 52-T2 ──┬──→ 52-T3 ──┐
+                  ├──→ 52-T4 ──┤
+                  │             ├──→ 52-T6
+                  └──→ 52-T5 ──┘
+```
+
+- 52-T1 (схема + типы) — первая.
+- 52-T2 (loader) — после T1, потому что loader использует `DatasetBundleSchema`.
+- 52-T3 (runtime) и 52-T4 (backtest) — независимы между собой, но оба требуют T2.
+- 52-T5 (UI) — может стартовать параллельно с T3/T4, но интеграция с реальным backendom требует T4.
+- 52-T6 (тесты) — встраивается инкрементально + финальный e2e в конце.
+
+Каждая T-задача — отдельный PR. T3 и T4 поджимаются по приоритету: T4 нужнее для acceptance gate в `docs/53`/`docs/54` (walk-forward на multi-TF), поэтому идёт раньше T3 если дефицит времени.
+
+## Зависимости от других документов
+
+- `docs/50` — родительский. Особенно `§Решение 2`: bundle = JSON, не таблица.
+- `docs/51-strategy-preset-system.md` — независим. `StrategyPreset.datasetBundleHintJson` — просто метаданные пресета; сам preset-flow не требует 52.
+- `docs/53-adaptive-regime-bot-activation.md` — потребитель. Adaptive Regime использует bundle `{M5: ..., H1: ...}`.
+- `docs/54-flagship-rollout.md` — потребитель. MTF Scalper использует `{M1, M5, M15}`, SMC — `{M15, H1, H4}`. DCA — single-TF, не требует 52.
+- `docs/47-strategy-optimizer-plan.md` — закрыт. Sweep с bundle = небольшое расширение `runSweepAsync` (см. 52-T4 §3).
+- `docs/48-walk-forward-plan.md` — закрыт. Fold-runner с bundle = аналогично, расширение `WalkForwardRun` без правки логики split.
+- `docs/strategies/05-mtf-scalper.md`, `docs/strategies/03-adaptive-regime-bot.md` — concept-доки потребителей.
+
+## Backward compatibility checklist
+
+- Все Prisma миграции — additive nullable Json колонки. Existing rows получают `NULL`.
+- `Bot.datasetBundleJson === null` → legacy single-TF поведение. Все существующие боты живут без правок.
+- `BacktestSweep.datasetBundleJson === null` → старый sweep на одном dataset.
+- `WalkForwardRun.datasetBundleJson === null` → старый walk-forward.
+- `runBacktest(candles, dsl, opts)` — legacy сигнатура остаётся работать. Новая overload вызывается явно объектным аргументом.
+- `dslEvaluator` — bundle всегда был optional, никаких ломающих правок.
+- Lab UI без раскрытия "+ Add timeframe" работает идентично текущему — тот же single-dataset-select, тот же flow.
+- Замена `findMany({ where: { symbol } })` → `findMany({ where: { symbol, interval } })` в `botWorker.ts` — это **bugfix**, может изменить поведение в редких случаях; помечено отдельным риском в PR-описании 52-T3.
+- `MarketCandle`, `MarketDataset`, `BotIntent`, `BotRunState` — без изменений.
+
+## Ожидаемый результат
+
+После закрытия 52-T1..52-T6:
+
+- DSL-стратегии могут декларировать `sourceTimeframe` на любом блоке, и это работает в runtime, в `runBacktest`, в sweep, в walk-forward.
+- Bot/BacktestSweep/WalkForwardRun хранят bundle в одном Json-поле; миграций не больше, чем нужно.
+- Look-ahead bias guard явно протестирован — multi-TF backtest корректен даже на стрессовых фикстурах.
+- Lab UI позволяет добавить до 3 дополнительных интервалов к выбранному dataset одной кнопкой.
+- Adaptive Regime, MTF Scalper, SMC Liquidity Sweep получают рабочий слой данных, на котором их acceptance gates имеет смысл (без bundle их нельзя честно протестировать).
+- Single-TF DCA Momentum (`docs/54`) — никак не затронут; bundle не вводится в его flow.

--- a/docs/53-adaptive-regime-bot-activation.md
+++ b/docs/53-adaptive-regime-bot-activation.md
@@ -1,0 +1,362 @@
+# 53. Adaptive Regime Bot — End-to-End Activation
+
+Статус: draft  
+Владелец: core trading / lab  
+Последнее обновление: 2026-04-30  
+Родительский документ: `docs/50-flagship-activation-plan.md`  
+Связанный спек: `docs/strategies/03-adaptive-regime-bot.md`
+
+## Контекст
+
+Текущее состояние (проверено по коду):
+
+- Concept-документ стратегии — `docs/strategies/03-adaptive-regime-bot.md`. Идея: на M5 entry под управлением SuperTrend, фильтр по тренду на H1 (EMA200 + ADX), Bollinger reversion как контр-сигнал в режиме flat.
+- В нём упомянуты «composite signal types»: `"supertrend_direction"`, `"bb_rsi_reversion"`, `"supertrend_flip_or_bb_midline"`. В DSL evaluator таких отдельных типов **нет** — это синтетические high-level имена в исходной спецификации (см. `docs/50 §Решение 3`).
+- В `apps/api/src/lib/compiler/supportMap.ts` все необходимые блоки supported: `supertrend`, `ema`, `adx`, `bollinger_bands`, `compare`, `cross`, `and_gate`, `or_gate`, `enter_when`, `exit_when`. Capability matrix — `docs/strategies/08-strategy-capability-matrix.md`.
+- Pre-existing seed для `adaptive-regime` пресета — заглушка из `docs/51-T6` (минимальный валидный DSL); финальный DSL фиксируется в этом документе.
+- Multi-TF runtime/backtest — обеспечивается `docs/52`. Bundle `{M5, H1}`.
+- Walk-forward — `docs/48`, инструмент готов.
+- Demo smoke harness — отсутствует. Никаких автоматизированных «запустить бот на Bybit demo на N минут» сценариев сейчас нет; есть только unit + integration.
+- Bybit demo execution — работает через существующий `bybitOrder.ts` с `BYBIT_USE_DEMO=true` env; `category: "linear"`. Spot не требуется.
+
+## Цель
+
+Довести `adaptive-regime` пресет до состояния `PUBLIC` в Lab Library — первая end-to-end активация флагмана. Конкретно:
+
+1. Финальный, валидный DSL для `adaptive-regime`, целиком составленный из 33 supported блоков. Никаких composite signal types; никакого расширения evaluator.
+2. Golden walk-forward acceptance: на 6+ folds показывает `pnl > 0`, `sharpe > 0.3`, `maxDrawdown > -25%` (acceptance gate из `docs/50 §A5`).
+3. Demo smoke: бот, созданный через `POST /presets/adaptive-regime/instantiate`, работает на Bybit demo 30+ минут без unhandled runtime errors; intents идут до demo endpoint'ов.
+4. После прохождения 1-3 — admin переводит preset из `PRIVATE` в `PUBLIC` и он появляется в `/lab/library`.
+5. Capability matrix и concept doc обновлены: композитные имена сигналов помечены как «реализовано через примитивы DSL»; в matrix добавлена строка `adaptive-regime: implemented`.
+
+После закрытия 53 у нас есть **рабочий первый флагман в галерее** — это валидация всего стека (preset + bundle + acceptance + go/no-go gate).
+
+## Не входит в задачу
+
+- **Live trading.** Demo only. Перевод `BYBIT_ALLOW_LIVE` для пользователя — отдельный gate-doc (`docs/50 T10 в docs/54`), не часть этого документа.
+- **Параметр-tuning через AI.** Параметры SuperTrend/EMA/ADX в DSL фиксируются как baseline; further optimization через Lab → Optimise (на основе `docs/47`) — отдельные эксперименты пользователя.
+- **Multi-symbol Adaptive Regime.** Один бот = один symbol (по умолчанию `BTCUSDT`). Раскат на ETH/SOL — после go/no-go gate, отдельным шагом.
+- **Перепроектирование SuperTrend / Bollinger индикаторов.** Используем существующие реализации `apps/api/src/lib/indicators/`.
+- **Изменения runtime safety / error classifier'а.** Существующий `safety/*` slice достаточен.
+- **Live order routing changes.** Никаких правок `bybitOrder.ts`.
+- **Реальные финансовые гарантии.** Acceptance — статистическое условие. «Стратегия может работать в demo» ≠ «стратегия принесёт прибыль на live».
+
+## Архитектурные решения
+
+### Решение 1: DSL целиком через примитивы
+
+Каждый высокоуровневый «сигнал» из concept doc развёртывается:
+
+- `supertrend_direction(M5)` → `{ "indicator": "supertrend", "params": {...}, "sourceTimeframe": "M5", "field": "direction" }`. Comparison: `compare(direction, "==", 1)`.
+- `bb_rsi_reversion` → `and_gate([ compare(close, "<", bb.lower), compare(rsi(14), "<", 30) ])`.
+- `supertrend_flip_or_bb_midline` → `or_gate([ cross(supertrend.direction, "flip"), cross(close, "==", bb.middle) ])`.
+
+Семантика flip: используем существующий `cross`-блок с режимом `direction_change` (если такой supported; иначе явный `compare(direction[t], "!=", direction[t-1])` через `prev` accessor — проверить в `supportMap.ts`).
+
+Все эти конструкции — комбинации supported блоков. Никаких новых типов в evaluator.
+
+### Решение 2: Bundle `{M5, H1}`, primary M5
+
+`Bot.timeframe = "M5"` (entry/exit); `datasetBundleJson = { M5: ..., H1: ... }` (см. `docs/52`). Все DSL-блоки с `sourceTimeframe="H1"` работают на H1-стороне bundle; основная итерация — по M5.
+
+### Решение 3: Acceptance gate — golden DSL + walk-forward + demo smoke
+
+Тройка условий из `docs/50 §A5`. Каждое — отдельная T-задача (T1, T2, T3). Только когда все три зелёные, T4 переводит preset в `PUBLIC`. Это явный, проверяемый barrier; ни одно из условий не может быть проигнорировано.
+
+### Решение 4: Demo smoke — отдельный harness, не unit-тест
+
+Demo smoke — это не тест в классическом смысле (не блокирует CI). Это harness-скрипт `apps/api/scripts/demoSmoke.ts`, который запускает реальный `Bot` на Bybit demo через стандартный flow (POST `/presets/.../instantiate` → POST `/bots/:id/start`), мониторит intent-flow в БД и unhandled errors в логах. По истечении интервала (default 30 минут) выдаёт отчёт. Ручной запуск перед T4. Опционально — настраивается под cron/cloud для regression tracking; это out-of-scope текущего документа.
+
+---
+
+## Задачи
+
+### 53-T1: Финальный DSL `adaptive-regime` через примитивы (golden fixture)
+
+**Цель:** заменить заглушку из `docs/51-T6` на финальный DSL `adaptive-regime` через 33 supported блока. Зафиксировать как golden fixture для тестов.
+
+**Файлы для изменения:**
+- `apps/api/prisma/seed/presets/adaptive-regime.json` — финальный DSL.
+- `apps/api/tests/fixtures/strategies/adaptive-regime.golden.json` (создать) — копия для тестов.
+- `apps/api/tests/lib/compiler/adaptiveRegime.test.ts` (создать) — DSL компилируется, нет unsupported блоков.
+
+**Шаги реализации:**
+1. Раскрыть три композитных сигнала из concept doc через примитивы (см. §Решение 1). Итог — структура примерно:
+   ```jsonc
+   {
+     "version": "v2",
+     "primaryTimeframe": "M5",
+     "datasetBundleHint": { "M5": true, "H1": true },
+     "enter_when": {
+       "or_gate": [
+         {
+           "and_gate": [
+             { "compare": { "left": { "indicator": "supertrend", "params": {"period": 10, "multiplier": 3.0}, "sourceTimeframe": "M5", "field": "direction" }, "op": "==", "right": 1 } },
+             { "compare": { "left": { "candle": "close" }, "op": ">", "right": { "indicator": "ema", "params": {"period": 200}, "sourceTimeframe": "H1" } } },
+             { "compare": { "left": { "indicator": "adx", "params": {"period": 14}, "sourceTimeframe": "H1" }, "op": ">", "right": 20 } }
+           ]
+         },
+         {
+           "and_gate": [
+             { "compare": { "left": { "candle": "close" }, "op": "<", "right": { "indicator": "bollinger_bands", "params": {"period": 20, "stdDev": 2}, "sourceTimeframe": "M5", "field": "lower" } } },
+             { "compare": { "left": { "indicator": "rsi", "params": {"period": 14}, "sourceTimeframe": "M5" }, "op": "<", "right": 30 } },
+             { "compare": { "left": { "indicator": "adx", "params": {"period": 14}, "sourceTimeframe": "H1" }, "op": "<", "right": 20 } }
+           ]
+         }
+       ]
+     },
+     "exit_when": {
+       "or_gate": [
+         { "compare": { "left": { "indicator": "supertrend", "params": {"period": 10, "multiplier": 3.0}, "sourceTimeframe": "M5", "field": "direction" }, "op": "==", "right": -1 } },
+         { "cross": { "left": { "candle": "close" }, "op": "above", "right": { "indicator": "bollinger_bands", "params": {"period": 20, "stdDev": 2}, "sourceTimeframe": "M5", "field": "middle" } } }
+       ]
+     },
+     "stopLoss": { "type": "atr", "atrPeriod": 14, "multiplier": 2.0 },
+     "takeProfit": { "type": "rr", "ratio": 2.0 }
+   }
+   ```
+   Конкретные значения параметров — baseline из concept doc; могут варьироваться, golden fixture фиксирует именно эту версию.
+2. Все блоки и поля проверяются `compileDsl` в тесте; если evaluator не поддерживает какое-то из обращений (например, `bollinger_bands.field=middle`) — это блокер, открывается follow-up T-задача на расширение конкретного блока (не на введение composite signal type).
+3. `defaultBotConfigJson` в seed-файле:
+   ```json
+   {
+     "symbol": "BTCUSDT",
+     "timeframe": "M5",
+     "quoteAmount": 100,
+     "maxOpenPositions": 1,
+     "leverage": 3
+   }
+   ```
+4. Golden fixture (`tests/fixtures/.../golden.json`) — точная копия dslJson из seed-файла, импортируется тестами compiler / evaluator / backtest. При любом изменении DSL — golden обновляется явным diff'ом в PR.
+
+**Тест-план:**
+- `compileDsl(adaptiveRegime.golden.json)` → ok, нет ошибок.
+- `evaluateDsl` на синтетической M5+H1 фикстуре с заведомо trend-up условиями → возвращает entry signal на ожидаемом баре.
+- `evaluateDsl` на flat фикстуре с touch lower BB + rsi<30 → возвращает entry signal по второй ветке.
+- `evaluateDsl` на flat без оверсолда → нет signal.
+
+**Критерии готовности:**
+- DSL компилируется.
+- Никаких composite signal types — все блоки находятся в `supportMap.ts` со статусом `supported`.
+- Golden fixture зафиксирована, тесты её используют.
+
+---
+
+### 53-T2: Backtest baseline + walk-forward acceptance run
+
+**Цель:** прогнать DSL из 53-T1 через backtest на реальных данных + walk-forward. Зафиксировать baseline-метрики и acceptance result.
+
+**Файлы для изменения:**
+- `apps/api/scripts/runAdaptiveRegimeBaseline.ts` (создать) — orchestration script.
+- `apps/api/tests/fixtures/datasets/adaptive-regime/M5.json`, `H1.json` (создать или ссылка на seeded MarketDataset).
+- `apps/api/prisma/seed/datasets/adaptive-regime-fixture.ts` (создать) — seed M5+H1 свечей для воспроизводимого backtest.
+- `docs/53-baseline-results.md` (создать как companion) — фиксация конкретных чисел.
+
+**Шаги реализации:**
+1. **Dataset fixture.** Не зависим от Bybit live history: используем зашитые JSON-файлы со свечами (минимум 6 месяцев M5 = ~52K свечей; H1 = ~4.3K). Источник — экспорт из существующего `MarketDataset` либо детерминированный generator (для unit-тестов; для baseline — реальные данные через одноразовый sync).
+2. **Baseline backtest.**
+   - `loadCandleBundle({ bundle: { M5: <id>, H1: <id> }, mode: "backtest" })`.
+   - `runBacktest({ bundle, primaryInterval: "M5", dsl: golden, opts: { feeBps: 6, slippageBps: 1, fillAt: "NEXT_OPEN" } })`.
+   - Зафиксировать: `tradeCount`, `winRate`, `pnlPct`, `sharpe`, `profitFactor`, `expectancy`, `maxDrawdownPct` в companion-doc.
+3. **Walk-forward.**
+   - Использовать существующий `walkForward/run.ts` (`docs/48`).
+   - Split: 6 folds, train 4 месяца / test 1 месяц, expanding window.
+   - Acceptance критерии (`docs/50 §A5`):
+     - На каждом fold: `pnlPct > 0`.
+     - Aggregated `sharpe > 0.3`.
+     - Aggregated `maxDrawdownPct > -25%` (то есть DD не глубже 25%).
+   - Если хотя бы один критерий не выполнен — T2 не закрыт. Варианты: tune baseline params (вручную через Lab → Optimise) и переделать walk-forward; или зафиксировать gap и эскалировать в `docs/50` (возможно, спека стратегии слишком оптимистична). Документ `docs/53-baseline-results.md` фиксирует и положительные, и отрицательные результаты.
+4. Скрипт идемпотентен: можно перезапускать, результаты пишутся в companion-doc с timestamp.
+
+**Тест-план:**
+- Запуск скрипта → отчёт сгенерирован в companion-doc.
+- Walk-forward все folds зелёные → acceptance pass.
+- Любой fold красный → acceptance fail, документировано в companion-doc, T2 не закрыт.
+
+**Критерии готовности:**
+- Baseline metrics зафиксированы в `docs/53-baseline-results.md`.
+- Walk-forward acceptance pass подтверждён (или иначе явно эскалирован).
+- Walk-forward результат сохранён в `WalkForwardRun` записи; `walkForwardRunId` упомянут в companion-doc.
+- Никаких изменений в производственной БД — все данные на тестовом workspace.
+
+---
+
+### 53-T3: Demo smoke harness — 30-минутный прогон на Bybit demo
+
+**Цель:** скрипт `demoSmoke.ts`, запускающий Adaptive Regime бот на Bybit demo, мониторящий поток intent'ов и unhandled errors в течение 30+ минут.
+
+**Файлы для изменения:**
+- `apps/api/scripts/demoSmoke.ts` (создать) — generic harness, параметризуется `presetSlug`.
+- `apps/api/scripts/demoSmoke.adaptiveRegime.ts` (создать) — тонкая обёртка с `presetSlug="adaptive-regime"`.
+- `docs/53-baseline-results.md` — добавить раздел «Demo smoke run».
+
+**Шаги реализации:**
+1. Параметры (env / args):
+   - `BYBIT_USE_DEMO=true` — обязательно.
+   - `BYBIT_API_KEY_DEMO`, `BYBIT_API_SECRET_DEMO` — берутся из существующего `ExchangeConnection` записи workspace'а (script использует тот же loader, что runtime).
+   - `--duration-min` (default 30).
+   - `--symbol` (default `BTCUSDT`).
+2. Алгоритм:
+   1. POST `/presets/adaptive-regime/instantiate` с `{ workspaceId, overrides: { symbol, quoteAmount: 50 /* минимум для demo */ } }`.
+   2. POST `/bots/:id/start`.
+   3. Запуск polling-loop в скрипте: каждые 60s читать `BotIntent` count, `BotRunState`, последние ошибки из существующего error-log таблицы (`BotError` или эквивалент в текущем коде — проверить).
+   4. По истечении `duration-min`: POST `/bots/:id/stop`. Финальный отчёт.
+3. Acceptance условия для T3:
+   - `BotRunState` за весь период != `ERRORED`.
+   - Хотя бы 1 `BotIntent` сгенерирован (это не требование к торговому результату — это проверка, что polling реально вызывает evaluator). Если 0 интентов за 30 минут — это red flag по DSL (либо рынок строго flat без сигналов, либо баг). Помечается warning, не failure; принимается решение запустить ещё раз / увеличить duration.
+   - 0 unhandled errors в logs.
+   - Bybit demo endpoints отвечают 200 OK (нет 401/403/429 sustained).
+4. Отчёт пишется в companion-doc + полная копия логов (за минусом секретов) сохраняется в `apps/api/scripts/.smoke-output/<timestamp>.log`. `.smoke-output/` добавляется в `.gitignore`.
+5. Запуск — ручной, перед T4. Не часть CI.
+
+**Тест-план:**
+- Скрипт запускается локально / на staging-сервере с настроенными demo credentials.
+- Через 30+ минут отчёт сохранён, acceptance условия проверены.
+- Если acceptance не выполнено — T3 не закрыт, разбираем root cause; не «закрываем глаза».
+
+**Критерии готовности:**
+- Скрипт работает, отчёт за один полный run сохранён.
+- В companion-doc раздел «Demo smoke run» содержит дату, длительность, intent count, ссылка на лог-файл (или его статус-summary).
+- В логах нет unhandled errors / Bybit auth issues.
+- Решение «proceed to T4» зафиксировано подписью владельца документа в companion-doc.
+
+---
+
+### 53-T4: Visibility flip: PRIVATE → PUBLIC + публикация в Lab Library
+
+**Цель:** перевод preset из `PRIVATE` в `PUBLIC` после прохождения T1+T2+T3. Появление карточки в `/lab/library`.
+
+**Файлы для изменения:**
+- `apps/api/scripts/publishPreset.ts` (создать) — admin-only утилита, обновляющая `visibility`.
+- `docs/53-baseline-results.md` — раздел «Visibility flip».
+
+**Шаги реализации:**
+1. Скрипт принимает аргументы `--slug adaptive-regime --visibility PUBLIC`. Проверки внутри:
+   - Существует preset с таким slug.
+   - В companion-doc `docs/53-baseline-results.md` указано "Acceptance: PASS" (через простой grep по конкретной строке-маркеру). Это охранник от случайной публикации без acceptance. Если маркера нет — скрипт просит явный `--force` и логирует warning.
+   - Запись в audit-log (существующая `AuditLog` таблица или просто `console.log` + persistent file `apps/api/.publish-audit.log`).
+2. После update: открыть `/lab/library` (вручную), убедиться, что карточка появилась.
+3. Никакой автоматизации публикации в CI — это сознательно ручной шаг с проверкой.
+4. Откат: `--visibility PRIVATE` через тот же скрипт. Это восстанавливает PRIVATE без удаления preset'а / связанных ботов.
+
+**Тест-план:**
+- Запуск без acceptance-маркера → warning, требуется `--force`.
+- Запуск с маркером → preset переведён в `PUBLIC`.
+- `GET /presets` без auth → возвращает `adaptive-regime`.
+- `GET /lab/library` в браузере → карточка видна.
+- Откат `--visibility PRIVATE` → карточка исчезает.
+
+**Критерии готовности:**
+- `adaptive-regime` в `PUBLIC`, виден в Lab Library.
+- В audit-log запись с timestamp и admin-ID.
+- В companion-doc раздел «Visibility flip» с timestamp.
+
+---
+
+### 53-T5: Capability matrix update + concept doc cross-link
+
+**Цель:** обновить capability matrix (`docs/strategies/08-strategy-capability-matrix.md`) и concept doc (`docs/strategies/03-adaptive-regime-bot.md`).
+
+**Файлы для изменения:**
+- `docs/strategies/08-strategy-capability-matrix.md` — добавить строку `adaptive-regime: implemented` (или эквивалент для текущего формата матрицы).
+- `docs/strategies/03-adaptive-regime-bot.md` — добавить раздел «Реализация», ссылающийся на этот документ + golden fixture; явно отметить, что composite signal types из исходного спека развёрнуты через примитивы.
+- `docs/16-roadmap.md` — отметить Adaptive Regime как `delivered` в Post-MVP секции.
+
+**Шаги реализации:**
+1. Открыть текущую матрицу, понять формат (строки = стратегии, колонки = блоки / индикаторы / статус). Найти строку для Adaptive Regime, проставить статус `implemented` или эквивалент. Если строки нет — добавить.
+2. В `03-adaptive-regime-bot.md` в начале документа после headline добавить блок:
+   > **Implementation status:** delivered as `adaptive-regime` preset (`docs/53`). DSL: `apps/api/prisma/seed/presets/adaptive-regime.json`. Golden fixture: `apps/api/tests/fixtures/strategies/adaptive-regime.golden.json`. Composite signal types из исходной спеки развёрнуты через примитивы DSL — см. `docs/53 §Решение 1`.
+3. В `docs/16-roadmap.md` — обновить статус первого флагмана. Без подробных правок остальных пунктов.
+4. **Никаких** изменений в `docs/strategies/01-flagship-overview.md` сверх ссылок на эти доки.
+
+**Тест-план:**
+- Ручная вычитка: matrix корректна, ссылки кликабельны.
+- Никаких сломанных линков (запустить markdown-link-check, если он есть в репо).
+
+**Критерии готовности:**
+- Capability matrix обновлена.
+- Concept doc содержит implementation status.
+- Roadmap отражает delivered-статус.
+
+---
+
+### 53-T6: Тесты — golden DSL fixture + walk-forward acceptance + smoke replay
+
+**Цель:** покрыть тестами: golden DSL (компиляция + sanity evaluator), walk-forward acceptance в CI на маленькой sub-fixture, smoke replay на recorded data.
+
+**Файлы для изменения:**
+- `apps/api/tests/lib/compiler/adaptiveRegime.test.ts` — компиляция DSL (создан в T1).
+- `apps/api/tests/integration/adaptiveRegimeWalkForward.test.ts` (создать).
+- `apps/api/tests/integration/adaptiveRegimeSmokeReplay.test.ts` (создать).
+
+**Шаги реализации:**
+1. **Golden DSL.** Загрузить `tests/fixtures/strategies/adaptive-regime.golden.json` через `compileDsl`. Любая регрессия в supportMap или DSL-форме → красный тест.
+2. **Walk-forward CI test.**
+   - Используется компактная sub-fixture (~2 месяца M5 + H1 свечей, hardcoded), не полные 6 месяцев из 53-T2.
+   - Запустить walk-forward через те же helpers, что в production code.
+   - Acceptance критерии **смягчены** для CI: `tradeCount > 0 на каждом fold`, `aggregated pnlPct != null`. То есть проверяем только что pipeline работает, не что результат соответствует «production-grade» acceptance. Полный acceptance — на full data, в T2 (вне CI).
+3. **Smoke replay.**
+   - Recorded data: один полный demo-smoke run сериализован в JSON (intent log, candle snapshots, evaluator outputs). Помещается в `tests/fixtures/.../smokeReplay.json`.
+   - Тест проигрывает intent flow через mocked `bybitOrder` (никаких real HTTP) и проверяет, что evaluator производит те же intents, что были в реальном run.
+   - Это regression test: если позже DSL или evaluator изменится — replay упадёт, надо явно обновить fixture.
+4. Все тесты — детерминированы, без рандома, без current time зависимостей.
+
+**Тест-план:**
+- `npm test` (apps/api) — все три новых теста зелёные.
+- Существующие тесты (`compiler`, `dslEvaluator`, `walkForward`, `botWorker`) — без регрессий.
+- Покрытие новых файлов ≥ 80%.
+
+**Критерии готовности:**
+- Все три теста добавлены и зелёные на CI.
+- Golden fixture явно используется как single source of truth.
+- Smoke replay fixture помечена с timestamp оригинального run'а в комментарии.
+
+---
+
+## Порядок выполнения задач
+
+```
+53-T1 ──→ 53-T2 ──→ 53-T3 ──→ 53-T4 ──→ 53-T5
+   │
+   └────────────────────────────────────→ 53-T6
+```
+
+- 53-T1 (DSL) — первая, всё опирается на golden fixture.
+- 53-T2 (walk-forward acceptance) — после T1.
+- 53-T3 (demo smoke) — после T2 (нет смысла гонять demo, если walk-forward провалился).
+- 53-T4 (publish) — только после T1+T2+T3 успеха. Это явный gate.
+- 53-T5 (matrix/concept doc) — после T4.
+- 53-T6 (тесты) — может вестись параллельно с T1-T5 инкрементально; финализируется после T1.
+
+Каждая T-задача — отдельный PR. T2 и T3 могут произвести negative result — тогда документ ставится на паузу до решения «tune params» / «эскалировать в `docs/50`».
+
+## Зависимости от других документов
+
+- `docs/50` — родительский overview.
+- `docs/51` — обязателен. Без preset-системы T4 («publish to Library») невозможен. T1 заменяет seed-заглушку из `docs/51-T6`.
+- `docs/52` — обязателен. Bundle `{M5, H1}` — фундамент multi-TF DSL.
+- `docs/47` (sweep) — может использоваться для tuning baseline params, если первый walk-forward run не пройдёт acceptance.
+- `docs/48` (walk-forward) — обязателен для T2.
+- `docs/49` (sharpe/PF/expectancy метрики) — обязателен для acceptance gate (T2 проверяет sharpe).
+- `docs/strategies/03-adaptive-regime-bot.md` — concept-doc, обновляется в T5.
+- `docs/strategies/08-strategy-capability-matrix.md` — capability matrix, обновляется в T5.
+
+## Backward compatibility checklist
+
+- Никаких изменений в `botWorker.ts`, `signalEngine.ts`, `exitEngine.ts`, `positionManager.ts` сверх того, что уже введено в `docs/52` и `docs/51`. Activation Adaptive Regime — чисто конфигурация (DSL + bundle), не правка ядра.
+- `bybitOrder.ts` — без правок. Demo smoke использует тот же путь, что обычный bot run.
+- Composite signal types из исходного спека НЕ вводятся в evaluator. Любая попытка добавить `"supertrend_direction"` как отдельный type — нарушение `docs/50 §Решение 3` и должна быть отклонена в код-ревью.
+- Никаких изменений в Prisma schema (`StrategyPreset`, `Bot`, `BacktestSweep`, `WalkForwardRun` уже расширены в `docs/51`/`docs/52`).
+- Existing public Lab Library страница (`docs/51-T5`) поддерживает добавление новой PUBLIC карточки без правок UI.
+- `routes/demo.ts` (hardcoded breakout-presets для лендинга) — не затронут.
+
+## Ожидаемый результат
+
+После закрытия 53-T1..53-T6:
+
+- В Lab Library живёт PUBLIC карточка `adaptive-regime`. Один клик → бот на Bybit demo.
+- Существует golden DSL fixture, gating CI: любая регрессия в DSL evaluator или supportMap, ломающая стратегию, ловится на CI.
+- Walk-forward acceptance (полный, на 6 folds) пройден на baseline parameters; результат зафиксирован в `docs/53-baseline-results.md`.
+- Demo smoke 30+ минут отработан без unhandled errors; intent flow подтверждён.
+- Capability matrix отражает delivered-статус. Concept doc указывает реализационные ссылки.
+- Архитектурно — это первая end-to-end активация, валидирующая работоспособность всего стека `docs/51 + docs/52 + docs/47/48/49` под реальную стратегию. Эта же шаблонная последовательность T1..T6 переиспользуется в `docs/54` для DCA / MTF Scalper / SMC.

--- a/docs/54-flagship-rollout.md
+++ b/docs/54-flagship-rollout.md
@@ -1,0 +1,357 @@
+# 54. Flagship Rollout — DCA / MTF Scalper / SMC
+
+Статус: draft  
+Владелец: core trading / lab  
+Последнее обновление: 2026-04-30  
+Родительский документ: `docs/50-flagship-activation-plan.md`  
+Связанные спеки:
+- `docs/strategies/02-dca-momentum-bot.md`
+- `docs/strategies/05-mtf-scalper.md`
+- `docs/strategies/06-smc-liquidity-sweep.md`
+
+## Контекст
+
+Текущее состояние (проверено по коду):
+
+- **DCA Momentum (`docs/strategies/02-dca-momentum-bot.md`).** Single-TF (например, M15). Использует `dca_config` блок (supported в `apps/api/src/lib/compiler/supportMap.ts`), `dcaEngine.ts` и `dcaBridge.ts` в `apps/api/src/lib/runtime/`. Семантика: фиксированные averaging steps под управлением momentum-фильтра (RSI / MACD / EMA-trend).
+- **MTF Scalper (`docs/strategies/05-mtf-scalper.md`).** 3 TF: M1 (entry timing) + M5 (signal) + M15 (trend filter). Все индикаторы supported. `intervalAlignment.ts` уже умеет резолвить эти TF в bundle.
+- **SMC Liquidity Sweep (`docs/strategies/06-smc-liquidity-sweep.md`).** 3 TF: M15 (entry) + H1 (structure) + H4 (HTF bias). Использует `liquidity_sweep`, `fair_value_gap`, `order_block`, `market_structure_shift` блоки — все реализованы в `apps/api/src/lib/runtime/patternEngine.ts` и supported в `supportMap.ts`.
+- Шаблон активации стратегии — установлен в `docs/53` для Adaptive Regime: T1 (DSL) → T2 (walk-forward) → T3 (demo smoke) → T4 (publish). Этот документ переиспользует тот же шаблон, по 4 шага на каждую из трёх стратегий, с поправками для DCA (нет MTF bundle).
+- Production go/no-go gate как процедура — отсутствует. До этого момента нет осознанного критерия «можно открывать live». T6 этот пробел закрывает.
+
+## Цель
+
+Довести 3 не-Funding флагмана до состояния `PUBLIC` в Lab Library, по тому же шаблону, что Adaptive Regime в `docs/53`:
+
+1. **DCA Momentum** — single-TF, использует `dcaEngine`. Активация наиболее простая.
+2. **MTF Scalper** — multi-TF (M1+M5+M15). Стресс-тест для bundle на быстрых интервалах.
+3. **SMC Liquidity Sweep** — multi-TF (M15+H1+H4). Стресс-тест для pattern-based блоков.
+
+Каждая — golden DSL + walk-forward acceptance + 30-минутный demo smoke + capability matrix update.
+
+После 54-T1..T3 готовы все 4 не-Funding пресета в `PUBLIC`. T6 — формализация go/no-go gate: документ-aудит, по которому принимается решение «можно включать `BYBIT_ALLOW_LIVE` для отдельных пользователей». Реализация переключателя — за пределами этого документа; здесь только процедура и критерии.
+
+## Не входит в задачу
+
+- **Funding Arbitrage.** Отдельный трек — `docs/55`.
+- **Live trading включение.** T6 — это документ-gate, не код. Изменение `BYBIT_ALLOW_LIVE` env / админ-toggle для отдельных пользователей — отдельная инженерная задача, которая стартует после прохождения T6 для каждой конкретной стратегии.
+- **Multi-symbol раскат каждой стратегии.** Один пресет = baseline на одном symbol (BTCUSDT для всех). ETH/SOL/etc — после go/no-go gate для конкретной стратегии.
+- **Кросс-стратегийные portfolio limits.** Out of scope.
+- **Перепроектирование `dcaEngine`/`patternEngine`.** Используем существующие реализации.
+- **AI-чат генерация preset'ов для этих стратегий.** DSL фиксируются вручную (как в `docs/53-T1`), не через AI.
+- **Полный admin UI для preset versioning.** Если нужно тюнить параметры baseline пресетов после публикации — это делается через создание нового slug (`dca-momentum-v2`).
+
+## Архитектурные решения
+
+### Решение 1: Шаблон 54-Tn повторяет docs/53 для каждой стратегии
+
+Каждая T-задача (T1, T2, T3) внутри себя повторяет структуру docs/53-T1..T6 — DSL → walk-forward → demo smoke → publish — но компактнее, потому что инфраструктура уже есть. Каждая T-задача = весь lifecycle одной стратегии до PUBLIC. Это экономнее, чем плодить 18 sub-tasks (3 стратегии × 6 шагов).
+
+### Решение 2: Один companion-doc на каждую стратегию
+
+`docs/54-baseline-results.md` — единый файл с тремя разделами: «DCA Momentum», «MTF Scalper», «SMC Liquidity Sweep». Каждый раздел: walk-forward summary + demo smoke summary + visibility flip timestamp. Легче навигировать, чем три отдельных файла.
+
+### Решение 3: DCA Momentum — single-TF, без bundle
+
+`Bot.datasetBundleJson === null` для DCA. Используется legacy single-TF путь из `docs/52-T3` (с уже исправленным interval-фильтром). Это проверяет, что multi-TF infra additive: single-TF стратегия не должна задействовать ни одну строку MTF кода.
+
+### Решение 4: MTF Scalper — стресс-тест на M1
+
+`Bot.timeframe = "M1"`. Polling cadence остаётся существующая (60s или короче, проверить config). M1 — самый быстрый TF в системе; load `loadCandleBundle({ M1, M5, M15 })` каждый tick должен укладываться в polling-cadence. Если профайлинг покажет регресс — fallback: уменьшить `lookbackBars` для M1 до 200 (вместо 500).
+
+### Решение 5: SMC Liquidity Sweep — pattern blocks из patternEngine
+
+Все блоки (`liquidity_sweep`, `fair_value_gap`, `order_block`, `market_structure_shift`) уже supported (`apps/api/src/lib/runtime/patternEngine.ts`). DSL компонуется в T3-T1 через эти блоки + standard compare/and_gate. Никакой новой логики паттернов не вводится.
+
+### Решение 6: Production go/no-go gate — формальный документ, не код
+
+T6 даёт audit-template, проверяющий 9 критериев готовности (security review, ops runbook, observability, demo smoke pass для всех 4, walk-forward pass для всех 4, и тд). Documentation-only, не вводит фичи. Реальное переключение `BYBIT_ALLOW_LIVE` — отдельная задача, которая ссылается на этот документ как на свой prerequisite.
+
+---
+
+## Задачи
+
+### 54-T1: DCA Momentum — DSL + acceptance + publish (single-TF)
+
+**Цель:** довести `dca-momentum` пресет от seed-заглушки (`docs/51-T6`) до `PUBLIC`. Single-TF, без bundle.
+
+**Файлы для изменения:**
+- `apps/api/prisma/seed/presets/dca-momentum.json` — финальный DSL.
+- `apps/api/tests/fixtures/strategies/dca-momentum.golden.json`.
+- `apps/api/scripts/runDcaMomentumBaseline.ts` — orchestration.
+- `apps/api/scripts/demoSmoke.dcaMomentum.ts` — обёртка над generic `demoSmoke.ts` из `docs/53-T3`.
+- `docs/54-baseline-results.md` — раздел «DCA Momentum».
+
+**Шаги реализации:**
+1. **DSL.** Полный preset через примитивы:
+   - `enter_when`: `and_gate([ rsi(14, M15) < 30, ema(50, M15) trending up, momentum > 0 ])`. Конкретные блоки — `compare`, `cross`, optional `dca_config` для управления averaging.
+   - `dca_config`: 3-5 averaging steps (зависит от concept doc), step distance 1.5%, размер шага возрастающий (martingale-light).
+   - `exit_when`: `or_gate([ tp_hit, sl_hit, rsi(14) > 70 ])`.
+   - `defaultBotConfigJson`: `{ symbol: "BTCUSDT", timeframe: "M15", quoteAmount: 100, maxOpenPositions: 1, ... }`.
+   - **Без** `datasetBundleHintJson` — single-TF.
+2. **Walk-forward acceptance.** Те же 6 folds, 4-1 train-test split (см. `docs/53-T2`). DCA-специфика: для acceptance проверять также `averageEntries` (среднее число DCA-step'ов на trade) и `maxDcaDepth` (максимальная глубина) — добавить эти агрегаты в companion-doc, без изменения Walk-Forward UI.
+3. **Demo smoke.** 30+ мин на Bybit demo с `BTCUSDT`, M15. Acceptance — те же из `docs/53-T3`: 0 unhandled errors, ≥1 intent (вероятно — несколько за 30 мин при правильной настройке RSI<30 порога).
+4. **Publish.** `publishPreset.ts --slug dca-momentum --visibility PUBLIC` после прохождения acceptance.
+5. **Companion-doc.** Раздел «DCA Momentum» в `docs/54-baseline-results.md` со всем выше.
+
+**Тест-план:**
+- DSL компилируется (golden fixture тест).
+- Walk-forward на CI sub-fixture: pipeline работает, `tradeCount > 0`, `dca_config` блок отрабатывает (по логам — DCA step вызвался хотя бы раз).
+- Smoke replay (как в `docs/53-T6`) — отдельный fixture для DCA.
+
+**Критерии готовности:**
+- `dca-momentum` в PUBLIC, виден в `/lab/library`.
+- Walk-forward acceptance pass.
+- Demo smoke pass.
+- Companion-doc раздел заполнен.
+
+---
+
+### 54-T2: MTF Scalper — DSL + acceptance + publish (3 TF)
+
+**Цель:** довести `mtf-scalper` пресет до `PUBLIC`. Bundle `{M1, M5, M15}`.
+
+**Файлы для изменения:**
+- `apps/api/prisma/seed/presets/mtf-scalper.json`.
+- `apps/api/tests/fixtures/strategies/mtf-scalper.golden.json`.
+- `apps/api/scripts/runMtfScalperBaseline.ts`.
+- `apps/api/scripts/demoSmoke.mtfScalper.ts`.
+- `docs/54-baseline-results.md` — раздел «MTF Scalper».
+
+**Шаги реализации:**
+1. **DSL.**
+   - `primaryTimeframe: "M1"`.
+   - `datasetBundleHint: { M1: true, M5: true, M15: true }`.
+   - `enter_when`: 3-уровневое выравнивание тренда — `and_gate([ ema_fast(9, M1) > ema_slow(21, M1), close(M5) > vwap(M5), ema(50, M15) trending up ])`. Все блоки supported.
+   - `exit_when`: `or_gate([ ema_fast crosses below ema_slow on M1, atr-based trailing stop ])`.
+   - `defaultBotConfigJson`: `{ symbol: "BTCUSDT", timeframe: "M1", quoteAmount: 50 (меньше из-за частоты), maxOpenPositions: 1, leverage: 5 }`.
+2. **Walk-forward acceptance.** Особенности для high-frequency:
+   - 6 folds, train 1 месяц / test 1 неделя (потому что M1 даёт ~43K свечей в месяц — больше плотность сигналов, можно укоротить fold).
+   - `tradeCount` per fold ожидается высокий (десятки-сотни). Acceptance: `pnl > 0`, `sharpe > 0.5` (выше чем у Adaptive Regime, потому что HFT pattern должен иметь более стабильный edge при честных costs), `maxDD > -25%`.
+   - Особое внимание `feeBps` — на M1 fee impact выше; baseline `feeBps: 6, slippageBps: 2`.
+3. **Demo smoke.** 30+ мин. Особенности:
+   - Polling cadence на M1 — проверить, что текущий polling-loop успевает (если нет — это блокер для MTF Scalper, эскалируется в `docs/50` как новая T-задача).
+   - Ожидается заметно большее число intents за 30 мин (десятки), это нормально.
+4. **Profile-check.** Перед T4 (publish) запустить профайлер `loadCandleBundle({M1,M5,M15})` per-tick — должно укладываться в <500ms на typical workspace. Если нет — fallback: уменьшить `lookbackBars` для M1 (см. §Решение 4 выше).
+5. **Publish.** `--slug mtf-scalper --visibility PUBLIC`.
+
+**Тест-план:**
+- Golden DSL компилируется.
+- Walk-forward sub-fixture (M1+M5+M15 на 1 неделе) — pipeline работает.
+- Smoke replay fixture для MTF Scalper.
+- Профайлер benchmark в companion-doc.
+
+**Критерии готовности:**
+- `mtf-scalper` в PUBLIC.
+- Bundle `{M1, M5, M15}` корректно загружается per-tick без timeout'ов.
+- Walk-forward acceptance pass.
+- Demo smoke pass.
+- Profile-check pass или явный fallback зафиксирован.
+
+---
+
+### 54-T3: SMC Liquidity Sweep — DSL + acceptance + publish (3 TF)
+
+**Цель:** довести `smc-liquidity-sweep` пресет до `PUBLIC`. Bundle `{M15, H1, H4}`.
+
+**Файлы для изменения:**
+- `apps/api/prisma/seed/presets/smc-liquidity-sweep.json`.
+- `apps/api/tests/fixtures/strategies/smc-liquidity-sweep.golden.json`.
+- `apps/api/scripts/runSmcBaseline.ts`.
+- `apps/api/scripts/demoSmoke.smc.ts`.
+- `docs/54-baseline-results.md` — раздел «SMC Liquidity Sweep».
+
+**Шаги реализации:**
+1. **DSL.**
+   - `primaryTimeframe: "M15"`.
+   - `datasetBundleHint: { M15: true, H1: true, H4: true }`.
+   - `enter_when`: типичный SMC сетап — `and_gate([ liquidity_sweep on H1, fair_value_gap on M15, market_structure_shift on M15, htf_bias from H4 (EMA200 trend) ])`. Все блоки supported в `patternEngine.ts`.
+   - `exit_when`: `or_gate([ opposite order_block reached on M15, atr-trailing stop, structure invalidation on H1 ])`.
+   - `defaultBotConfigJson`: `{ symbol: "BTCUSDT", timeframe: "M15", quoteAmount: 100, maxOpenPositions: 1, leverage: 3 }`.
+2. **Walk-forward acceptance.**
+   - 6 folds, train 4 месяца / test 1 месяц (как Adaptive Regime).
+   - SMC даёт меньше сигналов (более избирательная стратегия). Acceptance: `pnl > 0`, `sharpe > 0.4`, `maxDD > -25%`. Если `tradeCount` на каком-то fold = 0 — это допустимо (фолд может быть в режиме без подходящих структур); но aggregate должен быть с положительным числом trades.
+3. **Demo smoke.** 60+ мин (вместо 30) — потому что сигналы реже. Acceptance: 0 unhandled errors, ≥0 intents (signal может не появиться, не обязательно — это особенность SMC). Достаточно подтвердить, что polling-loop вызывает evaluator с bundle и pattern blocks возвращают валидные snapshots.
+4. **Pattern engine sanity.** Один отдельный sub-test перед T4: на zashитой fixture (M15+H1+H4 за 2 недели с известным sweep событием) verify, что DSL правильно triggers entry. Это catches случаи, когда patternEngine выдаёт false negative из-за specific bundle alignment edge cases.
+5. **Publish.** `--slug smc-liquidity-sweep --visibility PUBLIC`.
+
+**Тест-план:**
+- Golden DSL компилируется.
+- Walk-forward sub-fixture работает.
+- Pattern fixture sanity test (упомянутый выше) зелёный.
+- Smoke replay fixture для SMC.
+
+**Критерии готовности:**
+- `smc-liquidity-sweep` в PUBLIC.
+- Walk-forward acceptance pass.
+- Demo smoke 60-мин pass.
+- Pattern sanity test passed.
+
+---
+
+### 54-T4: Capability matrix + concept doc updates для всех трёх
+
+**Цель:** обновить capability matrix и concept-доки для всех трёх стратегий — аналогично `docs/53-T5`, но скопом.
+
+**Файлы для изменения:**
+- `docs/strategies/08-strategy-capability-matrix.md` — три новые строки (или статусы) `dca-momentum: implemented`, `mtf-scalper: implemented`, `smc-liquidity-sweep: implemented`.
+- `docs/strategies/02-dca-momentum-bot.md` — implementation status block.
+- `docs/strategies/05-mtf-scalper.md` — то же.
+- `docs/strategies/06-smc-liquidity-sweep.md` — то же.
+- `docs/16-roadmap.md` — обновить статусы трёх стратегий в Post-MVP секции.
+- `docs/strategies/01-flagship-overview.md` — отметить, что 4 не-Funding флагмана delivered (5-я — funding arb — статус из `docs/55`).
+
+**Шаги реализации:**
+1. В каждый concept-doc добавить implementation status (как в `docs/53-T5 §2`):
+   > **Implementation status:** delivered as `<slug>` preset (`docs/54`). DSL: `apps/api/prisma/seed/presets/<slug>.json`. Golden fixture: `apps/api/tests/fixtures/strategies/<slug>.golden.json`.
+2. В matrix — три обновления, формат точно совпадает с тем, что был добавлен в `docs/53-T5`.
+3. В roadmap — пункт «5 флагманов» становится «4 delivered, 1 in funding-arb-track (`docs/55`)».
+4. `docs/strategies/01-flagship-overview.md` — добавить timeline-block в верх документа: «Stage 3 delivered 2026-04-30 → 5 flagships implementation initiated. As of <date>: Adaptive Regime, DCA Momentum, MTF Scalper, SMC Liquidity Sweep — PUBLIC. Funding Arbitrage — see `docs/55`.»
+
+**Тест-план:**
+- Ручная вычитка матрицы.
+- Markdown-link-check (если есть в репо).
+
+**Критерии готовности:**
+- Capability matrix обновлён для трёх стратегий.
+- Implementation status block добавлен в каждый concept doc.
+- Roadmap отражает статус.
+
+---
+
+### 54-T5: Тесты — golden DSL + walk-forward CI + smoke replay для каждой стратегии
+
+**Цель:** для каждой из трёх стратегий — тот же набор тестов, что в `docs/53-T6`: golden DSL, walk-forward CI sub-fixture, smoke replay.
+
+**Файлы для изменения:**
+- `apps/api/tests/lib/compiler/dcaMomentum.test.ts`.
+- `apps/api/tests/lib/compiler/mtfScalper.test.ts`.
+- `apps/api/tests/lib/compiler/smcLiquiditySweep.test.ts`.
+- `apps/api/tests/integration/dcaMomentumWalkForward.test.ts`.
+- `apps/api/tests/integration/mtfScalperWalkForward.test.ts`.
+- `apps/api/tests/integration/smcWalkForward.test.ts`.
+- `apps/api/tests/integration/dcaMomentumSmokeReplay.test.ts`.
+- `apps/api/tests/integration/mtfScalperSmokeReplay.test.ts`.
+- `apps/api/tests/integration/smcSmokeReplay.test.ts`.
+
+**Шаги реализации:**
+1. Каждый test-файл — копия паттерна из `docs/53-T6`, под конкретный preset.
+2. Sub-fixture для walk-forward — компактная (1-2 недели данных), достаточная только для проверки, что pipeline работает; не для полного acceptance (полный — в T1/T2/T3 этого документа).
+3. Smoke replay — recorded JSON каждой стратегии, сериализованный после успешного demo smoke run в T1/T2/T3.
+4. **Общий helper.** Чтобы не дублировать boilerplate, вынести helpers в `apps/api/tests/_helpers/strategyAcceptance.ts`:
+   ```ts
+   export function describeGoldenStrategy(slug: string, fixturePath: string) { ... }
+   export function describeWalkForwardCi(slug: string, dataPath: string) { ... }
+   export function describeSmokeReplay(slug: string, replayPath: string) { ... }
+   ```
+   Каждый concrete test-файл — 5-10 строк, вызов helper'а.
+5. Ретроспективно обновить `docs/53-T6`-тесты на тот же helper (отдельный refactor PR, не блокирует T5).
+
+**Тест-план:**
+- `npm test` — все 9 новых тестов зелёные.
+- Существующие тесты (`compiler`, `dslEvaluator`, `walkForward`, `botWorker`) — без регрессий.
+
+**Критерии готовности:**
+- 9 новых тестов добавлены и зелёные на CI.
+- Общий helper в `_helpers/`.
+- Smoke replay fixtures созданы.
+
+---
+
+### 54-T6: Production go/no-go gate (audit doc)
+
+**Цель:** документ-аудит `docs/54-go-no-go-gate.md`, по которому принимается осознанное решение о включении live-торговли. Documentation-only, не вводит код.
+
+**Файлы для изменения:**
+- `docs/54-go-no-go-gate.md` (создать).
+
+**Шаги реализации:**
+
+Документ содержит 9 разделов-критериев. Решение «GO» возможно только когда все 9 имеют статус PASS (либо явно записанный в gate-документе rationale для каждого пункта, который PASS не получает).
+
+1. **Strategy acceptance.** Все 4 не-Funding флагмана:
+   - `walkForwardRunId` валиден и acceptance pass;
+   - `demoSmokeRunId` (или ссылка на `.smoke-output/` запись) пройден;
+   - golden fixture / DSL / smoke replay тесты зелёные на main.
+2. **Security review.** `docs/05-security.md`, `docs/06-threat-model.md` — пересмотрены в течение 30 дней до gate. Аудит-checklist: secrets management, rate limiting, auth, idempotency, input validation на всех новых эндпоинтах из `docs/51`.
+3. **Ops runbook.** `docs/15-operations.md` содержит процедуры: «как остановить все боты в emergency», «как откатить preset из PUBLIC в PRIVATE без удаления», «как продиагностировать застрявший bot run».
+4. **Observability.** Минимум: дашборд / alerting на (a) число ERRORED ботов за 5/15 минут (alert при skyrocket), (b) p95 latency `/bots/:id/start`, (c) Bybit API error rate, (d) circuit breaker triggered count.
+5. **Kill switch.** Глобальный admin-flag для отключения всей торговли (`TRADING_ENABLED=false`) — присутствует и протестирован.
+6. **Liability.** Юридический disclaimer в Lab Library и на Bot create UI: «Trading involves risk. Past performance is not indicative of future results.» Текст согласован с product/legal.
+7. **Capacity / cost.** Estimate БД-нагрузки и Bybit API rate-limit usage при ожидаемом числе одновременно работающих ботов (X = первый пилотный число пользователей).
+8. **Rollback procedure.** Если после go-live обнаружен критический баг — есть план: остановить новых ботов через rate-limit/feature flag, оповестить активных пользователей, hotfix или rollback BYBIT_ALLOW_LIVE.
+9. **Sign-off.** Подписи (по именам в companion-doc или git-blame на этом файле): tech lead, product lead, ops lead.
+
+**Структура документа:**
+- Заголовок, дата, версия.
+- 9 секций как чек-лист с полями `Status: PASS|FAIL|PENDING`, `Evidence: <ссылка>`, `Notes:`.
+- Финальное решение: GO / NO-GO / DEFERRED with rationale.
+
+**Тест-план:**
+- N/A — документ-аудит, не код.
+
+**Критерии готовности:**
+- Файл создан, шаблон заполнен placeholder'ами.
+- Секции пронумерованы и каждая имеет Status-поле.
+- Документ ссылается на companion-docs (`docs/53-baseline-results.md`, `docs/54-baseline-results.md`).
+- В roadmap указано «go/no-go gate template ready, awaiting acceptance for individual flagships».
+
+---
+
+## Порядок выполнения задач
+
+```
+54-T1 (DCA) ──┐
+              ├──→ 54-T4 (matrix) ──→ 54-T6 (gate doc)
+54-T2 (MTF) ──┤                           │
+              │       54-T5 (tests) ──────┘
+54-T3 (SMC) ──┘
+```
+
+- 54-T1, T2, T3 — независимы между собой, могут идти параллельно или последовательно.
+- DCA рекомендуется первой как самая простая (нет multi-TF, мало pattern complexity); это даёт быстрый второй success после Adaptive Regime, валидирующий single-TF путь.
+- MTF Scalper может стартовать после T1 (нужен опыт `loadCandleBundle` performance).
+- SMC может стартовать параллельно с MTF Scalper.
+- T4 (capability matrix) выполняется кумулятивно: после каждого из T1/T2/T3 матрица обновляется на одну строку. Финальное закрытие T4 — после всех трёх.
+- T5 (тесты) — параллельно с T1-T3, инкрементально.
+- T6 (gate doc) — последний. Может писаться черновиком параллельно, но финализация — после прохождения acceptance всеми 4 не-Funding флагманами.
+
+Каждая T-задача — отдельный PR.
+
+## Зависимости от других документов
+
+- `docs/50` — родительский overview.
+- `docs/51` — обязателен. T1/T2/T3 публикуют preset'ы через preset system.
+- `docs/52` — обязателен для T2 (MTF Scalper) и T3 (SMC). T1 (DCA) — single-TF, не использует.
+- `docs/53` — обязателен. Этот документ переиспользует шаблон Adaptive Regime activation. Также `docs/53-T6` helpers (golden DSL test, walk-forward CI sub-fixture, smoke replay) переиспользуются в 54-T5.
+- `docs/47` (sweep) — опциональный инструмент для tuning baseline params, если walk-forward acceptance не пройдёт с первого раза.
+- `docs/48` (walk-forward) — обязателен для T1/T2/T3.
+- `docs/49` (метрики) — обязателен. Acceptance gate проверяет sharpe.
+- `docs/55` — независим. Не блокирует, но T6 (go/no-go gate) обновляется после закрытия `docs/55` ещё одной строкой.
+- `docs/strategies/02, 05, 06, 08` — concept/matrix.
+- `docs/05-security.md`, `docs/06-threat-model.md`, `docs/15-operations.md`, `docs/16-roadmap.md` — обновляются в T4/T6.
+
+## Backward compatibility checklist
+
+- `botWorker.ts`, `signalEngine.ts`, `exitEngine.ts`, `positionManager.ts`, `dcaEngine.ts`, `patternEngine.ts` — без правок. Все три стратегии реализуются конфигурацией DSL.
+- `bybitOrder.ts` — без правок.
+- Никаких новых composite signal types в evaluator.
+- Никаких новых Prisma миграций (StrategyPreset, datasetBundleJson, templateSlug — уже введены `docs/51`/`docs/52`).
+- Никаких изменений в `routes/demo.ts`.
+- Public Lab Library поддерживает добавление новых PUBLIC карточек без правок UI.
+- DCA single-TF путь использует legacy single-TF candle loading (с уже исправленным interval-фильтром из `docs/52-T3`).
+- Existing single-TF backtest (`runBacktest(candles, dsl, opts)`) продолжает работать для DCA-сценариев без перехода на bundle-overload.
+- T6 — documentation-only, никаких бинарных артефактов.
+
+## Ожидаемый результат
+
+После закрытия 54-T1..54-T6:
+
+- В Lab Library живут 4 PUBLIC карточки: `adaptive-regime` (`docs/53`), `dca-momentum`, `mtf-scalper`, `smc-liquidity-sweep`.
+- Каждая стратегия имеет: golden DSL fixture, walk-forward acceptance результат, demo smoke audit, capability matrix entry, smoke replay test в CI.
+- `docs/54-baseline-results.md` — companion-doc с тремя разделами, фиксирующими реальные числа per стратегия.
+- `docs/54-go-no-go-gate.md` — формальный template для production go-live решения; готов к заполнению по мере прохождения acceptance.
+- Spec'и `docs/strategies/02, 05, 06` — содержат implementation status, ссылающийся на этот документ.
+- Roadmap отражает: 4 не-Funding флагмана delivered. Funding Arb — в `docs/55` (параллельный трек).
+- DSL evaluator, signal/exit/position engine, dcaEngine, patternEngine, botWorker — не модифицированы; все правки на уровне DSL configurations + acceptance pipeline.
+- Это ставит платформу в состояние, в котором go-live решение зависит только от прохождения T6 gate-документа, а не от инженерных блокеров.

--- a/docs/55-funding-arbitrage-plan.md
+++ b/docs/55-funding-arbitrage-plan.md
@@ -1,0 +1,450 @@
+# 55. Funding Arbitrage — Plan
+
+Статус: draft  
+Владелец: core trading  
+Последнее обновление: 2026-04-30  
+Родительский документ: `docs/50-flagship-activation-plan.md`  
+Связанный спек: `docs/strategies/04-funding-arbitrage-delta-hedge.md`
+
+## Контекст
+
+Текущее состояние (проверено по коду):
+
+- Concept-документ: `docs/strategies/04-funding-arbitrage-delta-hedge.md`. Идея: при положительном funding rate на perpetual — short perp + long spot того же символа, удержать через funding payment, выйти. Дельта-нейтральная позиция, прибыль = funding − fees − spread cost.
+- Funding lib **уже есть**: `apps/api/src/lib/funding/` содержит `basis.ts`, `fetcher.ts`, `hedgePlanner.ts`, `hedgeTypes.ts`, `index.ts`, `ingestJob.ts`, `ingestion.ts`, `scanner.ts`, `types.ts`.
+- Prisma модели готовы: `FundingSnapshot` (`schema.prisma:764`), `SpreadSnapshot` (`schema.prisma:774`), `HedgePosition` (`schema.prisma:794`), `LegExecution` (`schema.prisma:810`).
+- Роут `/hedges` живой: `apps/api/src/routes/hedges.ts`. Эндпоинты:
+  - `POST /hedges/entry` — создать `HedgePosition` со spot- и perp-leg как `BotIntent` записями.
+  - `POST /hedges/:id/execute` — пометить как executed.
+  - `POST /hedges/:id/exit` — exit процедура.
+  - `GET /hedges`, `GET /hedges/:id` — read.
+- Spot-нога создаётся как `BotIntent` с `metaJson.category = "spot"` (`hedges.ts:152`, `hedges.ts:227`). **Реального spot-исполнения через Bybit API нет** — intent создаётся, но никакой POST к `/v5/order/create` с `category=spot` сегодня не происходит.
+- `bybitOrder.ts` параметризован: `category: "linear" | "spot"` (`apps/api/src/lib/bybitOrder.ts:89`, `:174`). Уровень API готов.
+- `apps/api/src/lib/exchange/` содержит **только** `instrumentCache.ts` и `normalizer.ts`. Spot-specific market-data adapter (`bybitSpot.ts`: ticker, candles, instrument cache) — **отсутствует**.
+- `ExchangeConnection` Prisma model — single API key (linear). Spot обычно требует отдельные права; в текущей схеме нет места для spot-credentials, либо отсутствует phys-проверка scope'ов.
+- Funding events на Bybit perpetual — раз в 8 часов (00:00, 08:00, 16:00 UTC). Демо-smoke на 30 минут не зацепит ни одного — поэтому acceptance gate расширяется до 60+ минут с явной привязкой к funding window.
+
+## Цель
+
+Довести funding-arb до состояния production-ready BETA-пресета в Lab Library:
+
+1. Spot-нога реально исполняется в Bybit (не остаётся «бумажным» BotIntent).
+2. Funding scanner доступен через UI; пользователь видит таблицу кандидатов (symbol × current funding rate × spread).
+3. Dedicated runtime — `hedgeBotWorker` — обрабатывает funding-arb mode, не ломая основной `botWorker.ts`.
+4. Acceptance gate проходит: 60+ минут на Bybit demo с реально зацепленным funding event, обе ноги исполнились, hedge закрылся, P&L соответствует expected funding − costs.
+5. Preset `funding-arb` опубликован в Lab Library со специальной visibility=`BETA` (или эквивалентом, см. §Решение 4) — отличающейся от обычной `PUBLIC`, чтобы UI явно сигнализировал «это experimental, multi-leg, может стоить денег при ошибке».
+
+После закрытия 55 в Lab Library — 5 карточек, последняя помечена как BETA. Live-включение funding-arb — отдельное решение, с дополнительным sub-gate'ом в `docs/54 §54-T6` (поскольку multi-leg execution имеет свой класс рисков, отличный от single-leg флагманов).
+
+## Не входит в задачу
+
+- **Live trading.** Только demo. Live-включение funding-arb — после go/no-go gate с дополнительными критериями (spot/perp inventory accounting, manual approval для каждого entry в первое время, position size cap).
+- **Negative funding (long perp + short spot).** Spot-shorting на Bybit или сложный, или недоступен на demo. Покрываем только positive-funding direction (short perp + long spot).
+- **Множественные одновременные hedge positions.** Один бот = один активный hedge за раз. Концепт «portfolio of hedges» — out of scope.
+- **Cross-exchange funding arb.** Только Bybit (perp + spot одной биржи). Multi-exchange — отдельный документ.
+- **Auto-recovery после частичного fill.** Если spot fill 0.5 BTC из 1.0 запрошенных — hedge ставится на pause и эскалируется как ERRORED. Авто-добивание / re-quote — out of scope первой версии.
+- **Базис-arb (spot ↔ perp price diff trading).** Только funding rate, не basis spread.
+- **Перепроектирование `bybitOrder.ts`.** Уже параметризован — используем как есть.
+- **Отдельный AI-чат для funding-arb.** DSL для funding-arb minimal (mode flag + symbol + size); не требует AI-генерации.
+
+## Архитектурные решения
+
+### Решение A1: Bybit Spot adapter — отдельный модуль
+
+`apps/api/src/lib/exchange/bybitSpot.ts` (создаётся в 55-T1). Содержит:
+- `fetchSpotCandles(symbol, interval, limit)` — для UI / диагностики, не критично для funding-arb runtime.
+- `fetchSpotTicker(symbol)` — последняя цена + bid/ask, для расчёта spread cost.
+- `getSpotInstrumentInfo(symbol)` — tick size, lot size, min order size — параметры, нужные для round'ера sizing.
+- Trading сам по себе — через существующий `bybitOrder.ts` с `category: "spot"`. Этот модуль market-data only.
+- Использует существующий нормализатор `apps/api/src/lib/exchange/normalizer.ts` для преобразования сырого Bybit response → внутренний формат.
+
+### Решение A2: Multi-leg execution = HedgePosition с двумя BotIntent'ами
+
+Существующая модель `HedgePosition` + два `BotIntent`'а (один с `metaJson.category="linear"`, второй с `category="spot"`) — оставляется как есть. 55-T2 завершает execution: spot-leg `BotIntent` действительно отправляется в Bybit через `bybitOrder` с `category: "spot"`. После исполнения обоих legs `HedgePosition.status` переходит в `EXECUTED`; если только один — `PARTIAL_ERROR` и алёрт.
+
+### Решение A3: Acceptance gate — 60+ минут, привязка к funding event
+
+В отличие от 30-минутного demo smoke для остальных флагманов (`docs/53-T3`), funding-arb acceptance включает:
+- Запуск runs strictly в окне (T_funding − 30 min, T_funding + 30 min) — то есть прямо вокруг funding event timestamp.
+- Проверка: entry-сигнал сработал до funding (perp short + spot long executed), funding payment получен (видно по Bybit API `/v5/account/transaction-log`), exit отработал после funding (close perp short + sell spot), P&L close to `funding_payment − fees − slippage`.
+- Если acceptance не проходит за один run — повтор на следующем funding window. Документировано в companion-doc.
+
+### Решение A4: Visibility = BETA
+
+`StrategyPreset` enum `PresetVisibility` сейчас имеет `PRIVATE | PUBLIC` (`docs/51-T1`). Для funding-arb нужна третья степень — `BETA`. Два варианта:
+1. Расширить enum до `PRIVATE | BETA | PUBLIC`. Минус: каждое место, где код фильтрует `visibility=PUBLIC`, нужно решить — включает ли он `BETA`.
+2. Добавить отдельную nullable колонку `isBeta Boolean @default(false)` рядом с `visibility`. Plus: orthogonal axis. Minus: ещё одна миграция, ещё одна ось.
+
+**Выбираем (1) — extend enum.** Конкретно — `PRIVATE | BETA | PUBLIC`. UI Lab Library показывает `PUBLIC` без бейджа; `BETA` — с явным жёлтым бейджем "BETA — multi-leg execution, monitor closely"; `PRIVATE` — только в admin view. Все эндпоинты `GET /presets` и `getPreset` явно опрашивают `visibility IN ('PUBLIC', 'BETA')` для аутентифицированных user'ов; неаутентифицированный landing — только `PUBLIC`. Миграция enum — additive (PostgreSQL: `ALTER TYPE ... ADD VALUE 'BETA' BEFORE 'PUBLIC'`).
+
+### Решение A5: Funding-arb runtime ≠ обычный botWorker
+
+Funding-arb — не «evaluator + intent» полный обычный bot. Его cycle:
+1. Сканирование funding rates (по cron / на старте бота).
+2. Если есть кандидат с rate > threshold — POST `/hedges/entry` с конкретным symbol+size.
+3. POST `/hedges/:id/execute`.
+4. Wait until next funding tick (sleep до T_funding + buffer).
+5. Verify funding payment received → POST `/hedges/:id/exit`.
+6. Repeat.
+
+Этот цикл не помещается в существующий polling-loop `botWorker.ts` (который заточен на DSL-evaluator). Поэтому вводим **dedicated runtime** — `apps/api/src/runtime/hedgeBotWorker.ts` (отдельная entrypoint). `Bot.mode` enum (новое поле) различает: `DSL` (default) → обычный botWorker; `FUNDING_ARB` → hedgeBotWorker. Это **аддитивно**: existing боты получают `mode=DSL` и работают через старый путь.
+
+Альтернатива — встраивать всё в `botWorker.ts` через if/else — отвергается: смешение state machines усложняет maintenance и ломает изоляцию.
+
+---
+
+## Задачи
+
+### 55-T1: Bybit Spot adapter — market data + ticker
+
+**Цель:** ввести `apps/api/src/lib/exchange/bybitSpot.ts` с тремя market-data функциями. Trading через `bybitOrder` (уже параметризован).
+
+**Файлы для изменения:**
+- `apps/api/src/lib/exchange/bybitSpot.ts` (создать).
+- `apps/api/src/lib/exchange/normalizer.ts` — переиспользовать или мягко расширить (если spot формат отличается чем-то от linear — добавить overload, не менять existing).
+- `apps/api/tests/lib/exchange/bybitSpot.test.ts` (создать).
+
+**Шаги реализации:**
+1. Сигнатуры:
+   ```ts
+   export async function fetchSpotCandles(args: {
+     symbol: string;
+     interval: CandleInterval;
+     limit?: number; // default 200, max 1000
+   }): Promise<MarketCandle[]>;
+
+   export async function fetchSpotTicker(symbol: string): Promise<{
+     symbol: string;
+     lastPrice: number;
+     bidPrice: number;
+     askPrice: number;
+     bidSize: number;
+     askSize: number;
+     timestamp: Date;
+   }>;
+
+   export async function getSpotInstrumentInfo(symbol: string): Promise<{
+     symbol: string;
+     baseAsset: string;
+     quoteAsset: string;
+     tickSize: number;
+     lotSize: number;
+     minOrderSize: number;
+     minOrderValue: number;
+   }>;
+   ```
+2. Endpoints (Bybit v5):
+   - Candles: `GET /v5/market/kline?category=spot&symbol=...`.
+   - Ticker: `GET /v5/market/tickers?category=spot&symbol=...`.
+   - Instrument: `GET /v5/market/instruments-info?category=spot&symbol=...`.
+3. Auth не требуется для market-data — public endpoints. Используется тот же HTTP-клиент, что в существующем коде (axios / undici, проверить).
+4. **Cache.** Instrument info — TTL 24h в memory (instruments редко меняются). Ticker — TTL 5s. Candles — без кэша на этом уровне.
+5. Normalizer: spot kline формат идентичен linear (Bybit v5 унифицирует). Если есть разница в timestamp / orderbook fields — добавить spot-overload в normalizer, не менять linear-логику.
+6. Логирование на каждом запросе (`logger.debug`) с маркером "[bybit-spot]".
+
+**Тест-план:**
+- Unit с mocked HTTP: `fetchSpotCandles("BTCUSDT", "M5", 100)` → возвращает 100 candles.
+- Unit: `fetchSpotTicker("BTCUSDT")` → возвращает объект с числовыми полями.
+- Unit: `getSpotInstrumentInfo` → возвращает корректную структуру.
+- Cache: два последовательных `fetchSpotTicker` в пределах 5s → один HTTP-запрос (assert mock call count).
+- Error: 4xx от Bybit → typed exception, понятный message.
+
+**Критерии готовности:**
+- 3 функции exported.
+- Unit-тесты зелёные.
+- Используется существующий HTTP-клиент / нормализатор; никакого нового HTTP-стека.
+- Lint / type-check pass.
+
+---
+
+### 55-T2: Завершить spot-leg execution в `/hedges/:id/execute` и `/hedges/:id/exit`
+
+**Цель:** в `/hedges/:id/execute` и `/hedges/:id/exit` дойти до реального вызова Bybit API для spot-ноги. Перевести `BotIntent` со `category="spot"` в `LegExecution` запись после успешного fill.
+
+**Файлы для изменения:**
+- `apps/api/src/routes/hedges.ts` — `POST /hedges/:id/execute`, `POST /hedges/:id/exit`.
+- `apps/api/src/lib/bybitOrder.ts` — без правок (уже параметризован), но добавить unit-tests конкретно для `category: "spot"` ветки если их нет.
+- `apps/api/tests/routes/hedges.test.ts` — расширить.
+
+**Шаги реализации:**
+1. В `/hedges/:id/execute`:
+   - Загрузить `HedgePosition` + два `BotIntent`'а (один linear, один spot).
+   - Для linear-ноги — текущий путь через `bybitOrder({ category: "linear", ... })` (если он сегодня уже работает; если нет — это блокер, эскалируется как pre-T2 fix).
+   - Для spot-ноги — новый путь: `bybitOrder({ category: "spot", side: "Buy", symbol, qty: spotQty, orderType: "Market" })`. Sizing: spot quantity вычисляется через `getSpotInstrumentInfo` из 55-T1 (минимум `minOrderSize`, кратно `lotSize`). При невозможности удовлетворить min — отказ операции с понятной ошибкой.
+   - **Атомарность.** Bybit API не предлагает atomic «execute both legs». Реализуем sequential: spot first (он медленнее по latency), затем perp. Если spot fail → перп не открывается, hedge помечается `FAILED`. Если spot ok, perp fail → spot уже открыт; делаем compensating market sell на spot (best-effort), помечаем `PARTIAL_ERROR`. Compensating sell — простая логика, не retry-loop.
+   - После успеха: создать `LegExecution` записи (одна на каждую ногу) с реальными fill prices/qtys из Bybit response. `HedgePosition.status = EXECUTED`.
+2. В `/hedges/:id/exit`:
+   - Reverse direction: spot Sell + perp Buy-to-close.
+   - Аналогичная sequential logic. Если perp close fail после spot sell → `PARTIAL_EXIT_ERROR` алёрт.
+   - `HedgePosition.status = EXITED`. Запись финальных fill prices в новую (или existing) `LegExecution` с типом `EXIT`.
+3. Idempotency: повторный POST `/hedges/:id/execute` после успешного execute → 409 `already executed`. Не выполнять второй раз.
+4. Logging: каждый вызов Bybit API + response status + ms — в structured log с hedgeId.
+
+**Тест-план:**
+- Mock Bybit: успешный execute обоих legs → `HedgePosition.status === "EXECUTED"`, две `LegExecution` записи.
+- Mock: spot fail → linear leg не вызывается, `status = "FAILED"`, нет orphan позиций.
+- Mock: spot ok, perp fail → compensating spot sell вызывается, `status = "PARTIAL_ERROR"`, алёрт залогирован.
+- Mock: повторный execute → 409.
+- Тоже для `/exit` — mock сценарии successful, partial, error.
+
+**Критерии готовности:**
+- Реальная spot-нога исполняется (пройдено на demo, не только моках).
+- `LegExecution` записи содержат корректные fill data.
+- Compensating logic покрыта тестом.
+- Existing `/hedges/entry` endpoint без правок (он только создаёт записи).
+
+---
+
+### 55-T3: Funding scanner — UI таблица кандидатов
+
+**Цель:** вывести существующий `lib/funding/scanner.ts` через эндпоинт + UI таблицу кандидатов. Пользователь видит, на каких symbol сейчас положительный funding и насколько он перекрывает предполагаемые costs.
+
+**Файлы для изменения:**
+- `apps/api/src/routes/funding.ts` (создать).
+- `apps/web/src/app/lab/funding/page.tsx` (создать).
+- `apps/web/src/app/lab/funding/CandidatesTable.tsx` (создать).
+- `apps/api/tests/routes/funding.test.ts` (создать).
+
+**Шаги реализации:**
+1. **API.** `POST /funding/scan` → запускает `scanner.scan()` (или эквивалентную функцию из `lib/funding/scanner.ts`), возвращает массив:
+   ```ts
+   type FundingCandidate = {
+     symbol: string;
+     currentFundingRate: number;       // например, 0.0001 = 0.01% per 8h
+     annualizedRate: number;           // *3*365
+     nextFundingTime: string;          // ISO
+     spotBidAsk: { bid: number; ask: number };
+     perpBidAsk: { bid: number; ask: number };
+     spread: number;                   // (perp.mid - spot.mid) / spot.mid
+     estimatedNetReturn: number;       // funding - feesEstimate - spreadCost
+   };
+   ```
+   Если scanner синхронен и быстр — возвращаем сразу. Если требует async fetch — POST возвращает `{ scanId }`, GET `/funding/scan/:id` возвращает результат (как у sweep). Уточнить по существующему `scanner.ts` — какая реализация.
+2. **GET `/funding/snapshots`** — read-only access к существующей `FundingSnapshot` таблице, для history view.
+3. **UI page `/lab/funding`.** Кнопка "Scan now" → POST → таблица результатов. Колонки: Symbol, Funding Rate (8h), Annualized, Next Funding, Spread, Net Return Estimate, Action (кнопка "Open hedge bot" → инстанцирует funding-arb preset с этим symbol).
+4. **Sort / filter.** Default sort by `estimatedNetReturn DESC`. Filter inputs: `min funding rate`, `max spread`, `symbol search`.
+5. Авторизация: только аутентифицированные пользователи.
+6. **Rate limit на `/funding/scan`.** 1 запрос в 30 сек на пользователя — Bybit market-data rate-limit предотвращает спам.
+
+**Тест-план:**
+- POST `/funding/scan` — возвращает массив (mock scanner output).
+- GET `/funding/snapshots` — возвращает persisted history.
+- Action "Open hedge bot" → корректно вызывает `POST /presets/funding-arb/instantiate` с overrides.
+- UI smoke: таблица рендерится, sort/filter работают.
+- Rate limit срабатывает на втором быстром запросе.
+
+**Критерии готовности:**
+- Эндпоинты работают.
+- UI page доступна, smoke прошёл.
+- Existing `lib/funding/scanner.ts` не модифицируется в части business-логики; правки только в части invoke / streaming output.
+
+---
+
+### 55-T4: Funding-arb «strategy mode» + dedicated hedgeBotWorker
+
+**Цель:** ввести `Bot.mode` (enum `DSL | FUNDING_ARB`); создать dedicated runtime `hedgeBotWorker.ts`; routing — по `bot.mode`.
+
+**Файлы для изменения:**
+- `apps/api/prisma/schema.prisma` — `BotMode` enum, `Bot.mode BotMode @default(DSL)`.
+- `apps/api/prisma/migrations/<timestamp>_bot_mode/migration.sql`.
+- `apps/api/src/runtime/hedgeBotWorker.ts` (создать).
+- `apps/api/src/botWorker.ts` — на старте каждого tick / scheduler — если `bot.mode === FUNDING_ARB`, делегировать `hedgeBotWorker.tick(bot)` и пропустить DSL evaluator. Это minimal-touch — добавление одной ветки.
+- `apps/api/prisma/seed/presets/funding-arb.json` (создать) — preset с `defaultBotConfigJson.mode = "FUNDING_ARB"`.
+- `apps/api/src/routes/presets.ts` — instantiate-обработчик из `docs/51-T3` копирует `mode` из `defaultBotConfigJson` в `Bot.create({ mode })`.
+
+**Шаги реализации:**
+1. **Schema.**
+   ```prisma
+   enum BotMode {
+     DSL
+     FUNDING_ARB
+   }
+   model Bot {
+     // ... existing
+     mode BotMode @default(DSL)
+   }
+   ```
+   Миграция additive: existing rows получают `DSL` (default). `bots.test.ts` зелёный без правок.
+2. **`hedgeBotWorker.tick(bot)`:**
+   - Stage 1 (no active hedge): запустить `scanner.scan()`, выбрать кандидата по `bot.config.thresholds`, если есть — POST `/hedges/entry` + POST `/hedges/:id/execute`. После успеха `Bot.lastHedgeId` (новое nullable поле; добавить в той же миграции) указывает на активный hedge.
+   - Stage 2 (active hedge, до funding): sleep до `nextFundingTime + delta_buffer` (нет polling — это event-driven через scheduled task).
+   - Stage 3 (post-funding): verify funding payment via Bybit account API; POST `/hedges/:id/exit`. `Bot.lastHedgeId = null`. Loop to Stage 1.
+   - Каждый stage переход — log + intent в существующий `BotIntent` для аудита (хоть это и не trading intent в DSL смысле, переиспользуем таблицу).
+3. **State machine.** `BotRunState` enum уже существует. Новые «псевдо-состояния» хранятся в `Bot.metaJson.hedgeStage` (`"SCANNING" | "WAITING_FUNDING" | "EXITING"`), не расширяем enum чтобы не ломать существующий код.
+4. **Routing.** В `botWorker.ts` (или scheduler — wherever ticks dispatched) — одна if-ветка:
+   ```ts
+   if (bot.mode === "FUNDING_ARB") {
+     await hedgeBotWorker.tick(bot);
+     return;
+   }
+   // ... existing DSL path
+   ```
+5. **Seed preset.** `funding-arb.json`:
+   ```json
+   {
+     "name": "Funding Arbitrage (Bybit Perp + Spot)",
+     "description": "Delta-neutral hedge: short perp + long spot when funding rate is positive. BETA — multi-leg execution.",
+     "category": "arb",
+     "dslJson": null,
+     "defaultBotConfigJson": {
+       "symbol": "BTCUSDT",
+       "mode": "FUNDING_ARB",
+       "minFundingRate": 0.0002,
+       "maxSpreadBps": 5,
+       "quoteAmount": 1000
+     }
+   }
+   ```
+   Видимость — `BETA` после T6.
+
+**Тест-план:**
+- Миграция applied: existing bots `mode === "DSL"`, новый bot c `mode="FUNDING_ARB"` создаётся.
+- Routing: bot с `mode=DSL` идёт через `botWorker`, evaluator вызывается; bot с `mode=FUNDING_ARB` — через `hedgeBotWorker`, evaluator НЕ вызывается (mock evaluator проверяет 0 вызовов).
+- `hedgeBotWorker.tick`: на mocked scanner выдает кандидата → entry+execute вызываются.
+- `tick` после executed: ожидает funding window → exit вызывается.
+- Recovery: если процесс перезапущен в Stage 2 — на следующем tick stage восстанавливается из `Bot.metaJson.hedgeStage` + `lastHedgeId`.
+
+**Критерии готовности:**
+- Existing DSL-боты работают без регрессий (tests `botWorker/*.test.ts` зелёные).
+- `hedgeBotWorker` тесты зелёные.
+- `botWorker.ts` изменения локализованы в одной if-ветке.
+- Seed preset создан, instantiate работает (проверено вручную).
+
+---
+
+### 55-T5: Spot/perp balance reconciliation + dual API key
+
+**Цель:** dual API key (perp + spot) на уровне `ExchangeConnection`; reconciliation при старте hedge — проверка достаточности balance на обеих сторонах.
+
+**Файлы для изменения:**
+- `apps/api/prisma/schema.prisma` — `ExchangeConnection` расширяется опциональными `spotApiKey String?`, `spotApiSecret String?` (encrypted, reuse existing crypto helpers). Миграция additive.
+- `apps/api/src/lib/exchange/balanceCheck.ts` (создать) — `checkBalanceForHedge(connection, symbol, quoteAmount): Promise<{ ok: boolean; reason?: string }>`.
+- `apps/api/src/runtime/hedgeBotWorker.ts` — вызов `checkBalanceForHedge` перед entry.
+- `apps/api/tests/lib/exchange/balanceCheck.test.ts`.
+- UI: `apps/web/src/app/account/exchange-connection/...` (пути уточнить по существующему фронту) — добавить optional поля spot key/secret.
+
+**Шаги реализации:**
+1. **Schema.** Поля `spotApiKey`, `spotApiSecret` опциональны. Если хотя бы одно null — `ExchangeConnection.canTradeSpot()` возвращает false. Funding-arb боты, которым нужен spot, при `canTradeSpot=false` отказывают в entry с понятной ошибкой.
+2. **balanceCheck.**
+   - Запросить `GET /v5/account/wallet-balance?accountType=UNIFIED` (linear) и `?accountType=SPOT` (или единый — Bybit unified трекинг работает по-разному; уточнить по docs Bybit). Вернуть available USDT-equivalents.
+   - Проверить, что perp side имеет достаточно для short с leverage; spot side имеет достаточно USDT для buy `quoteAmount`.
+   - Безопасный buffer 10% сверх минимума, чтобы fee/slippage не убили execute.
+3. **UI.** В странице ExchangeConnection — два набора полей: "Perp API key/secret" (existing), "Spot API key/secret" (new, optional, с подсказкой "required for funding arbitrage strategy").
+4. **Single-key fallback.** Если у Bybit-аккаунта unified-маржа и один API key с обеими permissions — пользователь оставляет spot fields пустыми; `balanceCheck` использует existing key для обоих запросов. Логика выбора:
+   ```ts
+   const spotCreds = connection.spotApiKey ?? connection.apiKey;
+   ```
+5. **Permissions check на старте.** При создании `ExchangeConnection` или функции "Test connection" — пробуем `GET /v5/account/info` с обоими ключами и проверяем scope'ы (Bybit отдаёт permissions). Если spot scope отсутствует — warning в UI.
+
+**Тест-план:**
+- Миграция applied — existing connections без spot полей живы.
+- `balanceCheck` mock'ed: достаточный баланс → ok; недостаточный → not ok с reason.
+- Single-key fallback: connection без spot key → balanceCheck использует apiKey, не падает.
+- UI smoke: spot fields добавляются, сохраняются, отображаются маскированными.
+
+**Критерии готовности:**
+- `ExchangeConnection` расширен.
+- `balanceCheck` работает для обоих режимов (single-key и dual-key).
+- `hedgeBotWorker` отказывает в entry при недостаточном балансе с понятной ошибкой.
+- UI обновлён, smoke прошёл.
+
+---
+
+### 55-T6: Acceptance gate (60-мин demo с funding event) + BETA publish + matrix update
+
+**Цель:** acceptance gate (60-мин demo run with funding event); расширение PresetVisibility до `BETA`; публикация `funding-arb` как `BETA`; capability matrix update.
+
+**Файлы для изменения:**
+- `apps/api/prisma/schema.prisma` — расширить `PresetVisibility` enum (см. §Решение A4).
+- `apps/api/prisma/migrations/<timestamp>_preset_beta/migration.sql`.
+- `apps/api/src/routes/presets.ts` — корректировка фильтрации `visibility IN ('PUBLIC', 'BETA')` для аутентифицированных user'ов.
+- `apps/web/src/app/lab/library/PresetCard.tsx` — BETA badge (yellow, текст "BETA — multi-leg execution, monitor closely").
+- `apps/api/scripts/demoSmoke.fundingArb.ts` (создать) — обёртка demoSmoke, заточенная под funding event window.
+- `docs/55-baseline-results.md` (создать) — companion-doc с раунд-ап.
+- `docs/strategies/04-funding-arbitrage-delta-hedge.md` — добавить implementation status block.
+- `docs/strategies/08-strategy-capability-matrix.md` — строка `funding-arb: implemented (BETA)`.
+
+**Шаги реализации:**
+1. **Schema.** `ALTER TYPE "PresetVisibility" ADD VALUE 'BETA' BEFORE 'PUBLIC'`. Existing rows с `PRIVATE` или `PUBLIC` остаются. Default не меняется.
+2. **Filtering.** В `GET /presets` без auth → `visibility = "PUBLIC"`. С auth → `visibility IN ("PUBLIC", "BETA")`. С admin → всё. Update `getPreset` аналогично.
+3. **UI badge.** На `PresetCard` если `preset.visibility === "BETA"` — yellow badge + tooltip с warning text. Тот же подход для странице `/bots/:id` если `bot.templateSlug` соответствует BETA preset'у.
+4. **Acceptance run.**
+   - Скрипт `demoSmoke.fundingArb.ts`: принимает `--funding-time T` (next funding timestamp). Запускает бот за 30 мин до T, мониторит до T+30 мин.
+   - Acceptance criteria:
+     - Entry: hedge entered with both legs filled (LegExecution × 2 records exist) до funding_time.
+     - Funding payment: запрос Bybit account API после funding_time подтверждает payment.
+     - Exit: hedge exited with both legs closed после funding payment.
+     - P&L: `realized_pnl ≈ funding_payment − total_fees − slippage_estimate`. Tolerance ±20% (потому что demo Bybit может flash-tick spreads).
+     - 0 unhandled errors в течение всего run.
+   - Если acceptance fail на первой попытке — не паника. Funding events каждые 8h; повторить на следующем. Документировать каждый attempt в companion-doc.
+5. **Publish.**
+   - `publishPreset.ts --slug funding-arb --visibility BETA` (расширить скрипт из `docs/53-T4` поддержкой `BETA` value).
+   - Audit log entry.
+6. **Matrix + concept doc updates** — те же что в `docs/53-T5`/`docs/54-T4`, но для funding-arb.
+
+**Тест-план:**
+- Миграция enum applied, existing API endpoints не сломаны.
+- Filtering корректен на трёх уровнях (none / authed / admin).
+- BETA badge виден в UI.
+- `demoSmoke.fundingArb.ts` запускается, отчёт сохранён.
+- Acceptance criteria evaluated в companion-doc для конкретного run.
+
+**Критерии готовности:**
+- `funding-arb` в `BETA`, виден в `/lab/library` для аутентифицированных user'ов с явным badge.
+- Companion-doc заполнен реальным runs.
+- Capability matrix обновлён.
+- Concept doc содержит implementation status.
+- Acceptance pass подтверждён хотя бы для одного funding event window.
+
+---
+
+## Порядок выполнения задач
+
+```
+55-T1 (spot adapter) ──┐
+55-T3 (scanner UI)  ──┴──→ 55-T2 (spot exec) ──→ 55-T4 (mode + worker) ──→ 55-T5 (balance) ──→ 55-T6 (acceptance + BETA)
+```
+
+- 55-T1 и 55-T3 — независимы и могут идти параллельно. T1 — фундамент; T3 — пользовательский discovery surface.
+- 55-T2 (spot execution) требует T1 (spot adapter) и существующего `bybitOrder` с `category=spot`.
+- 55-T4 (mode + worker) — после T2 (worker вызывает execute).
+- 55-T5 (balance) — после T4 (worker integration point для balanceCheck перед entry).
+- 55-T6 (acceptance + BETA publish) — последняя; требует всё предыдущее.
+
+Каждая T-задача — отдельный PR. T1 + T3 могут идти в одном спринте параллельно.
+
+## Зависимости от других документов
+
+- `docs/50` — родительский overview, `§Решение 4` явно указывает funding-arb как параллельный трек.
+- `docs/51` — обязателен. T6 публикует preset через preset system; T6 расширяет `PresetVisibility` enum, заведённый в `docs/51-T1`.
+- `docs/52` — **независим.** Funding-arb single-TF (smoke интервал — типично M5 для мониторинга, но не требует bundle). Никаких блок-зависимостей.
+- `docs/53/54` — независимы. Funding-arb идёт параллельно. T6 (go/no-go gate) в `docs/54` обновляется доп строкой про funding-arb sub-gate.
+- `docs/strategies/04-funding-arbitrage-delta-hedge.md` — concept-doc, обновляется в T6.
+- `docs/strategies/08-strategy-capability-matrix.md` — matrix, обновляется в T6.
+- `docs/15-operations.md` — runbook должен включать «как остановить активный hedge при инциденте» (добавить параграф в T6 либо отдельным follow-up).
+
+## Backward compatibility checklist
+
+- Все Prisma миграции — additive: новый `Bot.mode` с default `DSL` (existing rows получают этот default), новые nullable spot credentials в `ExchangeConnection`, новое значение `BETA` в `PresetVisibility` enum.
+- Existing DSL-боты работают без правок. Routing в `botWorker.ts` — одна if-ветка на старте tick.
+- `bybitOrder.ts` — без правок (уже параметризован).
+- `routes/hedges.ts` `/entry` endpoint — без правок (только creation `BotIntent` записей). Изменения в `/execute` и `/exit`.
+- `lib/funding/scanner.ts` — без правок business-логики.
+- `signalEngine.ts`, `exitEngine.ts`, `positionManager.ts`, `dslEvaluator.ts` — не модифицируются. Funding-arb их не использует.
+- `routes/presets.ts` (`docs/51-T2/T3`) — фильтры `visibility` в two мест расширяются на `BETA`; instantiate-обработчик копирует `mode` из defaultBotConfigJson — это лёгкое расширение, не breaking.
+- Existing Lab Library carddesign — добавляется один conditional badge для `BETA`; PUBLIC карточки выглядят без изменений.
+- AI-чат, Lab Build/Test/Optimise/Walk-Forward — не затронуты.
+
+## Ожидаемый результат
+
+После закрытия 55-T1..55-T6:
+
+- В Lab Library 5 карточек: 4 PUBLIC (Adaptive Regime, DCA Momentum, MTF Scalper, SMC Liquidity Sweep) + 1 BETA (Funding Arb) с явным warning-badge.
+- Bybit Spot adapter `bybitSpot.ts` существует, market-data доступна по public endpoints.
+- Spot-нога реально исполняется через `bybitOrder({ category: "spot" })`. `LegExecution` записи реальные, не «бумажные».
+- Dedicated `hedgeBotWorker` обрабатывает funding-arb cycle (scan → entry → wait → exit) без вмешательства в DSL `botWorker`.
+- Funding scanner UI доступен в `/lab/funding`; пользователь видит candidates с net-return оценкой.
+- ExchangeConnection поддерживает dual API key (perp + spot), balanceCheck блокирует entry при недостаточных средствах.
+- Acceptance gate пройден: 60-минутный demo run с реальным funding event подтвердил end-to-end funding-arb cycle.
+- BETA visibility означает: видно аутентифицированным user'ам, но not promoted to anonymous landing. Промоция в PUBLIC — после 30+ days BETA с положительной operational telemetry, отдельным решением вне этого документа.
+- Docs/16 roadmap отражает: 5 флагманов delivered (4 PUBLIC, 1 BETA). Stage 3 закрыт.


### PR DESCRIPTION
## Summary

Дочерние документы плана активации флагманов (`docs/50` уже в main через #320). Все пять — самодостаточные, по шаблону `docs/47`: Контекст / Цель / Не входит / Архитектурные решения / Задачи Tn / Порядок / Зависимости / Backward compatibility / Ожидаемый результат.

- **`docs/51-strategy-preset-system.md`** (436 строк) — `StrategyPreset` Prisma model, CRUD, `POST /presets/:slug/instantiate` (транзакция Strategy + StrategyVersion + Bot DRAFT), `Bot.templateSlug`, Lab Library UI, seed для 4 пресетов в PRIVATE. 7 T-задач.
- **`docs/52-multi-interval-dataset-bundle.md`** (389 строк) — `datasetBundleJson` как JSON-поле на Bot/BacktestSweep/WalkForwardRun (без отдельной таблицы DatasetBundle); `loadCandleBundle` с in-memory cache; runtime прокидывает CandleBundle в `dslEvaluator`; backtest получает overload с look-ahead bias guard; UI multi-TF селектор. Включает bugfix interval-фильтра в `botWorker.ts:1467`. 6 T-задач.
- **`docs/53-adaptive-regime-bot-activation.md`** (362 строки) — первая end-to-end активация. Финальный DSL через примитивы (composite signal types развёрнуты по `docs/50 §Решение 3`), walk-forward acceptance (6 folds), 30-мин demo smoke harness, visibility flip PRIVATE→PUBLIC, capability matrix. 6 T-задач.
- **`docs/54-flagship-rollout.md`** (357 строк) — DCA Momentum (single-TF) / MTF Scalper (M1+M5+M15) / SMC Liquidity Sweep (M15+H1+H4) по тому же шаблону, что Adaptive Regime. T6 — production go/no-go gate audit-template (9 критериев, sign-off). 6 T-задач.
- **`docs/55-funding-arbitrage-plan.md`** (450 строк) — параллельный трек. Bybit Spot adapter (market-data; trading через уже параметризованный `bybitOrder` с `category="spot"`), завершение spot-leg execution в `/hedges/*`, funding scanner UI, dedicated `hedgeBotWorker` под новый `Bot.mode = FUNDING_ARB` (не лезет в основной botWorker), dual API key в ExchangeConnection, BETA visibility. 60-мин acceptance с привязкой к funding event window. 6 T-задач.

Никакого кода не меняется в этом PR — только markdown-доки. Все архитектурные решения зафиксированы как именованные «Решение N» с обоснованием выбора.

## Test plan

- [ ] Документы рендерятся на GitHub (внутренние ссылки кликабельны, code blocks подсвечены).
- [ ] Каждый документ содержит все стандартные разделы (Контекст / Цель / Не входит / Архитектурные решения / Задачи Tn / Порядок / Зависимости / BC / Ожидаемый результат).
- [ ] Перекрёстные ссылки между 50/51/52/53/54/55 валидны.
- [ ] Capability matrix `docs/strategies/08` не сломан (изменения матрицы — внутри T-задач, не в этом PR).
- [ ] CI lint/typecheck/test — зелёный (правки только docs/, side-effects не ожидаются).

https://claude.ai/code/session_01PuFfc3HFSuGvkgxr7nMr1y

---
_Generated by [Claude Code](https://claude.ai/code/session_01PuFfc3HFSuGvkgxr7nMr1y)_