### PR TITLE
feat(prisma): StrategyPreset model + templateSlug columns (51-T1+T4)

### DIFF
--- a/apps/api/prisma/migrations/20260430000000_strategy_preset/migration.sql
+++ b/apps/api/prisma/migrations/20260430000000_strategy_preset/migration.sql
@@ -1,0 +1,37 @@
+-- 51-T1 + 51-T4: StrategyPreset model + Bot/Strategy.templateSlug.
+-- Additive migration only — no ALTER on existing data, no backfill.
+--
+-- StrategyPreset is an immutable JSON template that acts as a factory for
+-- StrategyVersion. Bot.templateSlug / Strategy.templateSlug carry the
+-- preset slug as a plain string (no FK), so deleting a preset does not
+-- cascade to existing bots.
+
+-- ── PresetVisibility enum ───────────────────────────────────────────────────
+CREATE TYPE "PresetVisibility" AS ENUM ('PRIVATE', 'PUBLIC');
+
+-- ── StrategyPreset table ────────────────────────────────────────────────────
+CREATE TABLE "StrategyPreset" (
+    "slug"                  TEXT NOT NULL,
+    "name"                  TEXT NOT NULL,
+    "description"           TEXT NOT NULL,
+    "category"              TEXT NOT NULL,
+    "dslJson"               JSONB NOT NULL,
+    "defaultBotConfigJson"  JSONB NOT NULL,
+    "datasetBundleHintJson" JSONB,
+    "visibility"            "PresetVisibility" NOT NULL DEFAULT 'PRIVATE',
+    "createdAt"             TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt"             TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "StrategyPreset_pkey" PRIMARY KEY ("slug")
+);
+
+CREATE INDEX "StrategyPreset_visibility_idx" ON "StrategyPreset"("visibility");
+CREATE INDEX "StrategyPreset_category_idx"   ON "StrategyPreset"("category");
+
+-- ── Strategy.templateSlug (51-T4) ───────────────────────────────────────────
+ALTER TABLE "Strategy" ADD COLUMN "templateSlug" TEXT;
+CREATE INDEX "Strategy_templateSlug_idx" ON "Strategy"("templateSlug");
+
+-- ── Bot.templateSlug (51-T4) ────────────────────────────────────────────────
+ALTER TABLE "Bot" ADD COLUMN "templateSlug" TEXT;
+CREATE INDEX "Bot_templateSlug_idx" ON "Bot"("templateSlug");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -94,14 +94,17 @@ enum Timeframe {
 }
 
 model Strategy {
-  id          String         @id @default(uuid())
-  workspaceId String
-  name        String
-  symbol      String
-  timeframe   Timeframe
-  status      StrategyStatus @default(DRAFT)
-  createdAt   DateTime       @default(now())
-  updatedAt   DateTime       @updatedAt
+  id           String         @id @default(uuid())
+  workspaceId  String
+  name         String
+  symbol       String
+  timeframe    Timeframe
+  status       StrategyStatus @default(DRAFT)
+  /// Optional link to the StrategyPreset this strategy was instantiated from.
+  /// String reference, no FK — preset can be deleted without cascading.
+  templateSlug String?
+  createdAt    DateTime       @default(now())
+  updatedAt    DateTime       @updatedAt
 
   workspace Workspace        @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
   versions  StrategyVersion[]
@@ -109,6 +112,7 @@ model Strategy {
 
   @@unique([workspaceId, name])
   @@index([workspaceId])
+  @@index([templateSlug])
 }
 
 model StrategyVersion {
@@ -146,6 +150,9 @@ model Bot {
   symbol               String
   timeframe            Timeframe
   status               BotStatus       @default(DRAFT)
+  /// Optional link to the StrategyPreset this bot was instantiated from.
+  /// String reference, no FK — preset can be deleted without cascading.
+  templateSlug         String?
   createdAt            DateTime        @default(now())
   updatedAt            DateTime        @updatedAt
 
@@ -160,6 +167,7 @@ model Bot {
   @@index([strategyVersionId])
   @@index([workspaceId, symbol])
   @@index([exchangeConnectionId])
+  @@index([templateSlug])
 }
 
 // ── Bot runtime domain ───────────────────────────────────────────
@@ -851,4 +859,33 @@ model LabJournalEntry {
   @@index([workspaceId])
   @@index([strategyGraphVersionId])
   @@index([workspaceId, createdAt(sort: Desc)])
+}
+
+// ── Strategy Preset (docs/51) ───────────────────────────────────────────────
+//
+// Immutable JSON template that acts as a factory for StrategyVersion.
+// Instantiation flow (POST /presets/:slug/instantiate) creates a fresh
+// Strategy + StrategyVersion + Bot triple in a single transaction.
+// Preset itself is not a runtime entity — once a Bot is created, the link
+// is preserved only via Bot.templateSlug (string, no FK).
+
+enum PresetVisibility {
+  PRIVATE
+  PUBLIC
+}
+
+model StrategyPreset {
+  slug                  String           @id
+  name                  String
+  description           String
+  category              String
+  dslJson               Json
+  defaultBotConfigJson  Json
+  datasetBundleHintJson Json?
+  visibility            PresetVisibility @default(PRIVATE)
+  createdAt             DateTime         @default(now())
+  updatedAt             DateTime         @updatedAt
+
+  @@index([visibility])
+  @@index([category])
 }

--- a/apps/api/tests/prisma/strategyPreset.test.ts
+++ b/apps/api/tests/prisma/strategyPreset.test.ts
@@ -1,0 +1,59 @@
+/**
+ * 51-T1 + 51-T4 — Prisma type sanity for the new StrategyPreset model and
+ * the additive Bot/Strategy.templateSlug columns.
+ *
+ * This is a type-level smoke test: it asserts that `prisma generate` produced
+ * the expected types after the migration. The actual DB-level behaviour
+ * (CREATE TABLE, default visibility, unique slug) is verified by Prisma at
+ * `prisma migrate deploy` time and is out of scope here.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  PresetVisibility,
+  type Bot,
+  type Strategy,
+  type StrategyPreset,
+} from "@prisma/client";
+
+describe("StrategyPreset (51-T1) — generated types", () => {
+  it("StrategyPreset row matches declared schema", () => {
+    const row: StrategyPreset = {
+      slug: "test-preset",
+      name: "Test Preset",
+      description: "A preset",
+      category: "trend",
+      dslJson: { ok: true },
+      defaultBotConfigJson: { symbol: "BTCUSDT", timeframe: "M15" },
+      datasetBundleHintJson: null,
+      visibility: PresetVisibility.PRIVATE,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    expect(row.slug).toBe("test-preset");
+    expect(row.visibility).toBe(PresetVisibility.PRIVATE);
+  });
+
+  it("PresetVisibility enum exposes both members", () => {
+    expect(PresetVisibility.PRIVATE).toBe("PRIVATE");
+    expect(PresetVisibility.PUBLIC).toBe("PUBLIC");
+  });
+});
+
+describe("Bot.templateSlug + Strategy.templateSlug (51-T4)", () => {
+  it("Bot exposes nullable templateSlug column", () => {
+    const slot: Pick<Bot, "templateSlug"> = { templateSlug: null };
+    expect(slot.templateSlug).toBeNull();
+
+    const tagged: Pick<Bot, "templateSlug"> = { templateSlug: "adaptive-regime" };
+    expect(tagged.templateSlug).toBe("adaptive-regime");
+  });
+
+  it("Strategy exposes nullable templateSlug column", () => {
+    const slot: Pick<Strategy, "templateSlug"> = { templateSlug: null };
+    expect(slot.templateSlug).toBeNull();
+
+    const tagged: Pick<Strategy, "templateSlug"> = { templateSlug: "dca-momentum" };
+    expect(tagged.templateSlug).toBe("dca-momentum");
+  });
+});


### PR DESCRIPTION
## Summary

Bundles 51-T1 (StrategyPreset model) with 51-T4 (templateSlug columns) — both are pure Prisma migrations and ship cleaner as a single additive change.

- New `StrategyPreset` model + `PresetVisibility` enum (PRIVATE | PUBLIC). Slug is the primary key; preset is immutable from the runtime's POV.
- New nullable `templateSlug` columns on `Bot` and `Strategy`. No FK so deleting a preset never cascades onto existing bots (per `docs/51 §Решение 1`).
- Type-level smoke test under `tests/prisma/strategyPreset.test.ts` to verify `prisma generate` produced the expected types.

CRUD endpoints, instantiate transaction, and seed land in follow-up PRs (51-T2, 51-T3, 51-T6). UI Library (51-T5) and the e2e spec (51-T7) are deferred to a later session.

## Test plan
- [x] `npx prisma generate` succeeds, no schema drift on existing models.
- [x] `npx tsc --noEmit` clean.
- [x] `npx vitest run tests/prisma/strategyPreset.test.ts` — 4/4 green.
- [x] `npx vitest run tests/routes/bots.test.ts tests/routes/strategies.test.ts` — 45/45 green (no regression on existing flows).
- [ ] CI green on `main` after merge.

Refs: docs/50 §Решение 1, docs/51-T1, docs/51-T4.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4cpvmWXEqCw697QZWRV7b)_