### PR TITLE
feat(lab-ui): /lab/library gallery + InstantiateDialog (51-T5)

### DIFF
--- a/apps/web/src/app/factory/bots/[id]/page.tsx
+++ b/apps/web/src/app/factory/bots/[id]/page.tsx
@@ -27,6 +27,7 @@ interface BotDetail {
   timeframe: string;
   status: string;
   exchangeConnectionId: string | null;
+  templateSlug: string | null;
   strategyVersion: {
     id: string;
     version: number;
@@ -183,6 +184,11 @@ export default function BotDetailPage() {
           <p style={{ color: "var(--text-secondary)", marginBottom: 4 }}>
             {bot.symbol} · {bot.timeframe} · {bot.status}
           </p>
+          {bot.templateSlug && (
+            <p style={{ marginBottom: 4 }}>
+              <span style={presetBadge}>From preset: {bot.templateSlug}</span>
+            </p>
+          )}
           <p style={{ color: "var(--text-secondary)", marginBottom: 4, fontSize: 13 }}>
             Strategy:{" "}
             <Link href={`/factory/strategies/${bot.strategyVersion.strategy.id}`}>
@@ -359,3 +365,15 @@ const btnDanger: React.CSSProperties = { ...btn, background: "#da3633" };
 const btnSecondary: React.CSSProperties = { ...btn, background: "var(--bg-secondary)", border: "1px solid var(--border)", color: "var(--text-primary)" };
 const th: React.CSSProperties = { textAlign: "left", padding: "8px 12px", borderBottom: "1px solid var(--border)", color: "var(--text-secondary)", fontSize: 13 };
 const td: React.CSSProperties = { padding: "8px 12px", borderBottom: "1px solid var(--border)", fontSize: 14 };
+const presetBadge: React.CSSProperties = {
+  display: "inline-block",
+  fontSize: 11,
+  fontWeight: 600,
+  textTransform: "uppercase",
+  letterSpacing: "0.06em",
+  padding: "2px 8px",
+  borderRadius: 4,
+  color: "#3B82F6",
+  background: "rgba(59,130,246,0.12)",
+  border: "1px solid rgba(59,130,246,0.4)",
+};

--- a/apps/web/src/app/lab/LabShell.tsx
+++ b/apps/web/src/app/lab/LabShell.tsx
@@ -14,6 +14,7 @@ import { PreviewPanel } from "./PreviewPanel";
 
 const TABS = [
   { id: "classic", label: "Classic mode", href: "/lab" },
+  { id: "library", label: "Library",      href: "/lab/library" },
   { id: "data",    label: "Data",         href: "/lab/data" },
   { id: "build",   label: "Build",        href: "/lab/build" },
   { id: "test",    label: "Test",         href: "/lab/test" },
@@ -23,6 +24,7 @@ type TabId = (typeof TABS)[number]["id"];
 
 function getActiveTab(pathname: string): TabId {
   if (pathname === "/lab" || pathname === "/lab/") return "classic";
+  if (pathname.startsWith("/lab/library")) return "library";
   if (pathname.startsWith("/lab/data"))  return "data";
   if (pathname.startsWith("/lab/build")) return "build";
   if (pathname.startsWith("/lab/test"))  return "test";

--- a/apps/web/src/app/lab/library/InstantiateDialog.tsx
+++ b/apps/web/src/app/lab/library/InstantiateDialog.tsx
@@ -1,0 +1,384 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  instantiatePreset,
+  type InstantiateOverrides,
+  type PresetSummary,
+  type PresetTimeframe,
+} from "../../../lib/api/presets";
+import type { ProblemDetails } from "../../../lib/api";
+
+const TIMEFRAMES: PresetTimeframe[] = ["M1", "M5", "M15", "H1"];
+
+interface FormState {
+  name: string;
+  symbol: string;
+  timeframe: PresetTimeframe;
+  quoteAmount: string;
+  maxOpenPositions: string;
+}
+
+function initialFormState(preset: PresetSummary): FormState {
+  const cfg = preset.defaultBotConfigJson;
+  return {
+    name: preset.name,
+    symbol: cfg.symbol,
+    timeframe: cfg.timeframe,
+    quoteAmount: String(cfg.quoteAmount),
+    maxOpenPositions: String(cfg.maxOpenPositions),
+  };
+}
+
+export function InstantiateDialog({
+  preset,
+  adminToken,
+  onClose,
+  onCreated,
+}: {
+  preset: PresetSummary;
+  adminToken?: string;
+  onClose: () => void;
+  onCreated: (botId: string) => void;
+}) {
+  const [form, setForm] = useState<FormState>(() => initialFormState(preset));
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<ProblemDetails | string | null>(null);
+
+  useEffect(() => {
+    setForm(initialFormState(preset));
+  }, [preset]);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape" && !submitting) onClose();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose, submitting]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    const quoteAmount = Number(form.quoteAmount);
+    const maxOpenPositions = Number(form.maxOpenPositions);
+    if (!Number.isFinite(quoteAmount) || quoteAmount <= 0) {
+      setError("quoteAmount must be a positive number");
+      return;
+    }
+    if (!Number.isInteger(maxOpenPositions) || maxOpenPositions < 1) {
+      setError("maxOpenPositions must be a positive integer");
+      return;
+    }
+    if (form.symbol.trim().length === 0) {
+      setError("symbol is required");
+      return;
+    }
+    if (form.name.trim().length === 0 || form.name.length > 120) {
+      setError("name must be 1..120 chars");
+      return;
+    }
+
+    const overrides: InstantiateOverrides = {
+      name: form.name,
+      symbol: form.symbol.trim(),
+      timeframe: form.timeframe,
+      quoteAmount,
+      maxOpenPositions,
+    };
+
+    setSubmitting(true);
+    const res = await instantiatePreset(preset.slug, { overrides }, { adminToken });
+    setSubmitting(false);
+
+    if (!res.ok) {
+      setError(res.problem);
+      return;
+    }
+    onCreated(res.data.botId);
+  }
+
+  const hasBundleHint =
+    preset.datasetBundleHintJson != null &&
+    typeof preset.datasetBundleHintJson === "object" &&
+    Object.keys(preset.datasetBundleHintJson as Record<string, unknown>).length > 0;
+
+  return (
+    <div style={overlayStyle} onClick={() => !submitting && onClose()}>
+      <div
+        style={modalStyle}
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Configure preset ${preset.name}`}
+      >
+        <header style={headerStyle}>
+          <h2 style={titleStyle}>{preset.name}</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={submitting}
+            style={closeBtnStyle}
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </header>
+
+        <p style={descStyle}>{preset.description}</p>
+
+        {hasBundleHint && (
+          <div style={hintBoxStyle}>
+            This preset uses multi-interval data. Configure the dataset bundle
+            on the bot page after creation.
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} style={formStyle}>
+          <Field label="Bot name">
+            <input
+              style={inputStyle}
+              value={form.name}
+              onChange={(e) => setForm({ ...form, name: e.target.value })}
+              maxLength={120}
+              required
+            />
+          </Field>
+
+          <div style={rowStyle}>
+            <Field label="Symbol">
+              <input
+                style={inputStyle}
+                value={form.symbol}
+                onChange={(e) => setForm({ ...form, symbol: e.target.value.toUpperCase() })}
+                required
+              />
+            </Field>
+            <Field label="Timeframe">
+              <select
+                style={inputStyle}
+                value={form.timeframe}
+                onChange={(e) => setForm({ ...form, timeframe: e.target.value as PresetTimeframe })}
+              >
+                {TIMEFRAMES.map((tf) => (
+                  <option key={tf} value={tf}>{tf}</option>
+                ))}
+              </select>
+            </Field>
+          </div>
+
+          <div style={rowStyle}>
+            <Field label="Quote amount (USDT)">
+              <input
+                style={inputStyle}
+                type="number"
+                step="any"
+                min="0"
+                value={form.quoteAmount}
+                onChange={(e) => setForm({ ...form, quoteAmount: e.target.value })}
+                required
+              />
+            </Field>
+            <Field label="Max open positions">
+              <input
+                style={inputStyle}
+                type="number"
+                step="1"
+                min="1"
+                value={form.maxOpenPositions}
+                onChange={(e) => setForm({ ...form, maxOpenPositions: e.target.value })}
+                required
+              />
+            </Field>
+          </div>
+
+          {error && <ErrorBox error={error} />}
+
+          <footer style={footerStyle}>
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={submitting}
+              style={secondaryBtnStyle}
+            >
+              Cancel
+            </button>
+            <button type="submit" disabled={submitting} style={primaryBtnStyle}>
+              {submitting ? "Creating…" : "Create bot"}
+            </button>
+          </footer>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label style={fieldStyle}>
+      <span style={fieldLabelStyle}>{label}</span>
+      {children}
+    </label>
+  );
+}
+
+function ErrorBox({ error }: { error: ProblemDetails | string }) {
+  const text = typeof error === "string" ? error : `${error.title}: ${error.detail}`;
+  const fieldErrors =
+    typeof error === "object" && Array.isArray(error.errors) ? error.errors : [];
+  return (
+    <div style={errorBoxStyle}>
+      <strong style={{ color: "#f87171" }}>{text}</strong>
+      {fieldErrors.length > 0 && (
+        <ul style={{ margin: "6px 0 0", paddingLeft: 18, fontSize: 12 }}>
+          {fieldErrors.map((fe, i) => (
+            <li key={i}>
+              <code>{fe.field}</code>: {fe.message}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+const overlayStyle: React.CSSProperties = {
+  position: "fixed",
+  inset: 0,
+  zIndex: 1000,
+  background: "rgba(0,0,0,0.5)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: 16,
+};
+
+const modalStyle: React.CSSProperties = {
+  background: "var(--bg-card)",
+  border: "1px solid var(--border)",
+  borderRadius: 10,
+  padding: 24,
+  width: "100%",
+  maxWidth: 540,
+  maxHeight: "90vh",
+  overflowY: "auto",
+  boxShadow: "0 20px 50px rgba(0,0,0,0.5)",
+};
+
+const headerStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  gap: 12,
+  marginBottom: 8,
+};
+
+const titleStyle: React.CSSProperties = {
+  margin: 0,
+  fontSize: 18,
+  fontWeight: 600,
+  color: "var(--text-primary)",
+};
+
+const closeBtnStyle: React.CSSProperties = {
+  background: "none",
+  border: "none",
+  color: "rgba(255,255,255,0.55)",
+  fontSize: 22,
+  lineHeight: 1,
+  cursor: "pointer",
+  padding: 0,
+  width: 28,
+  height: 28,
+};
+
+const descStyle: React.CSSProperties = {
+  margin: "0 0 16px",
+  color: "var(--text-secondary)",
+  fontSize: 13,
+  lineHeight: 1.5,
+};
+
+const hintBoxStyle: React.CSSProperties = {
+  background: "rgba(59,130,246,0.08)",
+  border: "1px solid rgba(59,130,246,0.3)",
+  borderRadius: 6,
+  padding: "8px 12px",
+  marginBottom: 16,
+  fontSize: 12,
+  color: "#93c5fd",
+};
+
+const formStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: 12,
+};
+
+const rowStyle: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "1fr 1fr",
+  gap: 12,
+};
+
+const fieldStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: 4,
+};
+
+const fieldLabelStyle: React.CSSProperties = {
+  fontSize: 12,
+  fontWeight: 500,
+  color: "var(--text-secondary)",
+};
+
+const inputStyle: React.CSSProperties = {
+  padding: "7px 10px",
+  background: "var(--bg-secondary)",
+  border: "1px solid var(--border)",
+  borderRadius: 6,
+  color: "var(--text-primary)",
+  fontSize: 13,
+  fontFamily: "inherit",
+};
+
+const errorBoxStyle: React.CSSProperties = {
+  background: "rgba(248,113,113,0.08)",
+  border: "1px solid rgba(248,113,113,0.4)",
+  borderRadius: 6,
+  padding: "8px 12px",
+  fontSize: 13,
+};
+
+const footerStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "flex-end",
+  gap: 8,
+  marginTop: 8,
+};
+
+const primaryBtnStyle: React.CSSProperties = {
+  padding: "8px 16px",
+  fontSize: 13,
+  fontWeight: 600,
+  background: "var(--accent)",
+  color: "#fff",
+  border: "none",
+  borderRadius: 6,
+  cursor: "pointer",
+  fontFamily: "inherit",
+};
+
+const secondaryBtnStyle: React.CSSProperties = {
+  padding: "8px 16px",
+  fontSize: 13,
+  fontWeight: 500,
+  background: "transparent",
+  color: "var(--text-primary)",
+  border: "1px solid var(--border)",
+  borderRadius: 6,
+  cursor: "pointer",
+  fontFamily: "inherit",
+};

--- a/apps/web/src/app/lab/library/PresetCard.tsx
+++ b/apps/web/src/app/lab/library/PresetCard.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import type { PresetSummary } from "../../../lib/api/presets";
+
+const CATEGORY_COLOR: Record<string, string> = {
+  trend: "#3B82F6",
+  dca: "#10B981",
+  scalping: "#F59E0B",
+  smc: "#8B5CF6",
+  arb: "#EC4899",
+};
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, max - 1).trimEnd()}…`;
+}
+
+export function PresetCard({
+  preset,
+  onUse,
+}: {
+  preset: PresetSummary;
+  onUse: (slug: string) => void;
+}) {
+  const isPrivate = preset.visibility === "PRIVATE";
+  const categoryColor = CATEGORY_COLOR[preset.category] ?? "#6B7280";
+
+  return (
+    <div style={cardStyle}>
+      <div style={headerStyle}>
+        <div style={categoryBadgeStyle(categoryColor)}>{preset.category}</div>
+        {isPrivate && <div style={privateBadgeStyle}>Private</div>}
+      </div>
+
+      <h3 style={titleStyle}>{preset.name}</h3>
+      <p style={descStyle}>{truncate(preset.description, 200)}</p>
+
+      <div style={metaStyle}>
+        <span>
+          <strong>{preset.defaultBotConfigJson.symbol}</strong>
+          <span style={metaSepStyle}> · </span>
+          {preset.defaultBotConfigJson.timeframe}
+        </span>
+        <span style={metaQuoteStyle}>
+          {preset.defaultBotConfigJson.quoteAmount} USDT
+        </span>
+      </div>
+
+      <button
+        onClick={() => onUse(preset.slug)}
+        style={useButtonStyle}
+        type="button"
+      >
+        Use preset
+      </button>
+    </div>
+  );
+}
+
+const cardStyle: React.CSSProperties = {
+  background: "var(--bg-card)",
+  border: "1px solid var(--border)",
+  borderRadius: 8,
+  padding: 16,
+  display: "flex",
+  flexDirection: "column",
+  gap: 10,
+  minHeight: 220,
+};
+
+const headerStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 8,
+};
+
+const categoryBadgeStyle = (color: string): React.CSSProperties => ({
+  fontSize: 10,
+  fontWeight: 700,
+  textTransform: "uppercase",
+  letterSpacing: "0.06em",
+  padding: "2px 8px",
+  borderRadius: 4,
+  color,
+  background: `${color}1F`,
+  border: `1px solid ${color}66`,
+});
+
+const privateBadgeStyle: React.CSSProperties = {
+  fontSize: 10,
+  fontWeight: 700,
+  textTransform: "uppercase",
+  letterSpacing: "0.06em",
+  padding: "2px 8px",
+  borderRadius: 4,
+  color: "rgba(255,255,255,0.55)",
+  background: "rgba(255,255,255,0.06)",
+  border: "1px solid rgba(255,255,255,0.18)",
+};
+
+const titleStyle: React.CSSProperties = {
+  margin: 0,
+  fontSize: 15,
+  fontWeight: 600,
+  color: "var(--text-primary)",
+};
+
+const descStyle: React.CSSProperties = {
+  margin: 0,
+  fontSize: 13,
+  color: "var(--text-secondary)",
+  lineHeight: 1.5,
+  flex: 1,
+};
+
+const metaStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  fontSize: 12,
+  color: "var(--text-secondary)",
+  paddingTop: 8,
+  borderTop: "1px solid var(--border)",
+};
+
+const metaSepStyle: React.CSSProperties = {
+  color: "rgba(255,255,255,0.25)",
+};
+
+const metaQuoteStyle: React.CSSProperties = {
+  fontFamily: "'SF Mono', 'Fira Code', monospace",
+  fontSize: 11,
+};
+
+const useButtonStyle: React.CSSProperties = {
+  marginTop: 4,
+  padding: "8px 14px",
+  fontSize: 13,
+  fontWeight: 600,
+  background: "var(--accent)",
+  color: "#fff",
+  border: "none",
+  borderRadius: 6,
+  cursor: "pointer",
+  fontFamily: "inherit",
+};

--- a/apps/web/src/app/lab/library/page.tsx
+++ b/apps/web/src/app/lab/library/page.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { listPresets, type PresetSummary } from "../../../lib/api/presets";
+import type { ProblemDetails } from "../../../lib/api";
+import { getWorkspaceId } from "../../../lib/api";
+import { PresetCard } from "./PresetCard";
+import { InstantiateDialog } from "./InstantiateDialog";
+
+const ADMIN_TOKEN_STORAGE_KEY = "labLibraryAdminToken";
+
+function readStoredAdminToken(): string {
+  if (typeof window === "undefined") return "";
+  return localStorage.getItem(ADMIN_TOKEN_STORAGE_KEY) ?? "";
+}
+
+export default function LabLibraryPage() {
+  const router = useRouter();
+
+  const [presets, setPresets] = useState<PresetSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<ProblemDetails | null>(null);
+  const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
+
+  // Admin lane: optional shared secret entered locally so PRIVATE presets
+  // can be browsed before public release. Persisted in localStorage so the
+  // operator does not have to re-enter on every navigation.
+  const [adminToken, setAdminToken] = useState<string>("");
+  const [adminMode, setAdminMode] = useState<boolean>(false);
+
+  useEffect(() => {
+    const stored = readStoredAdminToken();
+    if (stored) {
+      setAdminToken(stored);
+      setAdminMode(true);
+    }
+  }, []);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const tokenToUse = adminMode && adminToken ? adminToken : undefined;
+    const res = await listPresets({ adminToken: tokenToUse });
+    setLoading(false);
+    if (!res.ok) {
+      setError(res.problem);
+      setPresets([]);
+      return;
+    }
+    setPresets(res.data);
+  }, [adminMode, adminToken]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  function handleAdminToggle(next: boolean) {
+    setAdminMode(next);
+    if (!next && typeof window !== "undefined") {
+      localStorage.removeItem(ADMIN_TOKEN_STORAGE_KEY);
+    }
+  }
+
+  function handleAdminTokenChange(value: string) {
+    setAdminToken(value);
+    if (typeof window !== "undefined") {
+      if (value) localStorage.setItem(ADMIN_TOKEN_STORAGE_KEY, value);
+      else localStorage.removeItem(ADMIN_TOKEN_STORAGE_KEY);
+    }
+  }
+
+  const selected = selectedSlug ? presets.find((p) => p.slug === selectedSlug) ?? null : null;
+  const workspaceId = getWorkspaceId();
+
+  return (
+    <div style={pageStyle}>
+      <header style={headerStyle}>
+        <div>
+          <h1 style={titleStyle}>Strategy Library</h1>
+          <p style={subtitleStyle}>
+            Curated, ready-to-run strategy presets. One click materialises a
+            DRAFT bot in the active workspace.
+          </p>
+        </div>
+        <AdminControls
+          enabled={adminMode}
+          token={adminToken}
+          onEnabledChange={handleAdminToggle}
+          onTokenChange={handleAdminTokenChange}
+        />
+      </header>
+
+      {!workspaceId && (
+        <div style={warnBoxStyle}>
+          No active workspace. Set one on the Factory page before instantiating
+          a preset.
+        </div>
+      )}
+
+      {error && (
+        <div style={errorBoxStyle}>
+          <strong>{error.title}:</strong> {error.detail}
+        </div>
+      )}
+
+      {loading ? (
+        <p style={emptyStyle}>Loading presets…</p>
+      ) : presets.length === 0 ? (
+        <EmptyState adminMode={adminMode} />
+      ) : (
+        <div style={gridStyle}>
+          {presets.map((preset) => (
+            <PresetCard key={preset.slug} preset={preset} onUse={setSelectedSlug} />
+          ))}
+        </div>
+      )}
+
+      {selected && (
+        <InstantiateDialog
+          preset={selected}
+          adminToken={adminMode && adminToken ? adminToken : undefined}
+          onClose={() => setSelectedSlug(null)}
+          onCreated={(botId) => {
+            setSelectedSlug(null);
+            router.push(`/factory/bots/${botId}`);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function EmptyState({ adminMode }: { adminMode: boolean }) {
+  return (
+    <div style={emptyBoxStyle}>
+      <p style={{ margin: 0, fontSize: 14, color: "var(--text-primary)" }}>
+        {adminMode
+          ? "No presets in the catalog yet."
+          : "No public presets yet."}
+      </p>
+      <p style={{ margin: "6px 0 0", fontSize: 13, color: "var(--text-secondary)" }}>
+        Build your own via Lab → Build, or ask an admin to publish a preset.
+      </p>
+    </div>
+  );
+}
+
+function AdminControls({
+  enabled,
+  token,
+  onEnabledChange,
+  onTokenChange,
+}: {
+  enabled: boolean;
+  token: string;
+  onEnabledChange: (v: boolean) => void;
+  onTokenChange: (v: string) => void;
+}) {
+  return (
+    <div style={adminControlsStyle}>
+      <label style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 12 }}>
+        <input
+          type="checkbox"
+          checked={enabled}
+          onChange={(e) => onEnabledChange(e.target.checked)}
+        />
+        I'm an admin
+      </label>
+      {enabled && (
+        <input
+          type="password"
+          placeholder="X-Admin-Token"
+          value={token}
+          onChange={(e) => onTokenChange(e.target.value)}
+          style={tokenInputStyle}
+          aria-label="Admin token"
+        />
+      )}
+    </div>
+  );
+}
+
+const pageStyle: React.CSSProperties = {
+  padding: "32px 24px 64px",
+  maxWidth: 1200,
+  margin: "0 auto",
+};
+
+const headerStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "flex-start",
+  justifyContent: "space-between",
+  gap: 16,
+  marginBottom: 20,
+  flexWrap: "wrap",
+};
+
+const titleStyle: React.CSSProperties = {
+  margin: 0,
+  fontSize: 22,
+  fontWeight: 600,
+  color: "var(--text-primary)",
+};
+
+const subtitleStyle: React.CSSProperties = {
+  margin: "4px 0 0",
+  color: "var(--text-secondary)",
+  fontSize: 13,
+};
+
+const adminControlsStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 8,
+};
+
+const tokenInputStyle: React.CSSProperties = {
+  padding: "5px 8px",
+  background: "var(--bg-secondary)",
+  border: "1px solid var(--border)",
+  borderRadius: 4,
+  color: "var(--text-primary)",
+  fontSize: 12,
+  fontFamily: "'SF Mono', 'Fira Code', monospace",
+  minWidth: 200,
+};
+
+const gridStyle: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))",
+  gap: 16,
+};
+
+const emptyStyle: React.CSSProperties = {
+  color: "var(--text-secondary)",
+  fontSize: 14,
+};
+
+const emptyBoxStyle: React.CSSProperties = {
+  background: "var(--bg-secondary)",
+  border: "1px solid var(--border)",
+  borderRadius: 8,
+  padding: 24,
+  textAlign: "center",
+};
+
+const errorBoxStyle: React.CSSProperties = {
+  background: "rgba(248,113,113,0.08)",
+  border: "1px solid rgba(248,113,113,0.4)",
+  borderRadius: 6,
+  padding: "8px 12px",
+  marginBottom: 16,
+  fontSize: 13,
+  color: "#fca5a5",
+};
+
+const warnBoxStyle: React.CSSProperties = {
+  background: "rgba(251,191,36,0.08)",
+  border: "1px solid rgba(251,191,36,0.4)",
+  borderRadius: 6,
+  padding: "8px 12px",
+  marginBottom: 16,
+  fontSize: 13,
+  color: "#fbbf24",
+};

