### PR TITLE
feat(api): preset instantiate transaction (51-T3)

### DIFF
--- a/apps/api/src/routes/presets.ts
+++ b/apps/api/src/routes/presets.ts
@@ -1,25 +1,28 @@
 /**
- * Strategy Preset routes (docs/51-T2).
+ * Strategy Preset routes (docs/51-T2 + 51-T3).
  *
- * Public catalog of immutable JSON templates that the Lab Library renders
- * as cards and that POST /presets/:slug/instantiate (51-T3) materialises
- * into Strategy + StrategyVersion + Bot triples.
+ * Public catalog of immutable JSON templates. The Lab Library renders the
+ * list as cards and POST /presets/:slug/instantiate materialises them into
+ * Strategy + StrategyVersion + Bot triples in a single Prisma transaction.
  *
  * Endpoints:
- *   POST /presets         — admin-only; create a preset (validates DSL)
- *   GET  /presets         — list (PUBLIC only for anon; all for admin)
- *   GET  /presets/:slug   — single preset with dslJson
+ *   POST /presets                       — admin-only; create a preset (validates DSL)
+ *   GET  /presets                       — list (PUBLIC only for anon; all for admin)
+ *   GET  /presets/:slug                 — single preset with dslJson
+ *   POST /presets/:slug/instantiate     — workspace user; create Strategy + Version + Bot
  *
  * No PATCH / DELETE: presets are intentionally immutable. To replace,
  * create a new slug.
  */
 
+import { randomBytes } from "node:crypto";
 import type { FastifyInstance } from "fastify";
 import { Prisma, PresetVisibility } from "@prisma/client";
 import { prisma } from "../lib/prisma.js";
 import { problem } from "../lib/problem.js";
 import { validateDsl } from "../lib/dslValidator.js";
 import { isAdminRequest } from "../lib/adminGuard.js";
+import { resolveWorkspace } from "../lib/workspace.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -53,6 +56,78 @@ interface CreatePresetBody {
   defaultBotConfigJson: DefaultBotConfig;
   datasetBundleHintJson?: Record<string, unknown> | null;
   visibility?: "PRIVATE" | "PUBLIC";
