### PR TITLE
feat(api): preset CRUD endpoints + admin guard (51-T2)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -26,6 +26,7 @@ import { fundingRoutes } from "./routes/funding.js";
 import { hedgeRoutes } from "./routes/hedges.js";
 import { notificationRoutes } from "./routes/notifications.js";
 import { clientErrorRoutes } from "./routes/clientErrors.js";
+import { presetRoutes } from "./routes/presets.js";
 
 /**
  * Wrap a route plugin with a per-route rate-limit override.
@@ -60,6 +61,7 @@ async function registerRoutes(scope: import("fastify").FastifyInstance) {
   await scope.register(authRoutes);
   await scope.register(workspacesRoutes);
   await scope.register(strategyRoutes);
+  await scope.register(presetRoutes);
   await scope.register(botRoutes);
   await scope.register(runRoutes);
   await scope.register(intentRoutes);

--- a/apps/api/src/lib/adminGuard.ts
+++ b/apps/api/src/lib/adminGuard.ts
@@ -1,0 +1,36 @@
+/**
+ * Admin guard — minimal env-based authentication for catalog-management
+ * endpoints (e.g. POST /presets in docs/51-T2).
+ *
+ * The platform does not yet have a global "platform admin" role. Until that
+ * lands, endpoints that mutate cross-workspace catalogs gate on a shared
+ * secret carried in the `X-Admin-Token` header and matched against
+ * `process.env.ADMIN_API_TOKEN` in constant time. If the env var is unset
+ * the guard refuses every request — so a misconfigured deploy fails closed.
+ */
+
+import { timingSafeEqual } from "node:crypto";
+import type { FastifyRequest } from "fastify";
+
+const ADMIN_TOKEN_HEADER = "x-admin-token";
+
+/**
+ * Returns true when the request carries a valid admin token.
+ *
+ * Behaviour:
+ * - `ADMIN_API_TOKEN` env var unset → always false (fails closed).
+ * - Header missing or wrong length → false.
+ * - Otherwise constant-time comparison.
+ */
+export function isAdminRequest(request: FastifyRequest): boolean {
+  const expected = process.env.ADMIN_API_TOKEN;
+  if (!expected) return false;
+
+  const provided = request.headers[ADMIN_TOKEN_HEADER];
+  if (typeof provided !== "string" || provided.length === 0) return false;
+
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}

