### PR TITLE
feat(backtest): runBacktestWithBundle + look-ahead-safe alignment (52-T4a)

### DIFF
--- a/apps/api/src/lib/backtest.ts
+++ b/apps/api/src/lib/backtest.ts
@@ -33,6 +33,14 @@
 import type { Candle } from "./bybitCandles.js";
 import { runDslBacktest } from "./dslEvaluator.js";
 import type { DslBacktestReport, DslTradeRecord, MtfBacktestContext, DslFillAt } from "./dslEvaluator.js";
+import {
+  TIMEFRAME_TO_INTERVAL,
+  createClosedCandleBundle,
+  type Interval,
+  type MtfCandle,
+} from "./mtf/intervalAlignment.js";
+import type { CandlesByInterval } from "./mtf/loadCandleBundle.js";
+import type { CandleInterval } from "../types/datasetBundle.js";
 
 // Re-export DSL evaluator types as canonical backtest types
 export type { DslBacktestReport as BacktestReport, DslTradeRecord as TradeRecord, MtfBacktestContext };
@@ -75,4 +83,93 @@ export function runBacktest(
     slippageBps: opts.slippageBps ?? 0,
     fillAt: opts.fillAt ?? "CLOSE",
   }, mtfContext);
+}
+
+// ---------------------------------------------------------------------------
+// Multi-interval bundle entry point (docs/52-T4)
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a `MarketCandle` row (Decimal-backed, BigInt openTimeMs) into the
+ * lightweight `MtfCandle` shape used by the alignment helpers / evaluator.
+ */
+function toMtfCandle(row: {
+  openTimeMs: bigint;
+  open: { toString(): string } | number;
+  high: { toString(): string } | number;
+  low: { toString(): string } | number;
+  close: { toString(): string } | number;
+  volume: { toString(): string } | number;
+}): MtfCandle {
+  return {
+    openTime: Number(row.openTimeMs),
+    open: typeof row.open === "number" ? row.open : Number(row.open.toString()),
+    high: typeof row.high === "number" ? row.high : Number(row.high.toString()),
+    low: typeof row.low === "number" ? row.low : Number(row.low.toString()),
+    close: typeof row.close === "number" ? row.close : Number(row.close.toString()),
+    volume: typeof row.volume === "number" ? row.volume : Number(row.volume.toString()),
+  };
+}
+
+/** Translate a Prisma `CandleInterval` enum into the alignment-helper string. */
+function toAlignmentInterval(interval: CandleInterval): Interval {
+  const out = TIMEFRAME_TO_INTERVAL[interval];
+  if (!out) {
+    throw new Error(`runBacktestWithBundle: unsupported interval "${interval}"`);
+  }
+  return out;
+}
+
+export interface RunBacktestWithBundleArgs {
+  /** Candles per interval as returned by `loadCandleBundle`. */
+  bundle: CandlesByInterval;
+  /** Drives bar iteration; must be a key of `bundle`. */
+  primaryInterval: CandleInterval;
+  dslJson: unknown;
+  opts?: Partial<ExecOpts>;
+}
+
+/**
+ * Run a backtest from a multi-interval candle bundle.
+ *
+ * Iterates the primary-TF candles; HTF context is exposed to the evaluator
+ * via a {@link createClosedCandleBundle} (look-ahead-safe) — at every
+ * primary bar `i`, an HTF indicator can only see HTF candles whose period
+ * has fully closed by `primary[i].openTime`.
+ */
+export function runBacktestWithBundle(args: RunBacktestWithBundleArgs): DslBacktestReport {
+  const primaryRows = args.bundle.get(args.primaryInterval);
+  if (!primaryRows) {
+    throw new Error(
+      `runBacktestWithBundle: primary interval "${args.primaryInterval}" missing from bundle`,
+    );
+  }
+  if (primaryRows.length === 0) {
+    return {
+      trades: 0, wins: 0, winrate: 0, totalPnlPct: 0, maxDrawdownPct: 0,
+      candles: 0, tradeLog: [], sharpe: null, profitFactor: null, expectancy: null,
+    };
+  }
+
+  // Build a Record<intervalString, MtfCandle[]> for the alignment helpers.
+  // Skip intervals the alignment module does not understand (M30 — no
+  // mapping in TIMEFRAME_TO_INTERVAL today; runtime tolerates this and the
+  // backtest path simply ignores unmappable intervals).
+  const candlesByInterval: Record<string, MtfCandle[]> = {};
+  for (const [interval, rows] of args.bundle.entries()) {
+    const aligned = TIMEFRAME_TO_INTERVAL[interval];
+    if (!aligned) continue;
+    candlesByInterval[aligned] = rows.map(toMtfCandle);
+  }
+
+  const primaryAligned = toAlignmentInterval(args.primaryInterval);
+  const candleBundle = createClosedCandleBundle(primaryAligned, candlesByInterval);
+  const primaryCandles = candlesByInterval[primaryAligned];
+
+  return runBacktest(
+    primaryCandles as unknown as Candle[],
+    args.dslJson,
+    args.opts,
+    { bundle: candleBundle },
+  );
 }

