### PR TITLE
feat(lab): /lab/backtest/walk-forward persists datasetBundleJson (52-T4b-3)

### DIFF
--- a/apps/api/src/routes/lab.ts
+++ b/apps/api/src/routes/lab.ts
@@ -1201,6 +1201,7 @@ export async function labRoutes(app: FastifyInstance) {
       feeBps = 0,
       slippageBps = 0,
       fillAt = "CLOSE",
+      datasetBundleJson,
     } = request.body ?? {};
 
     // ── Validation — required fields ──────────────────────────────────────
@@ -1230,6 +1231,33 @@ export async function labRoutes(app: FastifyInstance) {
     const dataset = await prisma.marketDataset.findUnique({ where: { id: datasetId } });
     if (!dataset || dataset.workspaceId !== workspace.id) {
       return problem(reply, 404, "Not Found", "Dataset not found");
+    }
+
+    // ── Optional multi-interval bundle (docs/52-T4b-3, persistence-only) ─
+    // Validation rules mirror /lab/backtest and /lab/backtest/sweep. The
+    // bundle is persisted for round-trip integrity but the fold runner still
+    // honours the existing MTF preflight (rejects MTF DSLs); a follow-up PR
+    // will slice the bundle per-fold and run runBacktestWithBundle for IS/OOS.
+    let resolvedBundle: DatasetBundle | null = null;
+    if (datasetBundleJson !== undefined && datasetBundleJson !== null) {
+      const parsed = parseDatasetBundle(datasetBundleJson, { mode: "backtest" });
+      if (!parsed.bundle) {
+        return problem(reply, 400, "Validation Error", "Invalid datasetBundleJson", { errors: parsed.errors });
+      }
+      const primaryInterval = dataset.interval as BundleCandleInterval;
+      const pErrors = validateBundleAgainstPrimary(parsed.bundle, primaryInterval);
+      if (pErrors.length > 0) {
+        return problem(reply, 400, "Validation Error", "Invalid datasetBundleJson", { errors: pErrors });
+      }
+      if (parsed.bundle[primaryInterval] !== datasetId) {
+        return problem(reply, 400, "Validation Error", "Invalid datasetBundleJson", {
+          errors: [{
+            field: `datasetBundleJson.${primaryInterval}`,
+            message: `primary entry must equal body.datasetId (${datasetId})`,
+          }],
+        });
+      }
+      resolvedBundle = parsed.bundle;
     }
 
     // ── Pre-flight: load candles + run split() to compute foldCount ───────
@@ -1295,6 +1323,10 @@ export async function labRoutes(app: FastifyInstance) {
         status: "PENDING",
         foldConfigJson: cfg as object,
         foldCount,
+        // 52-T4b-3 (persistence-only): bundle is stored on the row so a
+        // follow-up that implements bundle-aware folding can pick it up
+        // without a schema change. Today's runner ignores it.
+        ...(resolvedBundle ? { datasetBundleJson: resolvedBundle as unknown as object } : {}),
       },
     });
 
@@ -1589,6 +1621,16 @@ interface WalkForwardRequestBody {
   feeBps?: number;
   slippageBps?: number;
   fillAt?: FillAt;
+  /**
+   * Optional multi-interval bundle (docs/52-T4b-3, persistence-only slice).
+   * Same rules as the other backtest routes: backtest mode (concrete
+   * `MarketDataset.id` strings), primary entry must equal `body.datasetId`.
+   * Persisted on `WalkForwardRun.datasetBundleJson` for round-trip
+   * integrity. The fold runner currently still rejects MTF DSLs at the
+   * `WalkForwardMtfNotSupportedError` preflight; bundle-aware walk-forward
+   * (slicing HTF per fold) lands in a follow-up PR.
+   */
+  datasetBundleJson?: unknown;
 }
 
 interface SweepParam {

--- a/apps/api/tests/routes/lab.test.ts
+++ b/apps/api/tests/routes/lab.test.ts
@@ -1954,6 +1954,52 @@ describe("POST /api/v1/lab/backtest/walk-forward", () => {
       "step < oosBars — adjacent OOS blocks overlap; aggregate metrics may double-count trades",
     );
   });
