### PR TITLE
feat(lab): /lab/backtest/sweep accepts datasetBundleJson (52-T4b-2)

### DIFF
--- a/apps/api/src/routes/lab.ts
+++ b/apps/api/src/routes/lab.ts
@@ -952,6 +952,7 @@ export async function labRoutes(app: FastifyInstance) {
       slippageBps = 0,
       fillAt = "CLOSE",
       rankBy = "pnlPct",
+      datasetBundleJson,
     } = request.body ?? {};
 
     // ── 47-T1 normalization ────────────────────────────────────────────
@@ -1045,6 +1046,32 @@ export async function labRoutes(app: FastifyInstance) {
       return problem(reply, 404, "Not Found", "Dataset not found");
     }
 
+    // ── Optional multi-interval bundle (docs/52-T4b-2) ───────────────────────
+    // Same rules as POST /lab/backtest: backtest mode, primary entry equals
+    // body.datasetId, primary TF present. Persisted on the sweep row so the
+    // async runner replays it identically across every grid iteration.
+    let resolvedBundle: DatasetBundle | null = null;
+    if (datasetBundleJson !== undefined && datasetBundleJson !== null) {
+      const parsed = parseDatasetBundle(datasetBundleJson, { mode: "backtest" });
+      if (!parsed.bundle) {
+        return problem(reply, 400, "Validation Error", "Invalid datasetBundleJson", { errors: parsed.errors });
+      }
+      const primaryInterval = dataset.interval as BundleCandleInterval;
+      const pErrors = validateBundleAgainstPrimary(parsed.bundle, primaryInterval);
+      if (pErrors.length > 0) {
+        return problem(reply, 400, "Validation Error", "Invalid datasetBundleJson", { errors: pErrors });
+      }
+      if (parsed.bundle[primaryInterval] !== datasetId) {
+        return problem(reply, 400, "Validation Error", "Invalid datasetBundleJson", {
+          errors: [{
+            field: `datasetBundleJson.${primaryInterval}`,
+            message: `primary entry must equal body.datasetId (${datasetId})`,
+          }],
+        });
+      }
+      resolvedBundle = parsed.bundle;
+    }
+
     // ── Guard: max 2 concurrent sweeps per workspace ─────────────────────────
     const activeSweeps = await prisma.backtestSweep.count({
       where: { workspaceId: workspace.id, status: { in: ["PENDING", "RUNNING"] } },
@@ -1069,6 +1096,9 @@ export async function labRoutes(app: FastifyInstance) {
         rankBy,
         runCount,
         status: "PENDING",
+        // 52-T4b-2: persist bundle so the async runner replays the same set
+        // of intervals on every iteration. NULL ⇒ legacy single-TF sweep.
+        ...(resolvedBundle ? { datasetBundleJson: resolvedBundle as unknown as object } : {}),
       },
     });
 