--- a/apps/api/src/lib/mtf/intervalAlignment.ts
+++ b/apps/api/src/lib/mtf/intervalAlignment.ts
@@ -152,6 +152,51 @@ export function buildAlignmentMap(
   return map;
 }
 
+/**
+ * Look-ahead-safe variant of `buildAlignmentMap` (docs/52-T4).
+ *
+ * For each primary candle, points to the *last closed* HTF candle — the one
+ * whose period has fully ended at or before the primary candle's openTime.
+ *
+ *   primary[i].openTime ≥ htf[j].openTime + INTERVAL_MS[contextInterval]
+ *
+ * That excludes the HTF candle that *contains* the primary timestamp (which
+ * has not closed yet and would leak future data into the indicator value).
+ *
+ * Used by backtest paths that must be deterministically free of look-ahead
+ * bias. Runtime paths typically still use {@link buildAlignmentMap} —
+ * they are evaluating "now" and want to see partial-bar HTF data.
+ *
+ * @precondition Both arrays are sorted ascending by openTime.
+ */
+export function buildClosedAlignmentMap(
+  primaryCandles: MtfCandle[],
+  contextCandles: MtfCandle[],
+  contextInterval: Interval,
+): number[] {
+  const map = new Array<number>(primaryCandles.length).fill(-1);
+  if (contextCandles.length === 0) return map;
+  const htfMs = INTERVAL_MS[contextInterval];
+
+  let ctxIdx = 0;
+  for (let i = 0; i < primaryCandles.length; i++) {
+    const primaryOpen = primaryCandles[i].openTime;
+    // Advance ctxIdx while the next candidate has already closed by primaryOpen.
+    while (
+      ctxIdx + 1 < contextCandles.length &&
+      contextCandles[ctxIdx + 1].openTime + htfMs <= primaryOpen
+    ) {
+      ctxIdx++;
+    }
+    // Verify the current candidate has closed; otherwise no look-ahead-safe
+    // HTF is available for this primary bar (e.g. start of the dataset).
+    if (contextCandles[ctxIdx].openTime + htfMs <= primaryOpen) {
+      map[i] = ctxIdx;
+    }
+  }
+  return map;
+}
+
 // ---------------------------------------------------------------------------
 // Multi-TF candle bundle
 // ---------------------------------------------------------------------------
