### PR TITLE
feat(prisma): seed 4 flagship presets as PRIVATE (51-T6)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -37,5 +37,8 @@
     "tsx": "^4.19.0",
     "typescript": "^5.7.0",
     "vitest": "^4.1.0"
+  },
+  "prisma": {
+    "seed": "tsx prisma/seed/index.ts"
   }
 }

--- a/apps/api/prisma/seed/index.ts
+++ b/apps/api/prisma/seed/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Prisma seed entrypoint (docs/51-T6).
+ *
+ * Triggered by `prisma db seed` (configured via `prisma.seed` in
+ * package.json). Currently only seeds Strategy Presets; further seeders
+ * can be appended here.
+ */
+
+import { PrismaClient } from "@prisma/client";
+import { seedPresets } from "./seedPresets.js";
+
+async function main() {
+  const prisma = new PrismaClient();
+  try {
+    const presetResults = await seedPresets(prisma);
+    // eslint-disable-next-line no-console
+    console.log("seedPresets:", presetResults);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((err) => {
+  // eslint-disable-next-line no-console
+  console.error("seed failed:", err);
+  process.exit(1);
+});

--- a/apps/api/prisma/seed/presets/adaptive-regime.json
+++ b/apps/api/prisma/seed/presets/adaptive-regime.json
@@ -1,0 +1,25 @@
+{
+  "name": "Adaptive Regime",
+  "description": "Trend-following + mean-reversion regime switcher. DSL is a placeholder; the final golden fixture lands in docs/53-T1.",
+  "dslJson": {
+    "id": "adaptive-regime",
+    "name": "Adaptive Regime",
+    "dslVersion": 1,
+    "enabled": true,
+    "market": { "exchange": "bybit", "env": "demo", "category": "linear", "symbol": "BTCUSDT" },
+    "entry": { "side": "Buy" },
+    "risk": { "maxPositionSizeUsd": 100, "riskPerTradePct": 1, "cooldownSeconds": 60 },
+    "execution": { "orderType": "Market", "clientOrderIdPrefix": "adaptive" },
+    "guards": { "maxOpenPositions": 1, "maxOrdersPerMinute": 10, "pauseOnError": true }
+  },
+  "defaultBotConfigJson": {
+    "symbol": "BTCUSDT",
+    "timeframe": "M15",
+    "quoteAmount": 100,
+    "maxOpenPositions": 1
+  },
+  "datasetBundleHintJson": {
+    "5m": true,
+    "1H": true
+  }
+}

--- a/apps/api/prisma/seed/presets/dca-momentum.json
+++ b/apps/api/prisma/seed/presets/dca-momentum.json
@@ -1,0 +1,33 @@
+{
+  "name": "DCA Momentum",
+  "description": "Dollar-cost-average ladder triggered by momentum confirmation. DSL is a placeholder; the final golden fixture lands in docs/54.",
+  "dslJson": {
+    "id": "dca-momentum",
+    "name": "DCA Momentum",
+    "dslVersion": 2,
+    "enabled": true,
+    "market": { "exchange": "bybit", "env": "demo", "category": "linear", "symbol": "BTCUSDT" },
+    "entry": { "side": "Buy" },
+    "risk": { "maxPositionSizeUsd": 100, "riskPerTradePct": 1, "cooldownSeconds": 60 },
+    "execution": { "orderType": "Market", "clientOrderIdPrefix": "dca-mom" },
+    "guards": { "maxOpenPositions": 1, "maxOrdersPerMinute": 10, "pauseOnError": true },
+    "exit": {
+      "stopLoss":   { "type": "fixed_pct", "value": 2 },
+      "takeProfit": { "type": "fixed_pct", "value": 1.5 }
+    },
+    "dca": {
+      "baseOrderSizeUsd": 10,
+      "maxSafetyOrders": 3,
+      "priceStepPct": 1,
+      "stepScale": 1.5,
+      "volumeScale": 1.5,
+      "takeProfitPct": 1.5
+    }
+  },
+  "defaultBotConfigJson": {
+    "symbol": "BTCUSDT",
+    "timeframe": "M15",
+    "quoteAmount": 200,
+    "maxOpenPositions": 1
+  }
+}

--- a/apps/api/prisma/seed/presets/mtf-scalper.json
+++ b/apps/api/prisma/seed/presets/mtf-scalper.json
@@ -1,0 +1,26 @@
+{
+  "name": "MTF Confluence Scalper",
+  "description": "Multi-timeframe confluence scalper aligning M1/M5/M15 trend filters. DSL is a placeholder; the final golden fixture lands in docs/54.",
+  "dslJson": {
+    "id": "mtf-scalper",
+    "name": "MTF Confluence Scalper",
+    "dslVersion": 1,
+    "enabled": true,
+    "market": { "exchange": "bybit", "env": "demo", "category": "linear", "symbol": "BTCUSDT" },
+    "entry": { "side": "Buy" },
+    "risk": { "maxPositionSizeUsd": 50, "riskPerTradePct": 0.5, "cooldownSeconds": 30 },
+    "execution": { "orderType": "Market", "clientOrderIdPrefix": "mtf-scalp" },
+    "guards": { "maxOpenPositions": 1, "maxOrdersPerMinute": 20, "pauseOnError": true }
+  },
+  "defaultBotConfigJson": {
+    "symbol": "BTCUSDT",
+    "timeframe": "M1",
+    "quoteAmount": 50,
+    "maxOpenPositions": 1
+  },
+  "datasetBundleHintJson": {
+    "1m": true,
+    "5m": true,
+    "15m": true
+  }
+}

--- a/apps/api/prisma/seed/presets/smc-liquidity-sweep.json
+++ b/apps/api/prisma/seed/presets/smc-liquidity-sweep.json
@@ -1,0 +1,26 @@
+{
+  "name": "SMC Liquidity Sweep",
+  "description": "Smart Money Concepts: liquidity sweep + market-structure-shift entry on FVG retest. DSL is a placeholder; the final golden fixture lands in docs/54.",
+  "dslJson": {
+    "id": "smc-liquidity-sweep",
+    "name": "SMC Liquidity Sweep",
+    "dslVersion": 1,
+    "enabled": true,
+    "market": { "exchange": "bybit", "env": "demo", "category": "linear", "symbol": "BTCUSDT" },
+    "entry": { "side": "Buy" },
+    "risk": { "maxPositionSizeUsd": 100, "riskPerTradePct": 1, "cooldownSeconds": 60 },
+    "execution": { "orderType": "Market", "clientOrderIdPrefix": "smc-sweep" },
+    "guards": { "maxOpenPositions": 1, "maxOrdersPerMinute": 10, "pauseOnError": true }
+  },
+  "defaultBotConfigJson": {
+    "symbol": "BTCUSDT",
+    "timeframe": "M15",
+    "quoteAmount": 100,
+    "maxOpenPositions": 1
+  },
+  "datasetBundleHintJson": {
+    "15m": true,
+    "1H": true,
+    "4H": true
+  }
+}

--- a/apps/api/prisma/seed/seedPresets.ts
+++ b/apps/api/prisma/seed/seedPresets.ts
@@ -1,0 +1,90 @@
+/**
+ * Strategy Preset seed (docs/51-T6).
+ *
+ * Loads the 4 non-Funding flagship presets (Adaptive Regime, DCA Momentum,
+ * MTF Scalper, SMC Liquidity Sweep) from JSON fixtures next to this file
+ * and upserts them into the StrategyPreset table.
+ *
+ * - Inserts always start as `PRIVATE` so a partially-finished preset is
+ *   never visible to end users. Promotion to `PUBLIC` is a separate admin
+ *   step (docs/51 §Решение 3) — the `update` branch below is intentionally
+ *   careful not to roll back a `PUBLIC` flip.
+ * - The DSL inside each fixture is a placeholder. Final flagship-grade DSL
+ *   lands in docs/53 (Adaptive Regime golden fixture) and docs/54 (DCA /
+ *   MTF / SMC). The placeholders are real enough to pass `validateDsl`.
+ */
+
+import { promises as fs } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Prisma, PresetVisibility, type PrismaClient } from "@prisma/client";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+interface PresetFixture {
+  name: string;
+  description: string;
+  dslJson: Record<string, unknown>;
+  defaultBotConfigJson: Record<string, unknown>;
+  datasetBundleHintJson?: Record<string, unknown> | null;
+}
+
+interface PresetSpec {
+  slug: string;
+  category: "trend" | "dca" | "scalping" | "smc" | "arb";
+  file: string;
+}
+
+const PRESETS: PresetSpec[] = [
+  { slug: "adaptive-regime",     category: "trend",    file: "presets/adaptive-regime.json" },
+  { slug: "dca-momentum",        category: "dca",      file: "presets/dca-momentum.json" },
+  { slug: "mtf-scalper",         category: "scalping", file: "presets/mtf-scalper.json" },
+  { slug: "smc-liquidity-sweep", category: "smc",      file: "presets/smc-liquidity-sweep.json" },
+];
+
+async function loadFixture(file: string): Promise<PresetFixture> {
+  const path = resolve(HERE, file);
+  const raw = await fs.readFile(path, "utf8");
+  return JSON.parse(raw) as PresetFixture;
+}
+
+export async function seedPresets(prisma: PrismaClient): Promise<{ slug: string; created: boolean }[]> {
+  const out: { slug: string; created: boolean }[] = [];
+
+  for (const spec of PRESETS) {
+    const fixture = await loadFixture(spec.file);
+
+    const datasetHint =
+      fixture.datasetBundleHintJson === undefined || fixture.datasetBundleHintJson === null
+        ? Prisma.JsonNull
+        : (fixture.datasetBundleHintJson as Prisma.InputJsonValue);
+
+    // The `update` branch deliberately omits `visibility` so an admin who
+    // promoted a preset to PUBLIC is not silently rolled back to PRIVATE
+    // by the next seed run.
+    const result = await prisma.strategyPreset.upsert({
+      where: { slug: spec.slug },
+      create: {
+        slug: spec.slug,
+        category: spec.category,
+        name: fixture.name,
+        description: fixture.description,
+        dslJson: fixture.dslJson as Prisma.InputJsonValue,
+        defaultBotConfigJson: fixture.defaultBotConfigJson as Prisma.InputJsonValue,
+        datasetBundleHintJson: datasetHint,
+        visibility: PresetVisibility.PRIVATE,
+      },
+      update: {
+        category: spec.category,
+        name: fixture.name,
+        description: fixture.description,
+        dslJson: fixture.dslJson as Prisma.InputJsonValue,
+        defaultBotConfigJson: fixture.defaultBotConfigJson as Prisma.InputJsonValue,
+        datasetBundleHintJson: datasetHint,
+      },
+    });
+    out.push({ slug: result.slug, created: result.createdAt.getTime() === result.updatedAt.getTime() });
+  }
+
+  return out;
+}

--- a/apps/api/tests/prisma/seedPresets.test.ts
+++ b/apps/api/tests/prisma/seedPresets.test.ts
@@ -1,0 +1,119 @@
+/**
+ * 51-T6 — seedPresets sanity.
+ *
+ * Verifies that:
+ *  1. each fixture under prisma/seed/presets/ has a real DSL that passes
+ *     `validateDsl`,
+ *  2. seedPresets() upserts all 4 presets, defaulting `visibility` to PRIVATE,
+ *  3. it is idempotent (a second run re-uses the same upsert path), and
+ *  4. the `update` branch does not roll back a manual PUBLIC promotion.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { promises as fs } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { validateDsl } from "../../src/lib/dslValidator.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SEED_DIR = resolve(HERE, "../../prisma/seed/presets");
+
+const SLUGS = ["adaptive-regime", "dca-momentum", "mtf-scalper", "smc-liquidity-sweep"] as const;
+
+// ---------------------------------------------------------------------------
+// Fixture-level DSL validation (no Prisma involved)
+// ---------------------------------------------------------------------------
+
+describe("seed/presets/*.json fixtures", () => {
+  for (const slug of SLUGS) {
+    it(`${slug}.json passes validateDsl`, async () => {
+      const path = resolve(SEED_DIR, `${slug}.json`);
+      const raw = await fs.readFile(path, "utf8");
+      const parsed = JSON.parse(raw) as { dslJson: unknown };
+      const errors = validateDsl(parsed.dslJson);
+      expect(errors).toBeNull();
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// seedPresets() behaviour (Prisma mocked)
+// ---------------------------------------------------------------------------
+
+const mockPresets: Record<string, Record<string, unknown>> = {};
+
+vi.mock("@prisma/client", () => ({
+  PrismaClient: vi.fn(),
+  Prisma: { JsonNull: "DbNull", InputJsonValue: {} as never },
+  PresetVisibility: { PRIVATE: "PRIVATE", PUBLIC: "PUBLIC" },
+}));
+
+const mockPrisma = {
+  strategyPreset: {
+    upsert: vi.fn().mockImplementation(async ({
+      where,
+      create,
+      update,
+    }: {
+      where: { slug: string };
+      create: Record<string, unknown>;
+      update: Record<string, unknown>;
+    }) => {
+      const existing = mockPresets[where.slug];
+      if (existing) {
+        const merged = { ...existing, ...update, updatedAt: new Date() };
+        mockPresets[where.slug] = merged;
+        return merged;
+      }
+      const now = new Date();
+      const fresh = { ...create, createdAt: now, updatedAt: now };
+      mockPresets[where.slug] = fresh;
+      return fresh;
+    }),
+  },
+};
+
+import { seedPresets } from "../../prisma/seed/seedPresets.js";
+
+beforeEach(() => {
+  Object.keys(mockPresets).forEach((k) => delete mockPresets[k]);
+  mockPrisma.strategyPreset.upsert.mockClear();
+});
+
+describe("seedPresets()", () => {
+  it("upserts all 4 presets with visibility=PRIVATE", async () => {
+    const results = await seedPresets(mockPrisma as unknown as import("@prisma/client").PrismaClient);
+    expect(results.map((r) => r.slug).sort()).toEqual([...SLUGS].sort());
+    expect(Object.keys(mockPresets).sort()).toEqual([...SLUGS].sort());
+    for (const slug of SLUGS) {
+      expect(mockPresets[slug].visibility).toBe("PRIVATE");
+      expect(mockPresets[slug].slug).toBe(slug);
+    }
+  });
+
+  it("is idempotent — second run produces no creates", async () => {
+    await seedPresets(mockPrisma as unknown as import("@prisma/client").PrismaClient);
+    await seedPresets(mockPrisma as unknown as import("@prisma/client").PrismaClient);
+    expect(Object.keys(mockPresets)).toHaveLength(SLUGS.length);
+    expect(mockPrisma.strategyPreset.upsert).toHaveBeenCalledTimes(SLUGS.length * 2);
+  });
+
+  it("does not roll back a manual PUBLIC promotion on re-seed", async () => {
+    await seedPresets(mockPrisma as unknown as import("@prisma/client").PrismaClient);
+    // Simulate an admin flipping one preset to PUBLIC out-of-band.
+    mockPresets["adaptive-regime"].visibility = "PUBLIC";
+    await seedPresets(mockPrisma as unknown as import("@prisma/client").PrismaClient);
+    expect(mockPresets["adaptive-regime"].visibility).toBe("PUBLIC");
+    // Other presets remain PRIVATE.
+    expect(mockPresets["dca-momentum"].visibility).toBe("PRIVATE");
+  });
+
+  it("each preset carries the documented category", async () => {
+    await seedPresets(mockPrisma as unknown as import("@prisma/client").PrismaClient);
+    expect(mockPresets["adaptive-regime"].category).toBe("trend");
+    expect(mockPresets["dca-momentum"].category).toBe("dca");
+    expect(mockPresets["mtf-scalper"].category).toBe("scalping");
+    expect(mockPresets["smc-liquidity-sweep"].category).toBe("smc");
+  });
+});


### PR DESCRIPTION
## Summary

Lays down the four non-Funding flagship presets (Adaptive Regime, DCA Momentum, MTF Scalper, SMC Liquidity Sweep) as `PRIVATE` rows so they are ready to be picked up by the per-flagship activation docs (53 / 54). Builds on PR #322 (T1+T4), #323 (T2), #324 (T3).

- JSON fixtures live in `apps/api/prisma/seed/presets/` — one file per preset. DSL inside each fixture is a **minimal-but-valid placeholder** that passes `validateDsl`. The final flagship-grade DSL lands with the activation documents (53-T1 golden fixture; 54 for DCA / MTF / SMC). Each fixture is annotated with this caveat in its `description`.
- `seedPresets.ts` upserts each fixture by slug. The CREATE branch inserts with `visibility=PRIVATE`. The UPDATE branch deliberately **omits** `visibility` so an admin who flipped a preset to PUBLIC is not silently rolled back to PRIVATE on re-seed (per `docs/51 §Решение 3`).
- `seed/index.ts` is the entrypoint, registered via `package.json#prisma.seed` so `prisma db seed` runs it.
- Funding Arb is intentionally excluded — that preset belongs to `docs/55` (parallel track).

## Test plan
- [x] `npx tsc --noEmit` clean.
- [x] `npx vitest run tests/prisma/seedPresets.test.ts` — **8/8** green:
  - each of the 4 JSON fixtures passes `validateDsl`,
  - `seedPresets()` upserts all four as `PRIVATE`,
  - second run is idempotent (no creates),
  - a manual PUBLIC promotion survives re-seed,
  - categories match docs/51-T6.
- [x] Full preset-system test sweep: `presets.test.ts` (27) + `bots.test.ts` (26) + `strategies.test.ts` (19) + `strategyPreset.test.ts` (4) + `seedPresets.test.ts` (8) = **84/84**.
- [ ] CI green on `main` after merge.

## Operator note
After merge, run `prisma db seed` against staging/prod to insert the four PRIVATE presets. Promoting any preset to `PUBLIC` is a separate manual SQL step (or admin tooling, future PR) — only happens after the per-flagship acceptance gate in `docs/50 §A5`.

Refs: docs/51-T6, docs/51 §Решение 3.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4cpvmWXEqCw697QZWRV7b)_