@@ -1588,6 +1618,13 @@ interface SweepRequestBody {
   fillAt?: FillAt;
   /** Metric by which the best row is chosen (47-T4). Default "pnlPct". */
   rankBy?: RankBy;
+  /**
+   * Optional multi-interval bundle (docs/52-T4). Same rules as on
+   * `POST /lab/backtest`: backtest mode (concrete datasetIds only),
+   * primary entry must equal `body.datasetId`. Persisted on
+   * `BacktestSweep.datasetBundleJson` and replayed on every sweep run.
+   */
+  datasetBundleJson?: unknown;
 }
 
 /**
@@ -1689,25 +1726,48 @@ async function runSweepAsync(sweepId: string): Promise<void> {
     const dataset = await prisma.marketDataset.findUnique({ where: { id: sweep.datasetId } });
     if (!dataset) throw new Error("Dataset not found");
 
-    // Load candles once (shared across all runs)
-    const dbCandles = await prisma.marketCandle.findMany({
-      where: {
-        exchange: dataset.exchange,
-        symbol: dataset.symbol,
-        interval: dataset.interval,
-        openTimeMs: { gte: dataset.fromTsMs, lte: dataset.toTsMs },
-      },
-      orderBy: { openTimeMs: "asc" },
-    });
+    // 52-T4b-2: if the sweep was created with a bundle, load every interval
+    // once and reuse on every grid iteration. Otherwise stay on the legacy
+    // single-TF candle load (bit-for-bit unchanged).
+    const persistedBundle = sweep.datasetBundleJson as unknown;
+    let candleBundle: Awaited<ReturnType<typeof loadCandleBundle>> | null = null;
+    let candles: Array<{
+      openTime: number; open: number; high: number; low: number; close: number; volume: number;
+    }> = [];
 
-    const candles = dbCandles.map((c) => ({
-      openTime: Number(c.openTimeMs),
-      open: Number(c.open),
-      high: Number(c.high),
-      low: Number(c.low),
-      close: Number(c.close),
-      volume: Number(c.volume),
-    }));
+    if (persistedBundle != null) {
+      const parsedBundle = parseDatasetBundle(persistedBundle, { mode: "backtest" });
+      if (!parsedBundle.bundle) {
+        throw new Error(
+          `bundle on BacktestSweep ${sweepId} is invalid: ${parsedBundle.errors.map((e) => e.message).join("; ")}`,
+        );
+      }
+      candleBundle = await loadCandleBundle({
+        symbol: dataset.symbol,
+        bundle: parsedBundle.bundle,
+        lookbackBars: 100_000,
+        mode: "backtest",
+        until: new Date(Number(dataset.toTsMs)),
+      });
+    } else {
+      const dbCandles = await prisma.marketCandle.findMany({
+        where: {
+          exchange: dataset.exchange,
+          symbol: dataset.symbol,
+          interval: dataset.interval,
+          openTimeMs: { gte: dataset.fromTsMs, lte: dataset.toTsMs },
+        },
+        orderBy: { openTimeMs: "asc" },
+      });
+      candles = dbCandles.map((c) => ({
+        openTime: Number(c.openTimeMs),
+        open: Number(c.open),
+        high: Number(c.high),
+        low: Number(c.low),
+        close: Number(c.close),
+        volume: Number(c.volume),
+      }));
+    }
 
     const dslJson = strategyVersion.dslJson;
     if (!dslJson) throw new Error("StrategyVersion has no dslJson");
@@ -1762,12 +1822,21 @@ async function runSweepAsync(sweepId: string): Promise<void> {
       });
 
       try {
-        // DSL-driven backtest — sweep-mutated DSL for this iteration
-        const report = runBacktest(candles, mutatedDsl, {
+        // DSL-driven backtest — sweep-mutated DSL for this iteration.
+        // Bundle path uses look-ahead-safe alignment via runBacktestWithBundle.
+        const execOpts = {
           feeBps: sweep.feeBps,
           slippageBps: sweep.slippageBps,
           fillAt: sweep.fillAt as FillAt,
-        });
+        };
+        const report = candleBundle
+          ? runBacktestWithBundle({
+              bundle: candleBundle,
+              primaryInterval: dataset.interval as BundleCandleInterval,
+              dslJson: mutatedDsl,
+              opts: execOpts,
+            })
+          : runBacktest(candles, mutatedDsl, execOpts);
 
         await prisma.backtestResult.update({
           where: { id: bt.id },

--- a/apps/api/tests/routes/lab.test.ts
+++ b/apps/api/tests/routes/lab.test.ts
@@ -1070,6 +1070,72 @@ describe("POST /api/v1/lab/backtest/sweep", () => {
     expect(finalRow!.bestParamValue).toBe(5);
     expect(finalRow!.bestParamValuesJson).toMatchObject({ "bL.pL": 5 });
   });
+
+  // ── 52-T4b-2: datasetBundleJson plumbing on sweep ─────────────────────────
+  const bundleSweepHeaders = (ip: string) => ({ ...authHeaders(), "x-forwarded-for": ip });
+
+  it("52-T4b: persists datasetBundleJson on the sweep row when provided", async () => {
+    mockStrategyVersions["sv-52-1"] = { id: "sv-52-1", strategyId: "strat-52", strategy: { workspaceId: WS_ID }, dslJson: {} };
+    mockDatasets["ds-52-1"] = { id: "ds-52-1", workspaceId: WS_ID, exchange: "bybit", symbol: "BTCUSDT", interval: "M15", fromTsMs: BigInt(0), toTsMs: BigInt(1), datasetHash: "h" };
+    mockDatasets["ds-52-h1"] = { id: "ds-52-h1", workspaceId: WS_ID, exchange: "bybit", symbol: "BTCUSDT", interval: "H1", fromTsMs: BigInt(0), toTsMs: BigInt(1), datasetHash: "h2" };
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/lab/backtest/sweep",
+      headers: bundleSweepHeaders("10.52.b2.1"),
+      payload: {
+        datasetId: "ds-52-1",
+        strategyVersionId: "sv-52-1",
+        sweepParams: [{ blockId: "b1", paramName: "p1", from: 1, to: 3, step: 1 }],
+        datasetBundleJson: { M15: "ds-52-1", H1: "ds-52-h1" },
+      },
+    });
+    expect(res.statusCode).toBe(202);
+    const { sweepId } = res.json();
+    expect(mockSweeps[sweepId]).toBeDefined();
+    expect((mockSweeps[sweepId] as Record<string, unknown>).datasetBundleJson).toEqual({
+      M15: "ds-52-1",
+      H1: "ds-52-h1",
+    });
+  });
+
+  it("52-T4b: rejects bundle whose primary entry mismatches body.datasetId (400)", async () => {
+    mockStrategyVersions["sv-52-2"] = { id: "sv-52-2", strategyId: "strat-52", strategy: { workspaceId: WS_ID }, dslJson: {} };
+    mockDatasets["ds-52-2"] = { id: "ds-52-2", workspaceId: WS_ID, exchange: "bybit", symbol: "BTCUSDT", interval: "M15", fromTsMs: BigInt(0), toTsMs: BigInt(1), datasetHash: "h" };
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/lab/backtest/sweep",
+      headers: bundleSweepHeaders("10.52.b2.2"),
+      payload: {
+        datasetId: "ds-52-2",
+        strategyVersionId: "sv-52-2",
+        sweepParams: [{ blockId: "b1", paramName: "p1", from: 1, to: 3, step: 1 }],
+        datasetBundleJson: { M15: "ds-other", H1: "ds-52-h1" },
+      },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.stringify(res.json())).toMatch(/primary entry must equal body\.datasetId/);
+  });
+
+  it("52-T4b: rejects bundle with `true` placeholder (backtest mode)", async () => {
+    mockStrategyVersions["sv-52-3"] = { id: "sv-52-3", strategyId: "strat-52", strategy: { workspaceId: WS_ID }, dslJson: {} };
+    mockDatasets["ds-52-3"] = { id: "ds-52-3", workspaceId: WS_ID, exchange: "bybit", symbol: "BTCUSDT", interval: "M15", fromTsMs: BigInt(0), toTsMs: BigInt(1), datasetHash: "h" };
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/lab/backtest/sweep",
+      headers: bundleSweepHeaders("10.52.b2.3"),
+      payload: {
+        datasetId: "ds-52-3",
+        strategyVersionId: "sv-52-3",
+        sweepParams: [{ blockId: "b1", paramName: "p1", from: 1, to: 3, step: 1 }],
+        datasetBundleJson: { M15: true },
+      },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.stringify(res.json())).toMatch(/backtest mode requires a concrete datasetId/);
+  });
 });
 
 // ── GET /lab/backtest/sweep/:id ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Second slice of `docs/52-T4` route wiring. Same contract as the
single-shot backtest route (52-T4b-1) but persisted on
`BacktestSweep`, so the async runner replays the same bundle on every
grid iteration.

### `POST /lab/backtest/sweep`

- Body accepts `datasetBundleJson`. Same rules as
  `POST /lab/backtest`: backtest mode (concrete `datasetId` strings
  only — `true` is rejected), primary TF must equal `dataset.interval`,
  primary entry value must equal `body.datasetId`. Validation
  surfaces `400` with field-level errors via `parseDatasetBundle` +
  `validateBundleAgainstPrimary`.

- `BacktestSweep.datasetBundleJson` is populated only when supplied
  (52-T1 column is nullable). Legacy sweeps stay on the existing
  single-TF path bit-for-bit.

### `runSweepAsync`

- **Bundle path**: `loadCandleBundle({ mode: "backtest" })` runs once
  before the grid loop (same shared-load discipline as the legacy
  single-dataset path), and `runBacktestWithBundle` (look-ahead-safe
  alignment) is dispatched per iteration.

- **Legacy path**: untouched. DESC-vs-ASC ordering, fee/slippage
  semantics, `BacktestResult` creation are all preserved bit-for-bit.

- Bundle parsing in the runner re-validates with `mode: "backtest"`, so
  a malformed row in the DB fails the sweep with a clear error rather
  than silently dropping back to legacy mode.

## Test plan

- [x] 3 new cases in `tests/routes/lab.test.ts > POST /lab/backtest/sweep`:
  - persists `datasetBundleJson` on the sweep row when provided.
  - 400 when primary entry mismatches `body.datasetId`.
  - 400 on `true` placeholder in backtest mode.
- [x] All 120/120 tests in `lab.test.ts` green (was 117 + 3 new).
- [x] `tsc --noEmit` clean.

## Out of scope

- `/lab/backtest/walk-forward` wiring → 52-T4b-3.
- `botWorker` runtime integration → 52-T3.
- UI selector → 52-T5.

https://claude.ai/code/session_01T32Us22aMPYosBMqmt7Kjn

---
_Generated by [Claude Code](https://claude.ai/code/session_01T32Us22aMPYosBMqmt7Kjn)_