@@ -188,6 +233,37 @@ export function createCandleBundle(
     if (interval === primaryInterval) continue;
     if (!INTERVAL_MS[interval as Interval]) continue;
     alignmentMaps[interval] = buildAlignmentMap(primary, candles, interval as Interval);
+  }
+
+  return {
+    primaryInterval,
+    candles: candlesByInterval,
+    alignmentMaps,
+  };
+}
+
+/**
+ * Look-ahead-safe variant of {@link createCandleBundle} (docs/52-T4).
+ *
+ * Pre-computes alignment maps via {@link buildClosedAlignmentMap}, so HTF
+ * indicator values resolved through this bundle never use a HTF candle that
+ * has not yet closed at the primary bar's `openTime`. This is the variant
+ * the backtest engine uses; the runtime path can keep `createCandleBundle`.
+ */
+export function createClosedCandleBundle(
+  primaryInterval: Interval,
+  candlesByInterval: Record<string, MtfCandle[]>,
+): CandleBundle {
+  const primary = candlesByInterval[primaryInterval];
+  if (!primary) {
+    throw new Error(`Primary interval "${primaryInterval}" not found in candle data`);
+  }
+
+  const alignmentMaps: Record<string, number[]> = {};
+  for (const [interval, candles] of Object.entries(candlesByInterval)) {
+    if (interval === primaryInterval) continue;
+    if (!INTERVAL_MS[interval as Interval]) continue;
+    alignmentMaps[interval] = buildClosedAlignmentMap(primary, candles, interval as Interval);
   }
 
   return {

--- a/apps/api/tests/lib/mtf/closedAlignmentMap.test.ts
+++ b/apps/api/tests/lib/mtf/closedAlignmentMap.test.ts
@@ -1,0 +1,145 @@
+/**
+ * 52-T4 — `buildClosedAlignmentMap` & `createClosedCandleBundle` (look-ahead guard).
+ *
+ * Anchor: at primary bar `i`, the resolved HTF candle MUST satisfy
+ *
+ *   htf.openTime + INTERVAL_MS[contextInterval] ≤ primary[i].openTime
+ *
+ * i.e. the HTF candle has fully closed by the time the primary bar opens.
+ * The standard {@link buildAlignmentMap} returns the *containing* HTF candle
+ * (not yet closed) and is therefore not safe for backtest usage.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  buildAlignmentMap,
+  buildClosedAlignmentMap,
+  createCandleBundle,
+  createClosedCandleBundle,
+  INTERVAL_MS,
+  type MtfCandle,
+} from "../../../src/lib/mtf/intervalAlignment.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/** 1 hour of M5 candles starting at 12:00 UTC (12 candles). */
+function makeM5Candles(): MtfCandle[] {
+  const start = Date.UTC(2026, 0, 1, 12, 0, 0);
+  return Array.from({ length: 12 }, (_, i) => ({
+    openTime: start + i * INTERVAL_MS["5m"],
+    open: 100 + i,
+    high: 101 + i,
+    low: 99 + i,
+    close: 100.5 + i,
+    volume: 1,
+  }));
+}
+
+/** 3 hours of H1 candles starting at 11:00 UTC (so H1[0]=11:00, H1[1]=12:00, H1[2]=13:00). */
+function makeH1Candles(): MtfCandle[] {
+  const start = Date.UTC(2026, 0, 1, 11, 0, 0);
+  return Array.from({ length: 3 }, (_, i) => ({
+    openTime: start + i * INTERVAL_MS["1h"],
+    open: 1000 + i,
+    high: 1001 + i,
+    low: 999 + i,
+    close: 1000.5 + i,
+    volume: 100,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// buildClosedAlignmentMap
+// ---------------------------------------------------------------------------
+
+describe("buildClosedAlignmentMap", () => {
+  it("at primary M5_12:05, the closed-safe H1 is the previous one (H1_11:00)", () => {
+    const m5 = makeM5Candles();
+    const h1 = makeH1Candles(); // 11:00, 12:00, 13:00
+    const closed = buildClosedAlignmentMap(m5, h1, "1h");
+
+    // Every M5 in [12:00, 13:00) must map to H1_11:00 (idx 0): H1_12:00 has
+    // not yet closed (closes at 13:00).
+    for (let i = 0; i < 12; i++) {
+      expect(closed[i]).toBe(0);
+    }
+  });
+
+  it("standard buildAlignmentMap maps to the containing (open) H1 — proves the difference", () => {
+    const m5 = makeM5Candles();
+    const h1 = makeH1Candles();
+    const open = buildAlignmentMap(m5, h1, "1h");
+    // Standard alignment maps every M5 in [12:00, 13:00) to H1_12:00 (idx 1).
+    for (let i = 0; i < 12; i++) {
+      expect(open[i]).toBe(1);
+    }
+  });
+
+  it("first primary bars get -1 when no closed HTF is available yet", () => {
+    const m5 = makeM5Candles();
+    // Only one H1 candle, opening at 12:00 — closes at 13:00, never closed
+    // before any of the M5 bars (which all live in [12:00, 13:00)).
+    const h1: MtfCandle[] = [
+      { openTime: Date.UTC(2026, 0, 1, 12, 0, 0), open: 1, high: 1, low: 1, close: 1, volume: 0 },
+    ];
+    const closed = buildClosedAlignmentMap(m5, h1, "1h");
+    for (let i = 0; i < 12; i++) {
+      expect(closed[i]).toBe(-1);
+    }
+  });
+
+  it("advances to the next closed HTF as primary crosses the boundary", () => {
+    // Build M5 candles spanning 12:00 .. 14:55 (35 bars, two H1 boundaries).
+    const m5: MtfCandle[] = Array.from({ length: 36 }, (_, i) => ({
+      openTime: Date.UTC(2026, 0, 1, 12, 0, 0) + i * INTERVAL_MS["5m"],
+      open: i, high: i, low: i, close: i, volume: 1,
+    }));
+    const h1 = makeH1Candles(); // 11:00, 12:00, 13:00
+    const closed = buildClosedAlignmentMap(m5, h1, "1h");
+
+    // [12:00, 13:00) → H1_11:00 (idx 0).
+    for (let i = 0; i < 12; i++) expect(closed[i]).toBe(0);
+    // [13:00, 14:00) → H1_12:00 (idx 1, just closed at 13:00).
+    for (let i = 12; i < 24; i++) expect(closed[i]).toBe(1);
+    // [14:00, 14:55] → H1_13:00 (idx 2, just closed at 14:00).
+    for (let i = 24; i < 36; i++) expect(closed[i]).toBe(2);
+  });
+
+  it("returns -1 for every primary bar when context is empty", () => {
+    const m5 = makeM5Candles();
+    const closed = buildClosedAlignmentMap(m5, [], "1h");
+    expect(closed).toHaveLength(12);
+    expect(closed.every((v) => v === -1)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createClosedCandleBundle
+// ---------------------------------------------------------------------------
+
+describe("createClosedCandleBundle", () => {
+  it("alignmentMaps use look-ahead-safe semantics; createCandleBundle does not", () => {
+    const m5 = makeM5Candles();
+    const h1 = makeH1Candles();
+
+    const closed = createClosedCandleBundle("5m", { "5m": m5, "1h": h1 });
+    const standard = createCandleBundle("5m", { "5m": m5, "1h": h1 });
+
+    expect(closed.alignmentMaps["1h"]).toEqual(new Array(12).fill(0));
+    expect(standard.alignmentMaps["1h"]).toEqual(new Array(12).fill(1));
+  });
+
+  it("throws when the primary interval is missing", () => {
+    expect(() => createClosedCandleBundle("5m", { "1h": [] })).toThrow(
+      /Primary interval "5m" not found/,
+    );
+  });
+
+  it("ignores unknown interval keys silently", () => {
+    const m5 = makeM5Candles();
+    const bundle = createClosedCandleBundle("5m", { "5m": m5, "3m": [] });
+    expect(bundle.alignmentMaps["3m"]).toBeUndefined();
+  });
+});

--- a/apps/api/tests/lib/runBacktestWithBundle.test.ts
+++ b/apps/api/tests/lib/runBacktestWithBundle.test.ts
@@ -1,0 +1,176 @@
+/**
+ * 52-T4 — `runBacktestWithBundle` smoke tests.
+ *
+ * Drives the new bundle-aware entry point with deterministic, hand-rolled
+ * fixtures. The runtime evaluator already supports MTF via `MtfBacktestContext`
+ * (#134); this test focuses on the conversion + look-ahead-safe alignment
+ * the new wrapper introduces. Trade-engine semantics (fees, slippage, fillAt)
+ * are covered exhaustively by `tests/lib/backtest.test.ts` — we deliberately
+ * keep the DSL minimal here so the bundle plumbing is the only signal.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  runBacktestWithBundle,
+  type BacktestReport,
+} from "../../src/lib/backtest.js";
+import { INTERVAL_MS, type MtfCandle } from "../../src/lib/mtf/intervalAlignment.js";
+import type { CandleInterval } from "../../src/types/datasetBundle.js";
+import type { MarketCandle } from "@prisma/client";
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+function toRow(c: MtfCandle, interval: CandleInterval): MarketCandle {
+  // The wrapper only reads the numeric / BigInt fields — populate the rest
+  // with shape-correct defaults so it satisfies the Prisma type.
+  return {
+    id: `c-${interval}-${c.openTime}`,
+    exchange: "bybit",
+    symbol: "BTCUSDT",
+    interval,
+    openTimeMs: BigInt(c.openTime),
+    open: c.open as unknown as MarketCandle["open"],
+    high: c.high as unknown as MarketCandle["high"],
+    low: c.low as unknown as MarketCandle["low"],
+    close: c.close as unknown as MarketCandle["close"],
+    volume: c.volume as unknown as MarketCandle["volume"],
+    createdAt: new Date(c.openTime),
+  };
+}
+
+function makeBundle(input: Partial<Record<CandleInterval, MtfCandle[]>>): Map<CandleInterval, MarketCandle[]> {
+  const out = new Map<CandleInterval, MarketCandle[]>();
+  for (const [interval, candles] of Object.entries(input)) {
+    if (!candles) continue;
+    out.set(interval as CandleInterval, candles.map((c) => toRow(c, interval as CandleInterval)));
+  }
+  return out;
+}
+
+/** A no-op DSL — never enters, never exits. Just exercises the bundle path. */
+const NEUTRAL_DSL = {
+  dslVersion: 1,
+  name: "neutral",
+  market: { exchange: "bybit", env: "demo", category: "linear", symbol: "BTCUSDT" },
+  entry: { side: "Buy" },
+  risk: { maxPositionSizeUsd: 100, riskPerTradePct: 1, cooldownSeconds: 60 },
+  execution: { orderType: "Market", clientOrderIdPrefix: "neutral" },
+  guards: { maxOpenPositions: 1, maxOrdersPerMinute: 10, pauseOnError: true },
+};
+
+function makeFlat(interval: CandleInterval, count: number): MtfCandle[] {
+  const ms = (() => {
+    switch (interval) {
+      case "M5": return INTERVAL_MS["5m"];
+      case "M15": return INTERVAL_MS["15m"];
+      case "M1": return INTERVAL_MS["1m"];
+      case "H1": return INTERVAL_MS["1h"];
+      case "H4": return INTERVAL_MS["4h"];
+      case "D1": return INTERVAL_MS["1d"];
+      default: throw new Error(`No alignment mapping for ${interval}`);
+    }
+  })();
+  const start = Date.UTC(2026, 0, 1, 0, 0, 0);
+  return Array.from({ length: count }, (_, i) => ({
+    openTime: start + i * ms,
+    open: 100, high: 101, low: 99, close: 100, volume: 1,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("runBacktestWithBundle", () => {
+  it("runs against a single-TF bundle and reports the candle count", () => {
+    const bundle = makeBundle({ M5: makeFlat("M5", 50) });
+    const report = runBacktestWithBundle({
+      bundle,
+      primaryInterval: "M5",
+      dslJson: NEUTRAL_DSL,
+    });
+    expect(report.candles).toBe(50);
+    expect(report.trades).toBe(0);
+  });
+
+  it("matches single-TF runBacktest output for the same primary candles", async () => {
+    // When the bundle has one interval (= primary), the wrapper should
+    // delegate to runBacktest with no MTF context and produce identical
+    // results bit-for-bit.
+    const m5 = makeFlat("M5", 30);
+    const bundle = makeBundle({ M5: m5 });
+
+    const fromWrapper = runBacktestWithBundle({
+      bundle,
+      primaryInterval: "M5",
+      dslJson: NEUTRAL_DSL,
+    });
+
+    // Hand-call runBacktest with the equivalent Candle[] directly.
+    const { runBacktest } = await import("../../src/lib/backtest.js");
+    const fromDirect = runBacktest(
+      m5 as unknown as Parameters<typeof runBacktest>[0],
+      NEUTRAL_DSL,
+    );
+
+    expect(fromWrapper).toEqual(fromDirect);
+  });
+
+  it("accepts a multi-interval bundle and produces a deterministic report", () => {
+    const bundle = makeBundle({
+      M5: makeFlat("M5", 24),
+      H1: makeFlat("H1", 5),
+    });
+    const reportA = runBacktestWithBundle({
+      bundle,
+      primaryInterval: "M5",
+      dslJson: NEUTRAL_DSL,
+    });
+    const reportB = runBacktestWithBundle({
+      bundle,
+      primaryInterval: "M5",
+      dslJson: NEUTRAL_DSL,
+    });
+    // Determinism: same input ⇒ same output.
+    expect(reportA).toEqual(reportB);
+    expect(reportA.candles).toBe(24);
+  });
+
+  it("returns an empty report when primary interval has no candles", () => {
+    const bundle = makeBundle({ M5: [] });
+    const report: BacktestReport = runBacktestWithBundle({
+      bundle,
+      primaryInterval: "M5",
+      dslJson: NEUTRAL_DSL,
+    });
+    expect(report.trades).toBe(0);
+    expect(report.candles).toBe(0);
+    expect(report.tradeLog).toEqual([]);
+  });
+
+  it("throws when the primary interval is absent from the bundle", () => {
+    const bundle = makeBundle({ M5: makeFlat("M5", 10) });
+    expect(() =>
+      runBacktestWithBundle({
+        bundle,
+        primaryInterval: "H1",
+        dslJson: NEUTRAL_DSL,
+      }),
+    ).toThrow(/primary interval "H1" missing/);
+  });
+
+  it("rejects intervals with no alignment mapping (M30 — no '30m' in helper)", () => {
+    // The wrapper's primary-interval translation goes through TIMEFRAME_TO_INTERVAL
+    // which has no entry for M30; calling with M30 as primary must throw.
+    const bundle = makeBundle({ M30: makeFlat("M5", 10).map((c) => ({ ...c })) });
+    expect(() =>
+      runBacktestWithBundle({
+        bundle,
+        primaryInterval: "M30",
+        dslJson: NEUTRAL_DSL,
+      }),
+    ).toThrow(/unsupported interval "M30"/);
+  });
+});


### PR DESCRIPTION
## Summary

Engine-level half of `docs/52-T4`. Adds the bundle-aware entry point to
the backtest engine and the look-ahead-bias guard the spec calls out as
a critical correctness requirement (`docs/52-T4 §2`).

### `apps/api/src/lib/mtf/intervalAlignment.ts`

- `buildClosedAlignmentMap(primary, ctx, ctxInterval)` — for each
  primary bar, points to the *last closed* HTF candle (period ended at
  or before `primary[i].openTime`). Excludes the HTF candle that
  contains the primary timestamp, which has not closed yet and would
  leak future data into HTF indicators.
- `createClosedCandleBundle(primaryInterval, candlesByInterval)` —
  same shape as `createCandleBundle`, but every map uses the closed-safe
  rule. Runtime continues to use the open-bar variant (it is evaluating
  "now"); backtest must use this one.

### `apps/api/src/lib/backtest.ts`

- `runBacktestWithBundle({ bundle, primaryInterval, dslJson, opts })`
  — translates `Map<CandleInterval, MarketCandle[]>` (from 52-T2's
  `loadCandleBundle`) into the `MtfBacktestContext` the evaluator
  already supports (#134-slice4), wrapped via `createClosedCandleBundle`
  so look-ahead is structurally impossible.

## Test plan

- [x] `tests/lib/mtf/closedAlignmentMap.test.ts` (8/8) — anchor case
      (M5_12:05 with H1 must resolve to H1_11:00, never H1_12:00),
      start-of-data `-1` fallback, multi-boundary advancement, factory
      output differs from `createCandleBundle`.
- [x] `tests/lib/runBacktestWithBundle.test.ts` (6/6) — single-TF
      parity with `runBacktest` (bit-for-bit equal for the same
      candles), multi-TF determinism, validation errors.
- [x] `apps/api/tsc --noEmit` clean.

## Out of scope

- Wiring into `routes/lab.ts` (`POST /lab/backtest`,
  `/lab/backtest/sweep`, `/lab/walk-forward`) — ships in 52-T4b.
- `botWorker` runtime integration — 52-T3.
- Real DSL multi-TF e2e via API — 52-T6 (uses this wrapper).

https://claude.ai/code/session_01T32Us22aMPYosBMqmt7Kjn

---
_Generated by [Claude Code](https://claude.ai/code/session_01T32Us22aMPYosBMqmt7Kjn)_