--- a/apps/web/src/lib/api/presets.ts
+++ b/apps/web/src/lib/api/presets.ts
@@ -1,0 +1,130 @@
+/**
+ * Typed clients for the strategy-preset endpoints (docs/51-T2/T3/T5).
+ *
+ * These wrap the shared `apiFetch`/`apiFetchNoWorkspace` helpers from
+ * `../api` so the Lab Library page does not have to assemble headers or
+ * problem-details handling itself.
+ */
+
+import { apiFetch, apiFetchNoWorkspace } from "../api";
+import type { ProblemDetails } from "../api";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type PresetCategory = "trend" | "dca" | "scalping" | "smc" | "arb";
+export type PresetVisibility = "PRIVATE" | "PUBLIC";
+export type PresetTimeframe = "M1" | "M5" | "M15" | "H1";
+
+export interface PresetDefaultBotConfig {
+  symbol: string;
+  timeframe: PresetTimeframe;
+  quoteAmount: number;
+  maxOpenPositions: number;
+  [k: string]: unknown;
+}
+
+/** GET /presets list row — no `dslJson`, only metadata + default config. */
+export interface PresetSummary {
+  slug: string;
+  name: string;
+  description: string;
+  category: PresetCategory;
+  defaultBotConfigJson: PresetDefaultBotConfig;
+  datasetBundleHintJson: Record<string, unknown> | null;
+  visibility: PresetVisibility;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** GET /presets/:slug — full record including `dslJson`. */
+export interface PresetDetail extends PresetSummary {
+  dslJson: unknown;
+}
+
+export interface InstantiateOverrides {
+  symbol?: string;
+  timeframe?: PresetTimeframe;
+  quoteAmount?: number;
+  maxOpenPositions?: number;
+  name?: string;
+}
+
+export interface InstantiateResult {
+  botId: string;
+  strategyId: string;
+  strategyVersionId: string;
+}
+
+export interface ListOptions {
+  category?: PresetCategory;
+  visibility?: PresetVisibility;
+  /** Pass an admin token to bypass the PUBLIC-only filter for anonymous reads. */
+  adminToken?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Result type — mirrors apiFetch's discriminated union
+// ---------------------------------------------------------------------------
+
+export type PresetResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; problem: ProblemDetails };
+
+// ---------------------------------------------------------------------------
+// Clients
+// ---------------------------------------------------------------------------
+
+function buildQuery(opts: ListOptions): string {
+  const params: string[] = [];
+  if (opts.category) params.push(`category=${encodeURIComponent(opts.category)}`);
+  if (opts.visibility) params.push(`visibility=${encodeURIComponent(opts.visibility)}`);
+  return params.length ? `?${params.join("&")}` : "";
+}
+
+function adminHeader(token?: string): Record<string, string> {
+  return token ? { "X-Admin-Token": token } : {};
+}
+
+/**
+ * GET /presets — list. Anonymous callers see only PUBLIC; pass `adminToken`
+ * to see PRIVATE entries (intended for the admin lane in /lab/library).
+ *
+ * Workspace-less endpoint: list does not require an active workspace.
+ */
+export function listPresets(opts: ListOptions = {}): Promise<PresetResult<PresetSummary[]>> {
+  return apiFetchNoWorkspace<PresetSummary[]>(`/presets${buildQuery(opts)}`, {
+    headers: adminHeader(opts.adminToken),
+  });
+}
+
+/**
+ * GET /presets/:slug — full record (PUBLIC anonymous, or PRIVATE with admin
+ * token). Returns 404 — not 403 — when the caller cannot see the preset.
+ */
+export function getPreset(
+  slug: string,
+  opts: { adminToken?: string } = {},
+): Promise<PresetResult<PresetDetail>> {
+  return apiFetchNoWorkspace<PresetDetail>(`/presets/${encodeURIComponent(slug)}`, {
+    headers: adminHeader(opts.adminToken),
+  });
+}
+
+/**
+ * POST /presets/:slug/instantiate — atomic Strategy + StrategyVersion + Bot
+ * create in the active workspace. Caller must be authenticated and have
+ * `X-Workspace-Id` set; admin token is only required for PRIVATE presets.
+ */
+export function instantiatePreset(
+  slug: string,
+  body: { overrides?: InstantiateOverrides } = {},
+  opts: { adminToken?: string } = {},
+): Promise<PresetResult<InstantiateResult>> {
+  return apiFetch<InstantiateResult>(`/presets/${encodeURIComponent(slug)}/instantiate`, {
+    method: "POST",
+    headers: adminHeader(opts.adminToken),
+    body: JSON.stringify(body),
+  });
+}


### PR DESCRIPTION
## Summary

Implements 51-T5 from `docs/51-strategy-preset-system.md`: surfaces the strategy-preset catalog as a Lab tab with one-click instantiation.

* `apps/web/src/lib/api/presets.ts` — typed `listPresets` / `getPreset` / `instantiatePreset` clients on top of the shared `apiFetch` helpers (problem-details aware).
* `apps/web/src/app/lab/library/page.tsx` — grid of `PresetSummary` cards, opt-in admin lane (`X-Admin-Token` stored locally) so PRIVATE presets remain visible before public release without a global admin role.
* `apps/web/src/app/lab/library/PresetCard.tsx` — category badge + Private badge + "Use preset" CTA.
* `apps/web/src/app/lab/library/InstantiateDialog.tsx` — modal with overrides (name / symbol / timeframe / quoteAmount / maxOpenPositions); submit → `POST /presets/:slug/instantiate` → `router.push("/factory/bots/<id>")`. Multi-interval bundle hint surfaces when `datasetBundleHintJson` is non-empty.
* `apps/web/src/app/lab/LabShell.tsx` — adds **Library** tab between Classic and Data.
* `apps/web/src/app/factory/bots/[id]/page.tsx` — renders `From preset: <slug>` badge when `bot.templateSlug != null` (response field already returned by `GET /bots/:id`).

No backend / runtime changes. Preset flow stays additive (`docs/50 §Решение 1`): nothing in `botWorker.ts`, `signalEngine.ts`, `exitEngine.ts`, `positionManager.ts`, `dslEvaluator.ts` is touched.

## Test plan

- [x] `npx tsc --noEmit` clean in `apps/web`.
- [ ] Manual smoke: open `/lab/library` without PUBLIC presets → empty state.
- [ ] Manual smoke: enable admin lane with valid `X-Admin-Token` → seeded PRIVATE presets render with Private badge.
- [ ] Manual smoke: "Use preset" → modal opens with defaults from `defaultBotConfigJson`; submit → redirects to `/factory/bots/<id>` with `From preset` badge visible.
- [ ] Regression: `/lab`, `/lab/data`, `/lab/build`, `/lab/test` continue to render, navigation tabs unchanged in behaviour.

https://claude.ai/code/session_01T32Us22aMPYosBMqmt7Kjn

---
_Generated by [Claude Code](https://claude.ai/code/session_01T32Us22aMPYosBMqmt7Kjn)_