+
+  // ── 52-T4b-3: datasetBundleJson persistence on walk-forward ────────────
+  it("52-T4b: persists datasetBundleJson on the walk-forward row when provided", async () => {
+    mockStrategyVersions["sv-wf-bundle"] = { id: "sv-wf-bundle", strategyId: "strat-wf-b", strategy: { workspaceId: WS_ID }, dslJson: {} };
+    mockDatasets["ds-wf-bundle-m15"] = { id: "ds-wf-bundle-m15", workspaceId: WS_ID, exchange: "bybit", symbol: "BTCUSDT", interval: "M15", fromTsMs: BigInt(0), toTsMs: BigInt(1), datasetHash: "h" };
+    mockDatasets["ds-wf-bundle-h1"] = { id: "ds-wf-bundle-h1", workspaceId: WS_ID, exchange: "bybit", symbol: "BTCUSDT", interval: "H1", fromTsMs: BigInt(0), toTsMs: BigInt(1), datasetHash: "h2" };
+    prismaMock.marketCandle.findMany.mockResolvedValueOnce(makeCandles(80));
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/lab/backtest/walk-forward",
+      headers: wfHeaders(),
+      payload: {
+        datasetId: "ds-wf-bundle-m15",
+        strategyVersionId: "sv-wf-bundle",
+        fold: { isBars: 30, oosBars: 10, step: 10, anchored: false },
+        datasetBundleJson: { M15: "ds-wf-bundle-m15", H1: "ds-wf-bundle-h1" },
+      },
+    });
+    expect(res.statusCode).toBe(202);
+    const { id } = res.json();
+    expect(mockWalkForwardRuns[id]).toBeDefined();
+    expect(mockWalkForwardRuns[id].datasetBundleJson).toEqual({
+      M15: "ds-wf-bundle-m15",
+      H1: "ds-wf-bundle-h1",
+    });
+  });
+
+  it("52-T4b: rejects walk-forward bundle whose primary mismatches body.datasetId (400)", async () => {
+    mockStrategyVersions["sv-wf-bundle-bad"] = { id: "sv-wf-bundle-bad", strategyId: "strat-wf-bad", strategy: { workspaceId: WS_ID }, dslJson: {} };
+    mockDatasets["ds-wf-bundle-bad"] = { id: "ds-wf-bundle-bad", workspaceId: WS_ID, exchange: "bybit", symbol: "BTCUSDT", interval: "M15", fromTsMs: BigInt(0), toTsMs: BigInt(1), datasetHash: "h" };
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/lab/backtest/walk-forward",
+      headers: wfHeaders(),
+      payload: {
+        datasetId: "ds-wf-bundle-bad",
+        strategyVersionId: "sv-wf-bundle-bad",
+        fold: { isBars: 30, oosBars: 10, step: 10, anchored: false },
+        datasetBundleJson: { M15: "ds-other", H1: "ds-h1" },
+      },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.stringify(res.json())).toMatch(/primary entry must equal body\.datasetId/);
+  });
 });
 
 describe("GET /api/v1/lab/backtest/walk-forward/:id", () => {


### PR DESCRIPTION
## Summary

Closes the route-wiring half of `docs/52-T4`. Same body shape and
validation rules as `/lab/backtest{,/sweep}`; bundle is persisted on
`WalkForwardRun.datasetBundleJson` for round-trip integrity.

### Behaviour

- `POST /lab/backtest/walk-forward` body now accepts an optional
  `datasetBundleJson` (backtest mode — concrete `MarketDataset.id`
  strings only, primary TF must equal `dataset.interval`, primary
  entry value must equal `body.datasetId`).
- Validation surfaces `400` with field-level errors via the same
  `parseDatasetBundle` + `validateBundleAgainstPrimary` pair used by
  the backtest and sweep routes.
- `WalkForwardRun.datasetBundleJson` is populated only when supplied
  (52-T1 column already nullable).

### Persistence-only — explicit

The fold runner still rejects MTF DSLs at the existing
`WalkForwardMtfNotSupportedError` preflight. **Bundle-aware folding**
(slicing HTF candles per fold with look-ahead-safe alignment) is a
substantial standalone change and is deferred to a follow-up; today
the bundle is stored on the row and ignored at execute time. This
unblocks UI (52-T5) and e2e (52-T6) work without inflating this PR.

## Test plan

- [x] 2 new cases in `tests/routes/lab.test.ts`:
  - persists `datasetBundleJson` on the walk-forward row when provided.
  - 400 when primary entry mismatches `body.datasetId`.
- [x] All 122/122 tests in `lab.test.ts` green (was 120 + 2 new).
- [x] `tsc --noEmit` clean.

## Out of scope / follow-ups

- Bundle-aware fold runner — separate follow-up tagged 52-T4b-3-bis.
- `botWorker` runtime integration → 52-T3.
- UI selector → 52-T5.
- e2e bundle backtest → 52-T6.

https://claude.ai/code/session_01T32Us22aMPYosBMqmt7Kjn

---
_Generated by [Claude Code](https://claude.ai/code/session_01T32Us22aMPYosBMqmt7Kjn)_