+}
+
+interface InstantiateBody {
+  overrides?: Partial<{
+    symbol: string;
+    timeframe: Timeframe;
+    quoteAmount: number;
+    maxOpenPositions: number;
+    name: string;
+  }>;
+}
+
+interface ResolvedConfig {
+  symbol: string;
+  timeframe: Timeframe;
+  quoteAmount: number;
+  maxOpenPositions: number;
+  baseName: string;
+}
+
+function resolveConfig(
+  preset: { name: string; defaultBotConfigJson: Prisma.JsonValue },
+  overrides: InstantiateBody["overrides"],
+): { config?: ResolvedConfig; errors: Array<{ field: string; message: string }> } {
+  const errors: Array<{ field: string; message: string }> = [];
+  const cfg = preset.defaultBotConfigJson as Record<string, unknown> | null;
+  if (!cfg || typeof cfg !== "object" || Array.isArray(cfg)) {
+    errors.push({ field: "preset.defaultBotConfigJson", message: "preset has no usable default config" });
+    return { errors };
+  }
+
+  const symbol = (overrides?.symbol ?? cfg.symbol) as unknown;
+  const timeframe = (overrides?.timeframe ?? cfg.timeframe) as unknown;
+  const quoteAmount = (overrides?.quoteAmount ?? cfg.quoteAmount) as unknown;
+  const maxOpenPositions = (overrides?.maxOpenPositions ?? cfg.maxOpenPositions) as unknown;
+  const baseName = (overrides?.name ?? preset.name) as unknown;
+
+  if (typeof symbol !== "string" || symbol.length === 0) {
+    errors.push({ field: "symbol", message: "symbol must be a non-empty string" });
+  }
+  if (typeof timeframe !== "string" || !VALID_TIMEFRAMES.includes(timeframe as Timeframe)) {
+    errors.push({
+      field: "timeframe",
+      message: `timeframe must be one of: ${VALID_TIMEFRAMES.join(", ")}`,
+    });
+  }
+  if (typeof quoteAmount !== "number" || !(quoteAmount > 0)) {
+    errors.push({ field: "quoteAmount", message: "quoteAmount must be > 0" });
+  }
+  if (
+    typeof maxOpenPositions !== "number" ||
+    !Number.isInteger(maxOpenPositions) ||
+    maxOpenPositions < 1
+  ) {
+    errors.push({ field: "maxOpenPositions", message: "maxOpenPositions must be a positive integer" });
+  }
+  if (typeof baseName !== "string" || baseName.length === 0 || baseName.length > 120) {
+    errors.push({ field: "name", message: "name must be 1..120 chars" });
+  }
+
+  if (errors.length > 0) return { errors };
+
+  return {
+    errors: [],
+    config: {
+      symbol: symbol as string,
+      timeframe: timeframe as Timeframe,
+      quoteAmount: quoteAmount as number,
+      maxOpenPositions: maxOpenPositions as number,
+      baseName: baseName as string,
+    },
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -224,4 +299,98 @@ export async function presetRoutes(app: FastifyInstance) {
 
     return reply.send(preset);
   });
+
+  // POST /presets/:slug/instantiate — workspace user creates Strategy + Version + Bot
+  //
+  // Workspace is taken from the X-Workspace-Id header (same convention as the
+  // rest of the API), not the body. The docs/51-T3 spec sketches `workspaceId`
+  // in the body, but using the header keeps membership enforcement uniform via
+  // resolveWorkspace().
+  app.post<{ Params: { slug: string }; Body: InstantiateBody }>(
+    "/presets/:slug/instantiate",
+    { onRequest: [app.authenticate] },
+    async (request, reply) => {
+      const workspace = await resolveWorkspace(request, reply);
+      if (!workspace) return;
+
+      const admin = isAdminRequest(request);
+      const preset = await prisma.strategyPreset.findUnique({
+        where: { slug: request.params.slug },
+      });
+      // PRIVATE presets are invisible to non-admins (matches GET semantics).
+      if (!preset || (preset.visibility === PresetVisibility.PRIVATE && !admin)) {
+        return problem(reply, 404, "Not Found", "Preset not found");
+      }
+
+      const overrides = request.body?.overrides;
+      const { config, errors } = resolveConfig(preset, overrides);
+      if (!config) {
+        return problem(reply, 400, "Validation Error", "Invalid instantiate payload", { errors });
+      }
+
+      // Generate a unique-per-workspace suffix for both Strategy and Bot names
+      // so repeated instantiate calls do not collide on the (workspaceId, name)
+      // unique index. Six hex chars = 24 bits of entropy — plenty for human
+      // disambiguation, retry-free.
+      const suffix = randomBytes(3).toString("hex");
+      const strategyName = `${config.baseName} (${suffix})`;
+      const botName = `${config.baseName} (${suffix})`;
+
+      try {
+        const result = await prisma.$transaction(async (tx) => {
+          const strategy = await tx.strategy.create({
+            data: {
+              workspaceId: workspace.id,
+              name: strategyName,
+              symbol: config.symbol,
+              timeframe: config.timeframe,
+              status: "DRAFT",
+              templateSlug: preset.slug,
+            },
+          });
+
+          const version = await tx.strategyVersion.create({
+            data: {
+              strategyId: strategy.id,
+              version: 1,
+              dslJson: preset.dslJson as Prisma.InputJsonValue,
+              executionPlanJson: {
+                kind: "preset",
+                presetSlug: preset.slug,
+                createdAt: new Date().toISOString(),
+              } as Prisma.InputJsonValue,
+            },
+          });
+
+          const bot = await tx.bot.create({
+            data: {
+              workspaceId: workspace.id,
+              name: botName,
+              strategyVersionId: version.id,
+              symbol: config.symbol,
+              timeframe: config.timeframe,
+              status: "DRAFT",
+              templateSlug: preset.slug,
+            },
+          });
+
+          return { strategy, version, bot };
+        });
+
+        return reply.status(201).send({
+          botId: result.bot.id,
+          strategyId: result.strategy.id,
+          strategyVersionId: result.version.id,
+        });
+      } catch (err) {
+        if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
+          // Astronomically unlikely with 24-bit suffix, but handle the
+          // (workspaceId, name) clash explicitly so the client gets a clean
+          // signal to retry.
+          return problem(reply, 409, "Conflict", "Generated name collided; please retry");
+        }
+        throw err;
+      }
+    },
+  );
 }

