### PR TITLE
feat(prisma): datasetBundleJson columns + DatasetBundle type (52-T1)

### DIFF
--- a/apps/api/prisma/migrations/20260501000000_dataset_bundle/migration.sql
+++ b/apps/api/prisma/migrations/20260501000000_dataset_bundle/migration.sql
@@ -1,0 +1,9 @@
+-- Multi-Interval Dataset Bundle (docs/52-T1)
+--
+-- Adds a nullable JSONB column on Bot, BacktestSweep and WalkForwardRun
+-- so callers can attach a `Partial<Record<CandleInterval, string | true>>`
+-- bundle. Existing rows are unaffected (NULL ⇒ legacy single-TF behaviour).
+
+ALTER TABLE "Bot"            ADD COLUMN "datasetBundleJson" JSONB;
+ALTER TABLE "BacktestSweep"  ADD COLUMN "datasetBundleJson" JSONB;
+ALTER TABLE "WalkForwardRun" ADD COLUMN "datasetBundleJson" JSONB;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -153,6 +153,10 @@ model Bot {
   /// Optional link to the StrategyPreset this bot was instantiated from.
   /// String reference, no FK — preset can be deleted without cascading.
   templateSlug         String?
+  /// Optional multi-interval dataset bundle (docs/52-T1).
+  /// Shape: Partial<Record<CandleInterval, string | true>>; null ⇒ legacy
+  /// single-TF behaviour driven by `timeframe` alone.
+  datasetBundleJson    Json?
   createdAt            DateTime        @default(now())
   updatedAt            DateTime        @updatedAt
 
@@ -719,6 +723,9 @@ model BacktestSweep {
   /// Multi-param best-row values (47-T4). Record<string, number> with key
   /// = `${blockId}.${paramName}`. Null until the run completes.
   bestParamValuesJson Json?
+  /// Optional multi-interval dataset bundle (docs/52-T1).
+  /// Backtest mode: every value MUST be a concrete datasetId string.
+  datasetBundleJson Json?
   createdAt         DateTime    @default(now())
   updatedAt         DateTime    @updatedAt
 
@@ -756,6 +763,9 @@ model WalkForwardRun {
   /// Truncated FoldReport[] (without per-fold tradeLog) — see docs/48-T4 §4
   foldsJson          Json?
   aggregateJson      Json?
+  /// Optional multi-interval dataset bundle (docs/52-T1). Backtest mode:
+  /// every value MUST be a concrete datasetId string.
+  datasetBundleJson  Json?
   error              String?
   createdAt          DateTime          @default(now())
   updatedAt          DateTime          @updatedAt

--- a/apps/api/src/types/datasetBundle.ts
+++ b/apps/api/src/types/datasetBundle.ts
@@ -1,0 +1,172 @@
+/**
+ * Multi-interval dataset bundle (docs/52-T1).
+ *
+ * A bundle is a `Partial<Record<CandleInterval, string | true>>`:
+ *
+ * - `string` — concrete `MarketDataset.id` for that interval. Required for
+ *   backtest / walk-forward, where exactly-this-data is the whole point.
+ * - `true`  — "any candles for this `(symbol, interval)`". Used by runtime,
+ *   where the bot just wants live candles, not a frozen historical slice.
+ *
+ * The bundle lives on `Bot.datasetBundleJson`, `BacktestSweep.datasetBundleJson`
+ * and `WalkForwardRun.datasetBundleJson` as a nullable JSON column. `null`
+ * keeps the legacy single-TF behaviour driven by the model's primary
+ * `timeframe` / `datasetId` fields.
+ *
+ * docs/50 §Решение 2 — bundle is intentionally NOT a Prisma model: keeps
+ * migrations additive, avoids cascading FKs.
+ *
+ * Validation lives here as a hand-rolled function rather than zod because the
+ * api package does not depend on zod (uses ajv elsewhere); the helper
+ * returns `{ field, message }[]` to match the validation style of other
+ * routes (`routes/presets.ts`, `routes/bots.ts`).
+ */
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export const CANDLE_INTERVALS = ["M1", "M5", "M15", "M30", "H1", "H4", "D1"] as const;
+export type CandleInterval = typeof CANDLE_INTERVALS[number];
+
+/** Practical ceiling — most flagship strategies need ≤3 TFs (5m/1H/4H, etc).
+ *  Cap at 4 to bound loader work and keep query plans predictable. */
+export const MAX_BUNDLE_INTERVALS = 4;
+
+export type DatasetBundleValue = string | true;
+export type DatasetBundle = Partial<Record<CandleInterval, DatasetBundleValue>>;
+
+export type BundleMode = "runtime" | "backtest";
+
+export interface BundleValidationError {
+  field: string;
+  message: string;
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+const CANDLE_INTERVAL_SET: ReadonlySet<string> = new Set(CANDLE_INTERVALS);
+
+/**
+ * Validate a candidate JSON value as a DatasetBundle.
+ *
+ * Returns `{ bundle }` on success or `{ errors }` on failure. `mode="backtest"`
+ * additionally requires every value to be a concrete `datasetId` (string).
+ */
+export function parseDatasetBundle(
+  raw: unknown,
+  opts: { mode?: BundleMode } = {},
+): { bundle: DatasetBundle; errors: [] } | { bundle?: undefined; errors: BundleValidationError[] } {
+  const errors: BundleValidationError[] = [];
+
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    return { errors: [{ field: "datasetBundleJson", message: "must be a non-null object" }] };
+  }
+
+  const entries = Object.entries(raw as Record<string, unknown>);
+  if (entries.length < 1) {
+    errors.push({ field: "datasetBundleJson", message: "bundle must contain at least 1 interval" });
+  }
+  if (entries.length > MAX_BUNDLE_INTERVALS) {
+    errors.push({
+      field: "datasetBundleJson",
+      message: `bundle must contain at most ${MAX_BUNDLE_INTERVALS} intervals (got ${entries.length})`,
+    });
+  }
+
+  const out: DatasetBundle = {};
+  for (const [key, value] of entries) {
+    if (!CANDLE_INTERVAL_SET.has(key)) {
+      errors.push({
+        field: `datasetBundleJson.${key}`,
+        message: `unknown interval "${key}" (allowed: ${CANDLE_INTERVALS.join(", ")})`,
+      });
+      continue;
+    }
+    const interval = key as CandleInterval;
+    if (value === true) {
+      if (opts.mode === "backtest") {
+        errors.push({
+          field: `datasetBundleJson.${interval}`,
+          message: "backtest mode requires a concrete datasetId; received literal true",
+        });
+        continue;
+      }
+      out[interval] = true;
+    } else if (typeof value === "string" && value.length > 0) {
+      out[interval] = value;
+    } else {
+      errors.push({
+        field: `datasetBundleJson.${interval}`,
+        message: "value must be a non-empty string (datasetId) or literal true",
+      });
+    }
+  }
+
+  if (errors.length > 0) return { errors };
+  return { bundle: out, errors: [] };
+}
+
+/**
+ * Throwing variant — use only when the caller has already established the
+ * value is supposed to be a valid bundle (e.g. data read back from a row that
+ * passed validation on write).
+ */
+export function parseDatasetBundleOrThrow(
+  raw: unknown,
+  opts: { mode?: BundleMode } = {},
+): DatasetBundle {
+  const result = parseDatasetBundle(raw, opts);
+  if (result.errors.length > 0) {
+    const summary = result.errors.map((e) => `${e.field}: ${e.message}`).join("; ");
+    throw new Error(`Invalid DatasetBundle — ${summary}`);
+  }
+  return result.bundle;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+export function bundleIntervals(bundle: DatasetBundle): CandleInterval[] {
+  // Preserve insertion order — callers that care about a primary-first
+  // layout can rely on it; helpers below treat the set semantically.
+  return Object.keys(bundle) as CandleInterval[];
+}
+
+export function bundleHasInterval(bundle: DatasetBundle, interval: CandleInterval): boolean {
+  return Object.prototype.hasOwnProperty.call(bundle, interval);
+}
+
+/**
+ * Returns the concrete datasetId for an interval, or `null` when:
+ *  - the interval is missing,
+ *  - the value is `true` (runtime placeholder, no dataset).
+ */
+export function bundleDatasetId(
+  bundle: DatasetBundle,
+  interval: CandleInterval,
+): string | null {
+  const v = bundle[interval];
+  return typeof v === "string" ? v : null;
+}
+
+/**
+ * The bundle is meaningful only if its primary TF is present — otherwise
+ * the runtime / backtest cannot drive evaluation. Use this on every code
+ * path that ingests a bundle alongside a primary timeframe.
+ */
+export function validateBundleAgainstPrimary(
+  bundle: DatasetBundle,
+  primaryInterval: CandleInterval,
+): BundleValidationError[] {
+  if (!bundleHasInterval(bundle, primaryInterval)) {
+    return [{
+      field: "datasetBundleJson",
+      message: `primary timeframe "${primaryInterval}" must be present in the bundle`,
+    }];
+  }
+  return [];
+}

--- a/apps/api/src/types/datasetBundle.ts
+++ b/apps/api/src/types/datasetBundle.ts
@@ -119,7 +119,7 @@ export function parseDatasetBundleOrThrow(
   opts: { mode?: BundleMode } = {},
 ): DatasetBundle {
   const result = parseDatasetBundle(raw, opts);
-  if (result.errors.length > 0) {
+  if (!result.bundle) {
     const summary = result.errors.map((e) => `${e.field}: ${e.message}`).join("; ");
     throw new Error(`Invalid DatasetBundle — ${summary}`);
   }

--- a/apps/api/tests/types/datasetBundle.test.ts
+++ b/apps/api/tests/types/datasetBundle.test.ts
@@ -1,0 +1,136 @@
+/**
+ * 52-T1 — DatasetBundle type validation.
+ *
+ * Covers the positive cases the loader (52-T2) and route handlers (52-T4)
+ * will rely on, plus the negative cases that catch malformed JSON before it
+ * reaches Prisma.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  parseDatasetBundle,
+  parseDatasetBundleOrThrow,
+  bundleIntervals,
+  bundleHasInterval,
+  bundleDatasetId,
+  validateBundleAgainstPrimary,
+  MAX_BUNDLE_INTERVALS,
+} from "../../src/types/datasetBundle.js";
+
+describe("parseDatasetBundle", () => {
+  it("accepts a backtest-shape bundle (every value is a datasetId)", () => {
+    const result = parseDatasetBundle({ M5: "ds_a", H1: "ds_b" });
+    expect(result.errors).toEqual([]);
+    expect(result.bundle).toEqual({ M5: "ds_a", H1: "ds_b" });
+  });
+
+  it("accepts a runtime-shape bundle (literal true)", () => {
+    const result = parseDatasetBundle({ M5: true });
+    expect(result.errors).toEqual([]);
+    expect(result.bundle).toEqual({ M5: true });
+  });
+
+  it("accepts a mixed-shape bundle in default (runtime-permissive) mode", () => {
+    const result = parseDatasetBundle({ M5: "ds_a", H1: true });
+    expect(result.errors).toEqual([]);
+    expect(result.bundle).toEqual({ M5: "ds_a", H1: true });
+  });
+
+  it("rejects empty bundle", () => {
+    const result = parseDatasetBundle({});
+    expect(result.bundle).toBeUndefined();
+    expect(result.errors.some((e) => /at least 1 interval/.test(e.message))).toBe(true);
+  });
+
+  it(`rejects bundle with more than ${MAX_BUNDLE_INTERVALS} intervals`, () => {
+    const result = parseDatasetBundle({
+      M1: "a", M5: "b", M15: "c", M30: "d", H1: "e",
+    });
+    expect(result.bundle).toBeUndefined();
+    expect(result.errors.some((e) => /at most/.test(e.message))).toBe(true);
+  });
+
+  it("rejects unknown interval keys", () => {
+    const result = parseDatasetBundle({ X1: "ds" });
+    expect(result.bundle).toBeUndefined();
+    expect(result.errors.some((e) => /unknown interval/.test(e.message))).toBe(true);
+  });
+
+  it("rejects empty-string datasetId", () => {
+    const result = parseDatasetBundle({ M5: "" });
+    expect(result.bundle).toBeUndefined();
+    expect(result.errors[0].field).toBe("datasetBundleJson.M5");
+  });
+
+  it("rejects non-string, non-true values", () => {
+    const result = parseDatasetBundle({ M5: 42 });
+    expect(result.bundle).toBeUndefined();
+    expect(result.errors[0].field).toBe("datasetBundleJson.M5");
+  });
+
+  it("rejects null / arrays / scalars at the top level", () => {
+    expect(parseDatasetBundle(null).errors[0].message).toMatch(/non-null object/);
+    expect(parseDatasetBundle([]).errors[0].message).toMatch(/non-null object/);
+    expect(parseDatasetBundle("ds_a").errors[0].message).toMatch(/non-null object/);
+    expect(parseDatasetBundle(42).errors[0].message).toMatch(/non-null object/);
+  });
+
+  it("rejects literal true in backtest mode", () => {
+    const result = parseDatasetBundle({ M5: true }, { mode: "backtest" });
+    expect(result.bundle).toBeUndefined();
+    expect(result.errors.some((e) => /backtest mode requires a concrete datasetId/.test(e.message))).toBe(true);
+  });
+
+  it("accepts all-string bundle in backtest mode", () => {
+    const result = parseDatasetBundle({ M5: "ds_a", H1: "ds_b" }, { mode: "backtest" });
+    expect(result.errors).toEqual([]);
+    expect(result.bundle).toEqual({ M5: "ds_a", H1: "ds_b" });
+  });
+
+  it("collects multiple errors at once", () => {
+    const result = parseDatasetBundle({ X1: "a", M5: 0 });
+    expect(result.bundle).toBeUndefined();
+    expect(result.errors.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("parseDatasetBundleOrThrow", () => {
+  it("returns the bundle on success", () => {
+    expect(parseDatasetBundleOrThrow({ M5: "ds_a" })).toEqual({ M5: "ds_a" });
+  });
+
+  it("throws on validation failure", () => {
+    expect(() => parseDatasetBundleOrThrow({})).toThrow(/Invalid DatasetBundle/);
+  });
+});
+
+describe("helpers", () => {
+  const bundle = { M5: "ds_a", H1: true } as const;
+
+  it("bundleIntervals returns insertion order", () => {
+    expect(bundleIntervals(bundle)).toEqual(["M5", "H1"]);
+  });
+
+  it("bundleHasInterval distinguishes present vs absent keys", () => {
+    expect(bundleHasInterval(bundle, "M5")).toBe(true);
+    expect(bundleHasInterval(bundle, "M15")).toBe(false);
+  });
+
+  it("bundleDatasetId returns the string for concrete entries and null for true", () => {
+    expect(bundleDatasetId(bundle, "M5")).toBe("ds_a");
+    expect(bundleDatasetId(bundle, "H1")).toBeNull();
+    expect(bundleDatasetId(bundle, "M15")).toBeNull();
+  });
+});
+
+describe("validateBundleAgainstPrimary", () => {
+  it("accepts when primary TF is present", () => {
+    expect(validateBundleAgainstPrimary({ M5: "ds_a", H1: "ds_b" }, "M5")).toEqual([]);
+  });
+
+  it("rejects when primary TF is missing", () => {
+    const errs = validateBundleAgainstPrimary({ M5: true }, "H1");
+    expect(errs).toHaveLength(1);
+    expect(errs[0].message).toMatch(/primary timeframe "H1" must be present/);
+  });
+});


### PR DESCRIPTION
## Summary

Lays the groundwork for multi-interval (MTF) support per `docs/52-T1`.

All three sites that drive bot / backtest evaluation now accept an
optional `datasetBundleJson` JSON column:

| Model            | Purpose                                  |
|------------------|------------------------------------------|
| `Bot`            | runtime config carried into `botWorker`  |
| `BacktestSweep`  | one bundle replayed across sweep runs    |
| `WalkForwardRun` | folds inherit the bundle for replay      |

Shape: `Partial<Record<CandleInterval, string | true>>`. A `string` is a
concrete `MarketDataset.id` (required for backtest / walk-forward).
`true` means "any candles for this `(symbol, interval)`" (runtime only).
`NULL` keeps the legacy single-TF behaviour driven by the model's
`timeframe` / `datasetId` fields — no existing row changes shape.

Validation lives in `apps/api/src/types/datasetBundle.ts` as a
hand-rolled function returning `{ field, message }[]`, matching the
existing style (`routes/presets.ts`, `routes/bots.ts`). The `docs/52-T1`
spec suggested zod, but the api package does not currently depend on
zod (uses ajv elsewhere) — chose not to introduce a new dependency for
this size of contract; helper signatures align so a swap to zod later
is mechanical.

Helpers exported for downstream T-tasks:
- `parseDatasetBundle(raw, { mode })` — main validator (mode `runtime`
  vs `backtest`).
- `parseDatasetBundleOrThrow(raw, opts)` — for trusted reads.
- `bundleIntervals` / `bundleHasInterval` / `bundleDatasetId`.
- `validateBundleAgainstPrimary(bundle, primaryInterval)`.

## Test plan

- [x] `apps/api/tests/types/datasetBundle.test.ts` — 19/19 green.
- [x] Existing tests in the area (`schema.prisma` consumers, presets, bots)
      not touched; column is additive.
- [ ] Migration run (additive, three `ALTER TABLE … ADD COLUMN … JSONB`
      statements) — green on CI.
- [ ] `apps/api/tsc --noEmit` clean (validated locally apart from the
      pre-existing `prisma generate` env quirk).

## Out of scope

No production code is rewired in this PR. The runtime / backtest /
sweep / walk-forward paths still ignore `datasetBundleJson`; that
plumbing arrives in 52-T2 → 52-T4.

https://claude.ai/code/session_01T32Us22aMPYosBMqmt7Kjn

---
_Generated by [Claude Code](https://claude.ai/code/session_01T32Us22aMPYosBMqmt7Kjn)_