--- a/apps/api/src/routes/presets.ts
+++ b/apps/api/src/routes/presets.ts
@@ -1,0 +1,227 @@
+/**
+ * Strategy Preset routes (docs/51-T2).
+ *
+ * Public catalog of immutable JSON templates that the Lab Library renders
+ * as cards and that POST /presets/:slug/instantiate (51-T3) materialises
+ * into Strategy + StrategyVersion + Bot triples.
+ *
+ * Endpoints:
+ *   POST /presets         — admin-only; create a preset (validates DSL)
+ *   GET  /presets         — list (PUBLIC only for anon; all for admin)
+ *   GET  /presets/:slug   — single preset with dslJson
+ *
+ * No PATCH / DELETE: presets are intentionally immutable. To replace,
+ * create a new slug.
+ */
+
+import type { FastifyInstance } from "fastify";
+import { Prisma, PresetVisibility } from "@prisma/client";
+import { prisma } from "../lib/prisma.js";
+import { problem } from "../lib/problem.js";
+import { validateDsl } from "../lib/dslValidator.js";
+import { isAdminRequest } from "../lib/adminGuard.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const SLUG_REGEX = /^[a-z0-9-]{3,64}$/;
+const VALID_CATEGORIES = ["trend", "dca", "scalping", "smc", "arb"] as const;
+const VALID_TIMEFRAMES = ["M1", "M5", "M15", "H1"] as const;
+
+type Category = typeof VALID_CATEGORIES[number];
+type Timeframe = typeof VALID_TIMEFRAMES[number];
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface DefaultBotConfig {
+  symbol: string;
+  timeframe: Timeframe;
+  quoteAmount: number;
+  maxOpenPositions: number;
+  [k: string]: unknown;
+}
+
+interface CreatePresetBody {
+  slug: string;
+  name: string;
+  description: string;
+  category: Category;
+  dslJson: unknown;
+  defaultBotConfigJson: DefaultBotConfig;
+  datasetBundleHintJson?: Record<string, unknown> | null;
+  visibility?: "PRIVATE" | "PUBLIC";
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+function validateCreateBody(
+  body: Partial<CreatePresetBody> | null | undefined,
+): { errors: Array<{ field: string; message: string }>; data?: CreatePresetBody } {
+  const errors: Array<{ field: string; message: string }> = [];
+  const b = body ?? {};
+
+  if (typeof b.slug !== "string" || !SLUG_REGEX.test(b.slug)) {
+    errors.push({ field: "slug", message: "slug must match /^[a-z0-9-]{3,64}$/" });
+  }
+  if (typeof b.name !== "string" || b.name.length < 1 || b.name.length > 120) {
+    errors.push({ field: "name", message: "name must be 1..120 chars" });
+  }
+  if (typeof b.description !== "string" || b.description.length < 1 || b.description.length > 500) {
+    errors.push({ field: "description", message: "description must be 1..500 chars" });
+  }
+  if (typeof b.category !== "string" || !VALID_CATEGORIES.includes(b.category as Category)) {
+    errors.push({
+      field: "category",
+      message: `category must be one of: ${VALID_CATEGORIES.join(", ")}`,
+    });
+  }
+  if (b.dslJson === undefined || b.dslJson === null) {
+    errors.push({ field: "dslJson", message: "dslJson is required" });
+  }
+
+  const cfg = b.defaultBotConfigJson;
+  if (!cfg || typeof cfg !== "object" || Array.isArray(cfg)) {
+    errors.push({ field: "defaultBotConfigJson", message: "defaultBotConfigJson is required" });
+  } else {
+    if (typeof cfg.symbol !== "string" || cfg.symbol.length === 0) {
+      errors.push({ field: "defaultBotConfigJson.symbol", message: "symbol is required" });
+    }
+    if (typeof cfg.timeframe !== "string" || !VALID_TIMEFRAMES.includes(cfg.timeframe as Timeframe)) {
+      errors.push({
+        field: "defaultBotConfigJson.timeframe",
+        message: `timeframe must be one of: ${VALID_TIMEFRAMES.join(", ")}`,
+      });
+    }
+    if (typeof cfg.quoteAmount !== "number" || !(cfg.quoteAmount > 0)) {
+      errors.push({ field: "defaultBotConfigJson.quoteAmount", message: "quoteAmount must be > 0" });
+    }
+    if (typeof cfg.maxOpenPositions !== "number" || !Number.isInteger(cfg.maxOpenPositions) || cfg.maxOpenPositions < 1) {
+      errors.push({
+        field: "defaultBotConfigJson.maxOpenPositions",
+        message: "maxOpenPositions must be a positive integer",
+      });
+    }
+  }
+
+  if (b.datasetBundleHintJson !== undefined && b.datasetBundleHintJson !== null) {
+    if (typeof b.datasetBundleHintJson !== "object" || Array.isArray(b.datasetBundleHintJson)) {
+      errors.push({
+        field: "datasetBundleHintJson",
+        message: "datasetBundleHintJson must be an object or null",
+      });
+    }
+  }
+
+  if (b.visibility !== undefined && b.visibility !== "PRIVATE" && b.visibility !== "PUBLIC") {
+    errors.push({ field: "visibility", message: "visibility must be PRIVATE or PUBLIC" });
+  }
+
+  if (errors.length > 0) return { errors };
+  return { errors: [], data: b as CreatePresetBody };
+}
+
+// ---------------------------------------------------------------------------
+// Routes
+// ---------------------------------------------------------------------------
+
+export async function presetRoutes(app: FastifyInstance) {
+  // POST /presets — admin only
+  app.post<{ Body: CreatePresetBody }>("/presets", async (request, reply) => {
+    if (!isAdminRequest(request)) {
+      return problem(reply, 401, "Unauthorized", "Admin token required");
+    }
+
+    const { errors, data } = validateCreateBody(request.body);
+    if (!data) {
+      return problem(reply, 400, "Validation Error", "Invalid preset payload", { errors });
+    }
+
+    const dslErrors = validateDsl(data.dslJson);
+    if (dslErrors) {
+      return problem(reply, 400, "Validation Error", "DSL validation failed", { errors: dslErrors });
+    }
+
+    try {
+      const created = await prisma.strategyPreset.create({
+        data: {
+          slug: data.slug,
+          name: data.name,
+          description: data.description,
+          category: data.category,
+          dslJson: data.dslJson as Prisma.InputJsonValue,
+          defaultBotConfigJson: data.defaultBotConfigJson as unknown as Prisma.InputJsonValue,
+          datasetBundleHintJson:
+            data.datasetBundleHintJson === undefined || data.datasetBundleHintJson === null
+              ? Prisma.JsonNull
+              : (data.datasetBundleHintJson as Prisma.InputJsonValue),
+          visibility: data.visibility ?? PresetVisibility.PRIVATE,
+        },
+      });
+      return reply.status(201).send(created);
+    } catch (err) {
+      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
+        return problem(reply, 409, "Conflict", `Preset "${data.slug}" already exists`);
+      }
+      throw err;
+    }
+  });
+
+  // GET /presets — public (PUBLIC only) or admin (all)
+  app.get<{ Querystring: { category?: string; visibility?: string } }>(
+    "/presets",
+    async (request, reply) => {
+      const admin = isAdminRequest(request);
+      const where: Prisma.StrategyPresetWhereInput = {};
+
+      // Visibility scoping
+      if (!admin) {
+        where.visibility = PresetVisibility.PUBLIC;
+      } else if (request.query?.visibility === "PRIVATE" || request.query?.visibility === "PUBLIC") {
+        where.visibility = request.query.visibility as PresetVisibility;
+      }
+
+      // Category filter
+      const categoryFilter = request.query?.category;
+      if (typeof categoryFilter === "string" && VALID_CATEGORIES.includes(categoryFilter as Category)) {
+        where.category = categoryFilter;
+      }
+
+      const rows = await prisma.strategyPreset.findMany({
+        where,
+        orderBy: { updatedAt: "desc" },
+        select: {
+          slug: true,
+          name: true,
+          description: true,
+          category: true,
+          defaultBotConfigJson: true,
+          datasetBundleHintJson: true,
+          visibility: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+      });
+      return reply.send(rows);
+    },
+  );
+
+  // GET /presets/:slug — full record
+  app.get<{ Params: { slug: string } }>("/presets/:slug", async (request, reply) => {
+    const admin = isAdminRequest(request);
+    const preset = await prisma.strategyPreset.findUnique({
+      where: { slug: request.params.slug },
+    });
+
+    // 404 (not 403) on PRIVATE without admin so existence is not revealed.
+    if (!preset || (preset.visibility === PresetVisibility.PRIVATE && !admin)) {
+      return problem(reply, 404, "Not Found", "Preset not found");
+    }
+
+    return reply.send(preset);
+  });
+}

--- a/apps/api/tests/routes/presets.test.ts
+++ b/apps/api/tests/routes/presets.test.ts
@@ -1,0 +1,364 @@
+/**
+ * Route tests: presets.ts (docs/51-T2)
+ *
+ * Covers POST /presets, GET /presets, GET /presets/:slug — visibility scoping,
+ * slug regex, DSL validation, admin token gating, and 404-not-403 leakage rule
+ * for PRIVATE presets.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from "vitest";
+
+// ── Mock state ──────────────────────────────────────────────────────────────
+
+const mockPresets: Record<string, Record<string, unknown>> = {};
+
+// ── Mock Prisma ─────────────────────────────────────────────────────────────
+
+vi.mock("@prisma/client", () => {
+  class PrismaClientKnownRequestError extends Error {
+    code: string;
+    constructor(message: string, opts: { code: string }) {
+      super(message);
+      this.code = opts.code;
+    }
+  }
+  return {
+    PrismaClient: vi.fn().mockImplementation(() => ({})),
+    Prisma: {
+      sql: vi.fn(),
+      join: vi.fn(),
+      JsonNull: "DbNull",
+      InputJsonValue: {} as never,
+      PrismaClientKnownRequestError,
+    },
+    PresetVisibility: { PRIVATE: "PRIVATE", PUBLIC: "PUBLIC" },
+  };
+});
+
+vi.mock("../../src/lib/prisma.js", () => ({
+  prisma: {
+    strategyPreset: {
+      create: vi.fn().mockImplementation(async ({ data }: { data: Record<string, unknown> }) => {
+        const slug = data.slug as string;
+        if (mockPresets[slug]) {
+          // emulate Prisma unique-constraint violation
+          const { Prisma } = await import("@prisma/client");
+          throw new Prisma.PrismaClientKnownRequestError("Unique constraint failed", { code: "P2002" } as never);
+        }
+        const row = {
+          ...data,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        };
+        mockPresets[slug] = row;
+        return row;
+      }),
+      findMany: vi.fn().mockImplementation(({ where, select }: { where: Record<string, unknown>; select?: Record<string, boolean> }) => {
+        const visibility = where?.visibility;
+        const category = where?.category;
+        const matched = Object.values(mockPresets).filter((p) => {
+          if (visibility !== undefined && p.visibility !== visibility) return false;
+          if (category !== undefined && p.category !== category) return false;
+          return true;
+        });
+        // Honour `select`: include only keys with truthy value (mirrors Prisma).
+        const projected = select
+          ? matched.map((row) => {
+              const out: Record<string, unknown> = {};
+              for (const [k, v] of Object.entries(select)) {
+                if (v) out[k] = (row as Record<string, unknown>)[k];
+              }
+              return out;
+            })
+          : matched;
+        return Promise.resolve(projected);
+      }),
+      findUnique: vi.fn().mockImplementation(({ where }: { where: { slug: string } }) => {
+        return Promise.resolve(mockPresets[where.slug] ?? null);
+      }),
+    },
+  },
+}));
+
+// Validate-DSL stub: accept any object that has `dslVersion` set, reject otherwise.
+// This is intentionally narrower than the real validator — we just need a way
+// to assert the route calls it before persisting.
+vi.mock("../../src/lib/dslValidator.js", () => ({
+  validateDsl: vi.fn().mockImplementation((dsl: unknown) => {
+    if (!dsl || typeof dsl !== "object") return [{ field: "dslJson", message: "must be object" }];
+    if ((dsl as Record<string, unknown>).dslVersion === undefined) {
+      return [{ field: "dslVersion", message: "missing" }];
+    }
+    return null;
+  }),
+}));
+
+import { buildApp } from "../../src/app.js";
+import type { FastifyInstance } from "fastify";
+
+// ── Setup ───────────────────────────────────────────────────────────────────
+
+let app: FastifyInstance;
+const ADMIN_TOKEN = "test-admin-token-very-secret";
+
+beforeAll(async () => {
+  process.env.ADMIN_API_TOKEN = ADMIN_TOKEN;
+  app = await buildApp();
+});
+
+afterAll(async () => {
+  delete process.env.ADMIN_API_TOKEN;
+  await app.close();
+});
+
+beforeEach(() => {
+  Object.keys(mockPresets).forEach((k) => delete mockPresets[k]);
+});
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function adminHeaders() {
+  return { "x-admin-token": ADMIN_TOKEN, "content-type": "application/json" };
+}
+
+const VALID_DSL = { dslVersion: 1, name: "x" };
+
+const VALID_BODY = {
+  slug: "trend-test",
+  name: "Trend Test",
+  description: "A test preset",
+  category: "trend" as const,
+  dslJson: VALID_DSL,
+  defaultBotConfigJson: {
+    symbol: "BTCUSDT",
+    timeframe: "M15" as const,
+    quoteAmount: 100,
+    maxOpenPositions: 1,
+  },
+};
+
+async function seedPreset(slug: string, visibility: "PRIVATE" | "PUBLIC", category = "trend") {
+  mockPresets[slug] = {
+    slug,
+    name: `Preset ${slug}`,
+    description: `Description ${slug}`,
+    category,
+    dslJson: VALID_DSL,
+    defaultBotConfigJson: { symbol: "BTCUSDT", timeframe: "M15", quoteAmount: 100, maxOpenPositions: 1 },
+    datasetBundleHintJson: null,
+    visibility,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// POST /api/v1/presets
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("POST /api/v1/presets", () => {
+  it("returns 401 without admin token", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/presets",
+      headers: { "content-type": "application/json" },
+      payload: VALID_BODY,
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns 401 with wrong admin token", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/presets",
+      headers: { "x-admin-token": "wrong", "content-type": "application/json" },
+      payload: VALID_BODY,
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("rejects uppercase slug (400)", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/presets",
+      headers: adminHeaders(),
+      payload: { ...VALID_BODY, slug: "Bad-SLUG" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().errors.some((e: { field: string }) => e.field === "slug")).toBe(true);
+  });
+
+  it("rejects invalid category (400)", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/presets",
+      headers: adminHeaders(),
+      payload: { ...VALID_BODY, category: "bogus" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().errors.some((e: { field: string }) => e.field === "category")).toBe(true);
+  });
+
+  it("rejects DSL that fails validateDsl (400)", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/presets",
+      headers: adminHeaders(),
+      payload: { ...VALID_BODY, dslJson: { malformed: true } },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().detail).toMatch(/DSL/);
+  });
+
+  it("creates preset (201) and persists with default PRIVATE visibility", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/presets",
+      headers: adminHeaders(),
+      payload: VALID_BODY,
+    });
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.slug).toBe(VALID_BODY.slug);
+    expect(body.visibility).toBe("PRIVATE");
+    expect(mockPresets[VALID_BODY.slug]).toBeDefined();
+  });
+
+  it("returns 409 on duplicate slug", async () => {
+    const r1 = await app.inject({
+      method: "POST",
+      url: "/api/v1/presets",
+      headers: adminHeaders(),
+      payload: VALID_BODY,
+    });
+    expect(r1.statusCode).toBe(201);
+    const r2 = await app.inject({
+      method: "POST",
+      url: "/api/v1/presets",
+      headers: adminHeaders(),
+      payload: VALID_BODY,
+    });
+    expect(r2.statusCode).toBe(409);
+  });
+
+  it("rejects defaultBotConfigJson with bad timeframe (400)", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/presets",
+      headers: adminHeaders(),
+      payload: {
+        ...VALID_BODY,
+        defaultBotConfigJson: { ...VALID_BODY.defaultBotConfigJson, timeframe: "M30" },
+      },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GET /api/v1/presets
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("GET /api/v1/presets", () => {
+  it("returns only PUBLIC presets without admin token", async () => {
+    await seedPreset("public-a", "PUBLIC");
+    await seedPreset("public-b", "PUBLIC", "dca");
+    await seedPreset("private-a", "PRIVATE");
+
+    const res = await app.inject({ method: "GET", url: "/api/v1/presets" });
+    expect(res.statusCode).toBe(200);
+    const slugs = (res.json() as Array<{ slug: string }>).map((p) => p.slug).sort();
+    expect(slugs).toEqual(["public-a", "public-b"]);
+  });
+
+  it("returns all presets with admin token", async () => {
+    await seedPreset("public-a", "PUBLIC");
+    await seedPreset("private-a", "PRIVATE");
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/presets",
+      headers: { "x-admin-token": ADMIN_TOKEN },
+    });
+    expect(res.statusCode).toBe(200);
+    expect((res.json() as unknown[]).length).toBe(2);
+  });
+
+  it("filters by category", async () => {
+    await seedPreset("trend-a", "PUBLIC", "trend");
+    await seedPreset("dca-a", "PUBLIC", "dca");
+
+    const res = await app.inject({ method: "GET", url: "/api/v1/presets?category=dca" });
+    expect(res.statusCode).toBe(200);
+    const rows = res.json() as Array<{ slug: string }>;
+    expect(rows.map((r) => r.slug)).toEqual(["dca-a"]);
+  });
+
+  it("does not include dslJson in list response", async () => {
+    await seedPreset("public-a", "PUBLIC");
+    const res = await app.inject({ method: "GET", url: "/api/v1/presets" });
+    const rows = res.json() as Array<Record<string, unknown>>;
+    expect(rows[0]).not.toHaveProperty("dslJson");
+    expect(rows[0]).toHaveProperty("defaultBotConfigJson");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GET /api/v1/presets/:slug
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("GET /api/v1/presets/:slug", () => {
+  it("returns 404 for unknown slug", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/v1/presets/does-not-exist" });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 404 (not 403) for PRIVATE preset without admin", async () => {
+    await seedPreset("secret", "PRIVATE");
+    const res = await app.inject({ method: "GET", url: "/api/v1/presets/secret" });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 200 with dslJson for PUBLIC preset (anonymous)", async () => {
+    await seedPreset("public-a", "PUBLIC");
+    const res = await app.inject({ method: "GET", url: "/api/v1/presets/public-a" });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.slug).toBe("public-a");
+    expect(body.dslJson).toBeDefined();
+    expect(body.visibility).toBe("PUBLIC");
+  });
+
+  it("returns 200 for PRIVATE preset with admin token", async () => {
+    await seedPreset("secret", "PRIVATE");
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/presets/secret",
+      headers: { "x-admin-token": ADMIN_TOKEN },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().slug).toBe("secret");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// adminGuard fail-closed
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("adminGuard — fail-closed when env is unset", () => {
+  it("rejects POST when ADMIN_API_TOKEN is unset, even with header", async () => {
+    const previous = process.env.ADMIN_API_TOKEN;
+    delete process.env.ADMIN_API_TOKEN;
+    try {
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/presets",
+        headers: { "x-admin-token": "anything", "content-type": "application/json" },
+        payload: VALID_BODY,
+      });
+      expect(res.statusCode).toBe(401);
+    } finally {
+      process.env.ADMIN_API_TOKEN = previous;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds the read/write surface for the Strategy Preset catalog from `docs/51-T2`. Builds on T1+T4 (PR #322).

- `POST /presets` — admin-only; validates body shape (slug regex `/^[a-z0-9-]{3,64}$/`, category whitelist, required fields) and runs `validateDsl` before persisting. Maps Prisma P2002 → 409.
- `GET /presets` — anonymous returns `visibility=PUBLIC` only; admin token unlocks all and accepts optional `?visibility=` and `?category=`. List responses intentionally omit `dslJson` (catalog metadata only).
- `GET /presets/:slug` — returns the full record including `dslJson`. PRIVATE preset without admin → **404** (not 403) so the existence is not revealed.

The platform has no global admin role yet, so writes are gated by a shared secret in the `X-Admin-Token` header, compared in constant time against `process.env.ADMIN_API_TOKEN`. **Fails closed when the env var is unset**, so a misconfigured deploy cannot accept writes.

No PATCH/DELETE — presets are immutable per `docs/51 §"Не входит в задачу"`.

## Test plan
- [x] `npx tsc --noEmit` clean.
- [x] `npx vitest run tests/routes/presets.test.ts` — 17/17 green (admin gating incl. fail-closed, slug regex, category whitelist, DSL rejection, duplicate slugs, list visibility scoping, category filter, dslJson absence in list response, 404-not-403 leakage rule).
- [x] `npx vitest run tests/routes/bots.test.ts tests/routes/strategies.test.ts tests/prisma/strategyPreset.test.ts` — 49/49 (no regressions).
- [ ] CI green on `main` after merge.

## Operator note
`ADMIN_API_TOKEN` must be added to staging/prod env before this can be used to seed presets. Until then write endpoints fail closed and read endpoints return only PUBLIC presets (the catalog is empty until 51-T6 lands).

Refs: docs/51-T2.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4cpvmWXEqCw697QZWRV7b)_