--- a/apps/api/tests/routes/presets.test.ts
+++ b/apps/api/tests/routes/presets.test.ts
@@ -1,9 +1,11 @@
 /**
- * Route tests: presets.ts (docs/51-T2)
+ * Route tests: presets.ts (docs/51-T2 + 51-T3)
  *
  * Covers POST /presets, GET /presets, GET /presets/:slug — visibility scoping,
- * slug regex, DSL validation, admin token gating, and 404-not-403 leakage rule
- * for PRIVATE presets.
+ * slug regex, DSL validation, admin token gating, 404-not-403 leakage rule —
+ * and POST /presets/:slug/instantiate — workspace gating, override merging,
+ * transactional Strategy + StrategyVersion + Bot create, and rollback when
+ * the Bot.create step fails.
  */
 
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from "vitest";
@@ -11,6 +13,17 @@ import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from "vites
 // ── Mock state ──────────────────────────────────────────────────────────────
 
 const mockPresets: Record<string, Record<string, unknown>> = {};
+const mockStrategies: Record<string, Record<string, unknown>> = {};
+const mockStrategyVersions: Record<string, Record<string, unknown>> = {};
+const mockBots: Record<string, Record<string, unknown>> = {};
+const mockWorkspaceMemberships: Array<Record<string, unknown>> = [];
+
+let strategyIdCounter = 0;
+let strategyVersionIdCounter = 0;
+let botIdCounter = 0;
+
+// Test-time hook: the next Bot.create raises this error (one-shot).
+let botCreateError: Error | null = null;
 
 // ── Mock Prisma ─────────────────────────────────────────────────────────────
 
@@ -35,21 +48,57 @@ vi.mock("@prisma/client", () => {
   };
 });
 
-vi.mock("../../src/lib/prisma.js", () => ({
-  prisma: {
+vi.mock("../../src/lib/prisma.js", () => {
+  // Build a "tx" client whose create methods write to a per-transaction
+  // staging buffer. On commit, staging is flushed to the global mocks; on
+  // throw, staging is discarded — emulating Prisma rollback semantics.
+  function buildTx(staging: {
+    strategies: Record<string, Record<string, unknown>>;
+    versions: Record<string, Record<string, unknown>>;
+    bots: Record<string, Record<string, unknown>>;
+  }) {
+    return {
+      strategy: {
+        create: vi.fn().mockImplementation(({ data }: { data: Record<string, unknown> }) => {
+          const id = `strat-${++strategyIdCounter}`;
+          const row = { id, ...data, createdAt: new Date(), updatedAt: new Date() };
+          staging.strategies[id] = row;
+          return Promise.resolve(row);
+        }),
+      },
+      strategyVersion: {
+        create: vi.fn().mockImplementation(({ data }: { data: Record<string, unknown> }) => {
+          const id = `sv-${++strategyVersionIdCounter}`;
+          const row = { id, ...data, createdAt: new Date() };
+          staging.versions[id] = row;
+          return Promise.resolve(row);
+        }),
+      },
+      bot: {
+        create: vi.fn().mockImplementation(({ data }: { data: Record<string, unknown> }) => {
+          if (botCreateError) {
+            const err = botCreateError;
+            botCreateError = null;
+            return Promise.reject(err);
+          }
+          const id = `bot-${++botIdCounter}`;
+          const row = { id, ...data, createdAt: new Date(), updatedAt: new Date() };
+          staging.bots[id] = row;
+          return Promise.resolve(row);
+        }),
+      },
+    };
+  }
+
+  const prisma = {
     strategyPreset: {
       create: vi.fn().mockImplementation(async ({ data }: { data: Record<string, unknown> }) => {
         const slug = data.slug as string;
         if (mockPresets[slug]) {
-          // emulate Prisma unique-constraint violation
           const { Prisma } = await import("@prisma/client");
           throw new Prisma.PrismaClientKnownRequestError("Unique constraint failed", { code: "P2002" } as never);
         }
-        const row = {
-          ...data,
-          createdAt: new Date(),
-          updatedAt: new Date(),
-        };
+        const row = { ...data, createdAt: new Date(), updatedAt: new Date() };
         mockPresets[slug] = row;
         return row;
       }),
@@ -61,7 +110,6 @@ vi.mock("../../src/lib/prisma.js", () => ({
           if (category !== undefined && p.category !== category) return false;
           return true;
         });
-        // Honour `select`: include only keys with truthy value (mirrors Prisma).
         const projected = select
           ? matched.map((row) => {
               const out: Record<string, unknown> = {};
@@ -77,8 +125,36 @@ vi.mock("../../src/lib/prisma.js", () => ({
         return Promise.resolve(mockPresets[where.slug] ?? null);
       }),
     },
-  },
-}));
+    workspaceMember: {
+      findUnique: vi.fn().mockImplementation(({ where }: { where: { workspaceId_userId: { workspaceId: string; userId: string } } }) => {
+        const m = mockWorkspaceMemberships.find(
+          (r) =>
+            r.workspaceId === where.workspaceId_userId.workspaceId &&
+            r.userId === where.workspaceId_userId.userId,
+        );
+        if (!m) return Promise.resolve(null);
+        return Promise.resolve({ ...m, workspace: { id: m.workspaceId, name: "Test WS" } });
+      }),
+    },
+    $transaction: vi.fn().mockImplementation(async (cb: (tx: ReturnType<typeof buildTx>) => Promise<unknown>) => {
+      const staging = {
+        strategies: {} as Record<string, Record<string, unknown>>,
+        versions: {} as Record<string, Record<string, unknown>>,
+        bots: {} as Record<string, Record<string, unknown>>,
+      };
+      const tx = buildTx(staging);
+      const result = await cb(tx); // throws → staging is dropped (rollback)
+      // Commit: flush staging into the global mocks.
+      Object.assign(mockStrategies, staging.strategies);
+      Object.assign(mockStrategyVersions, staging.versions);
+      Object.assign(mockBots, staging.bots);
+      return result;
+    }),
+    $connect: vi.fn(),
+    $disconnect: vi.fn(),
+  };
+  return { prisma };
+});
 
 // Validate-DSL stub: accept any object that has `dslVersion` set, reject otherwise.
 // This is intentionally narrower than the real validator — we just need a way
@@ -99,11 +175,15 @@ import type { FastifyInstance } from "fastify";
 // ── Setup ───────────────────────────────────────────────────────────────────
 
 let app: FastifyInstance;
+let userToken: string;
 const ADMIN_TOKEN = "test-admin-token-very-secret";
+const WS_ID = "ws-preset-test";
+const USER_ID = "user-preset-1";
 
 beforeAll(async () => {
   process.env.ADMIN_API_TOKEN = ADMIN_TOKEN;
   app = await buildApp();
+  userToken = app.jwt.sign({ sub: USER_ID, email: "preset@test.com" });
 });
 
 afterAll(async () => {
@@ -113,6 +193,16 @@ afterAll(async () => {
 
 beforeEach(() => {
   Object.keys(mockPresets).forEach((k) => delete mockPresets[k]);
+  Object.keys(mockStrategies).forEach((k) => delete mockStrategies[k]);
+  Object.keys(mockStrategyVersions).forEach((k) => delete mockStrategyVersions[k]);
+  Object.keys(mockBots).forEach((k) => delete mockBots[k]);
+  mockWorkspaceMemberships.length = 0;
+  strategyIdCounter = 0;
+  strategyVersionIdCounter = 0;
+  botIdCounter = 0;
+  botCreateError = null;
+
+  mockWorkspaceMemberships.push({ userId: USER_ID, workspaceId: WS_ID, role: "OWNER" });
 });
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -360,5 +450,165 @@ describe("adminGuard — fail-closed when env is unset", () => {
     } finally {
       process.env.ADMIN_API_TOKEN = previous;
     }
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// POST /api/v1/presets/:slug/instantiate
+// ═══════════════════════════════════════════════════════════════════════════
+
+function userHeaders() {
+  return {
+    authorization: `Bearer ${userToken}`,
+    "x-workspace-id": WS_ID,
+    "content-type": "application/json",
+  };
+}
+
+describe("POST /api/v1/presets/:slug/instantiate", () => {
+  it("returns 401 without auth", async () => {
+    await seedPreset("public-a", "PUBLIC");
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/presets/public-a/instantiate",
+      payload: {},
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns 403 for non-member workspace", async () => {
+    await seedPreset("public-a", "PUBLIC");
+    mockWorkspaceMemberships.length = 0;
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/presets/public-a/instantiate",
+      headers: userHeaders(),
+      payload: {},
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("returns 404 for unknown slug", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/presets/does-not-exist/instantiate",
+      headers: userHeaders(),
+      payload: {},
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 404 (not 403) for PRIVATE preset without admin token", async () => {
+    await seedPreset("secret", "PRIVATE");
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/presets/secret/instantiate",
+      headers: userHeaders(),
+      payload: {},
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("instantiates PRIVATE preset when admin token is provided", async () => {
+    await seedPreset("secret", "PRIVATE");
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/presets/secret/instantiate",
+      headers: { ...userHeaders(), "x-admin-token": ADMIN_TOKEN },
+      payload: {},
+    });
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.botId).toBeDefined();
+    expect(body.strategyId).toBeDefined();
+    expect(body.strategyVersionId).toBeDefined();
+  });
+
+  it("creates exactly one Strategy + Version + Bot, all tagged with templateSlug", async () => {
+    await seedPreset("public-a", "PUBLIC");
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/presets/public-a/instantiate",
+      headers: userHeaders(),
+      payload: {},
+    });
+    expect(res.statusCode).toBe(201);
+    expect(Object.keys(mockStrategies)).toHaveLength(1);
+    expect(Object.keys(mockStrategyVersions)).toHaveLength(1);
+    expect(Object.keys(mockBots)).toHaveLength(1);
+
+    const strategy = Object.values(mockStrategies)[0];
+    const version = Object.values(mockStrategyVersions)[0];
+    const bot = Object.values(mockBots)[0];
+
+    expect(strategy.templateSlug).toBe("public-a");
+    expect(strategy.workspaceId).toBe(WS_ID);
+    expect(bot.templateSlug).toBe("public-a");
+    expect(bot.workspaceId).toBe(WS_ID);
+    expect(bot.status).toBe("DRAFT");
+    expect(bot.strategyVersionId).toBe(version.id);
+    expect(version.strategyId).toBe(strategy.id);
+    expect(version.dslJson).toEqual(VALID_DSL);
+  });
+
+  it("honours overrides.symbol", async () => {
+    await seedPreset("public-a", "PUBLIC");
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/presets/public-a/instantiate",
+      headers: userHeaders(),
+      payload: { overrides: { symbol: "ETHUSDT" } },
+    });
+    expect(res.statusCode).toBe(201);
+    const bot = Object.values(mockBots)[0];
+    expect(bot.symbol).toBe("ETHUSDT");
+  });
+
+  it("rejects unsupported timeframe in overrides (400)", async () => {
+    await seedPreset("public-a", "PUBLIC");
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/presets/public-a/instantiate",
+      headers: userHeaders(),
+      payload: { overrides: { timeframe: "M30" } },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rolls back Strategy + StrategyVersion when Bot.create fails", async () => {
+    await seedPreset("public-a", "PUBLIC");
+    botCreateError = new Error("simulated bot.create failure");
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/presets/public-a/instantiate",
+      headers: userHeaders(),
+      payload: {},
+    });
+    expect(res.statusCode).toBe(500);
+    // Nothing committed — staging was discarded.
+    expect(Object.keys(mockStrategies)).toHaveLength(0);
+    expect(Object.keys(mockStrategyVersions)).toHaveLength(0);
+    expect(Object.keys(mockBots)).toHaveLength(0);
+  });
+
+  it("two consecutive instantiate calls produce two independent triples", async () => {
+    await seedPreset("public-a", "PUBLIC");
+    const r1 = await app.inject({
+      method: "POST",
+      url: "/api/v1/presets/public-a/instantiate",
+      headers: userHeaders(),
+      payload: {},
+    });
+    const r2 = await app.inject({
+      method: "POST",
+      url: "/api/v1/presets/public-a/instantiate",
+      headers: userHeaders(),
+      payload: {},
+    });
+    expect(r1.statusCode).toBe(201);
+    expect(r2.statusCode).toBe(201);
+    expect(r1.json().botId).not.toBe(r2.json().botId);
+    expect(Object.keys(mockBots)).toHaveLength(2);
+    expect(Object.keys(mockStrategies)).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary

`POST /presets/:slug/instantiate` — authenticated workspace user trades a preset slug for a Strategy + StrategyVersion + Bot triple, all created inside a single Prisma interactive transaction (per `docs/51 §Решение 2`). Builds on PR #322 (T1+T4) and PR #323 (T2).

- 401 without JWT, 403 for non-members (via existing `resolveWorkspace`).
- 404 for unknown slug **or** PRIVATE preset without admin token — matches GET semantics so existence is not leaked.
- Body shape: `{ overrides?: { symbol?, timeframe?, quoteAmount?, maxOpenPositions?, name? } }`. Workspace is taken from the `X-Workspace-Id` header (uniform with the rest of the API; small deviation from `docs/51-T3` which sketched `workspaceId` in the body — chose header for consistency with `resolveWorkspace`).
- Strategy and Bot names suffixed with a 24-bit hex chunk to avoid collisions on `(workspaceId, name)` unique index across repeat instantiations. P2002 still falls back to 409 just in case.
- `StrategyVersion.executionPlanJson` is `{ kind: "preset", presetSlug, createdAt }` — runtime treats it as opaque per `docs/50 §Решение 1`.
- Response: `201 { botId, strategyId, strategyVersionId }`. Bot starts in `DRAFT`; activation is the standard `POST /bots/:id/start`.

The preset path adds **zero** runtime semantics — `botWorker.ts`, `signalEngine.ts`, `exitEngine.ts`, `positionManager.ts`, `dslEvaluator.ts` are not touched (invariant from `docs/50 §Решение 1`).

## Test plan
- [x] `npx tsc --noEmit` clean.
- [x] `npx vitest run tests/routes/presets.test.ts` — **27/27** green (10 new instantiate cases on top of T2's 17).
- [x] `npx vitest run tests/routes/bots.test.ts tests/routes/strategies.test.ts tests/prisma/strategyPreset.test.ts` — 49/49 (no regressions).
- [x] Transactional rollback verified: when `Bot.create` throws, neither Strategy nor StrategyVersion are committed (mock with staging buffer).
- [ ] CI green on `main` after merge.

Refs: docs/51-T3, docs/50 §Решение 1, docs/50 §Решение 2.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4cpvmWXEqCw697QZWRV7b)_