### PR TITLE
feat(lab-ui): wire DatasetBundleSelector into 3 lab panels (52-T5b)

### DIFF
--- a/apps/web/src/app/lab/test/OptimisePanel.tsx
+++ b/apps/web/src/app/lab/test/OptimisePanel.tsx
@@ -10,6 +10,11 @@ import { apiFetch, getWorkspaceId } from "../../../lib/api";
 import { useLabGraphStore } from "../useLabGraphStore";
 import { BLOCK_DEF_MAP } from "../build/blockDefs";
 import type { LabNode } from "../useLabGraphStore";
+import {
+  DatasetBundleSelector,
+  type DatasetBundle,
+  type CandleInterval as BundleCandleInterval,
+} from "../_shared/DatasetBundleSelector";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -152,6 +157,13 @@ export default function OptimisePanel({
   const [feeBps, setFeeBps] = useState(10);
   const [slippageBps, setSlippageBps] = useState(5);
   const [metric, setMetric] = useState<OptimiseMetric>("pnl");
+  const [bundle, setBundle] = useState<DatasetBundle | null>(null);
+
+  // Reset bundle when the primary dataset changes — its (symbol, interval)
+  // anchors the bundle, so any extra TFs become inconsistent (docs/52-T5b).
+  useEffect(() => { setBundle(null); }, [datasetId]);
+
+  const selectedDataset = readyDatasets.find((d) => d.datasetId === datasetId);
 
   // ── Sweep state ─────────────────────────────────────────────────────────
   const [submitting, setSubmitting] = useState(false);
@@ -292,6 +304,7 @@ export default function OptimisePanel({
       slippageBps,
     };
     if (rankBy) body.rankBy = rankBy;
+    if (bundle) body.datasetBundleJson = bundle;
 
     const res = await apiFetch<{ sweepId: string; runCount: number; estimatedSeconds: number }>(
       "/lab/backtest/sweep",
@@ -315,7 +328,7 @@ export default function OptimisePanel({
       setSubmitError(res.problem.detail ?? res.problem.title ?? "Unknown error");
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [datasetId, versionId, sweepParams, feeBps, slippageBps, metric]);
+  }, [datasetId, versionId, sweepParams, feeBps, slippageBps, metric, bundle]);
 
   // ── Sort results ────────────────────────────────────────────────────────
   const handleSort = (key: SortKey) => {
@@ -727,6 +740,21 @@ export default function OptimisePanel({
               </select>
             )}
           </FormRow>
+
+          {/* Multi-interval bundle (docs/52-T5b) */}
+          {selectedDataset && (
+            <FormRow label="Multi-TF context">
+              <DatasetBundleSelector
+                primaryInterval={selectedDataset.interval as BundleCandleInterval}
+                primaryDatasetId={selectedDataset.datasetId}
+                primarySymbol={selectedDataset.symbol}
+                availableDatasets={readyDatasets}
+                bundle={bundle}
+                onChange={setBundle}
+                disabled={submitting}
+              />
+            </FormRow>
+          )}
 
           {/* Strategy version */}
           <FormRow label="Strategy version">

--- a/apps/web/src/app/lab/test/WalkForwardPanel.tsx
+++ b/apps/web/src/app/lab/test/WalkForwardPanel.tsx
@@ -8,6 +8,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { apiFetch, getWorkspaceId } from "../../../lib/api";
 import { useLabGraphStore } from "../useLabGraphStore";
+import {
+  DatasetBundleSelector,
+  type DatasetBundle,
+  type CandleInterval as BundleCandleInterval,
+} from "../_shared/DatasetBundleSelector";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -136,6 +141,11 @@ export default function WalkForwardPanel({
   const [feeBps, setFeeBps] = useState(10);
   const [slippageBps, setSlippageBps] = useState(5);
   const [fillAt, setFillAt] = useState<FillAt>("CLOSE");
+  const [bundle, setBundle] = useState<DatasetBundle | null>(null);
+
+  // Reset bundle when the primary dataset changes — its (symbol, interval)
+  // anchors the bundle, so any extra TFs become inconsistent (docs/52-T5b).
+  useEffect(() => { setBundle(null); }, [datasetId]);
 
   // Run state
   const [submitting, setSubmitting] = useState(false);
@@ -223,7 +233,7 @@ export default function WalkForwardPanel({
     setSubmitError(null);
     setWarnings([]);
 
-    const body = {
+    const body: Record<string, unknown> = {
       datasetId,
       strategyVersionId: versionId,
       fold: { isBars, oosBars, step, anchored },
@@ -231,6 +241,7 @@ export default function WalkForwardPanel({
       slippageBps,
       fillAt,
     };
+    if (bundle) body.datasetBundleJson = bundle;
 
     const res = await apiFetch<{ id: string; foldCount: number; status: string; warnings: string[] }>(
       "/lab/backtest/walk-forward",
@@ -257,7 +268,7 @@ export default function WalkForwardPanel({
       setSubmitError(res.problem.detail ?? res.problem.title ?? "Unknown error");
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [datasetId, versionId, isBars, oosBars, step, anchored, feeBps, slippageBps, fillAt]);
+  }, [datasetId, versionId, isBars, oosBars, step, anchored, feeBps, slippageBps, fillAt, bundle]);
 
   return (
     <div style={{ padding: "20px 24px", maxWidth: 900, overflow: "auto", height: "100%" }}>
@@ -373,6 +384,23 @@ export default function WalkForwardPanel({
               </select>
             )}
           </FormRow>
+
+          {/* Multi-interval bundle (docs/52-T5b). Bundle is persisted on
+              WalkForwardRun.datasetBundleJson; the fold runner currently
+              ignores it (deferred follow-up). */}
+          {selectedDataset && (
+            <FormRow label="Multi-TF context">
+              <DatasetBundleSelector
+                primaryInterval={selectedDataset.interval as BundleCandleInterval}
+                primaryDatasetId={selectedDataset.datasetId}
+                primarySymbol={selectedDataset.symbol}
+                availableDatasets={readyDatasets}
+                bundle={bundle}
+                onChange={setBundle}
+                disabled={submitting}
+              />
+            </FormRow>
+          )}
 
           <FormRow label="Strategy version">
             {strategyVersions.length === 0 ? (

--- a/apps/web/src/app/lab/test/page.tsx
+++ b/apps/web/src/app/lab/test/page.tsx
@@ -16,6 +16,11 @@ import type { IChartApi, LineData, Time } from "lightweight-charts";
 import OptimisePanel from "./OptimisePanel";
 import WalkForwardPanel from "./WalkForwardPanel";
 import { PreviewPanel } from "../PreviewPanel";
+import {
+  DatasetBundleSelector,
+  type DatasetBundle,
+  type CandleInterval as BundleCandleInterval,
+} from "../_shared/DatasetBundleSelector";
 
 // ---------------------------------------------------------------------------
 // Task 29 — AI Explainability helpers
@@ -452,7 +457,7 @@ function BacktestForm({
 }: {
   datasets: DatasetListItem[];
   strategyVersions: StrategyVersionItem[];
-  onSubmit: (params: { strategyVersionId: string; datasetId: string; feeBps: number; slippageBps: number; fillAt: FillAt }) => void;
+  onSubmit: (params: { strategyVersionId: string; datasetId: string; feeBps: number; slippageBps: number; fillAt: FillAt; datasetBundleJson?: DatasetBundle }) => void;
   submitting: boolean;
   error: string | null;
   activeDatasetId: string | null;
@@ -465,6 +470,12 @@ function BacktestForm({
   const [feeBps, setFeeBps] = useState(10);
   const [slippageBps, setSlippageBps] = useState(5);
   const [fillAt, setFillAt] = useState<FillAt>("CLOSE");
+  const [bundle, setBundle] = useState<DatasetBundle | null>(null);
+
+  // Reset bundle when the primary dataset changes — its (symbol, interval) is
+  // the bundle's anchor, so any extra TFs become inconsistent the moment the
+  // primary moves.
+  useEffect(() => { setBundle(null); }, [datasetId]);
 
   // Sync default dataset when props change
   useEffect(() => {
@@ -513,6 +524,21 @@ function BacktestForm({
           <div style={hintStyle}>{selectedDataset.candleCount.toLocaleString()} candles · hash {selectedDataset.datasetHash.slice(0, 8)}</div>
         )}
       </FormRow>
+
+      {/* Multi-interval bundle (docs/52-T5b) */}
+      {selectedDataset && (
+        <FormRow label="Multi-TF context">
+          <DatasetBundleSelector
+            primaryInterval={selectedDataset.interval as BundleCandleInterval}
+            primaryDatasetId={selectedDataset.datasetId}
+            primarySymbol={selectedDataset.symbol}
+            availableDatasets={readyDatasets}
+            bundle={bundle}
+            onChange={setBundle}
+            disabled={submitting}
+          />
+        </FormRow>
+      )}
 
       {/* Strategy version select */}
       <FormRow label="Strategy version">
@@ -586,7 +612,14 @@ function BacktestForm({
             cursor: canSubmit ? "pointer" : "not-allowed",
           }}
           disabled={!canSubmit}
-          onClick={() => onSubmit({ strategyVersionId: versionId, datasetId, feeBps, slippageBps, fillAt })}
+          onClick={() => onSubmit({
+            strategyVersionId: versionId,
+            datasetId,
+            feeBps,
+            slippageBps,
+            fillAt,
+            ...(bundle ? { datasetBundleJson: bundle } : {}),
+          })}
         >
           {submitting ? "Starting…" : "Run Backtest"}
         </button>
@@ -1111,7 +1144,7 @@ function ResultDetail({
   activeDatasetId: string | null;
   lastCompileVersionId: string | null;
   lastCompileGraphVersionId: string | null;
-  onSubmit: (params: { strategyVersionId: string; datasetId: string; feeBps: number; slippageBps: number; fillAt: FillAt }) => void;
+  onSubmit: (params: { strategyVersionId: string; datasetId: string; feeBps: number; slippageBps: number; fillAt: FillAt; datasetBundleJson?: DatasetBundle }) => void;
 }) {
   const [activeTab, setActiveTab] = useState<ResultTab>("run");
 
@@ -1324,6 +1357,7 @@ export default function LabTestPage() {
     feeBps: number;
     slippageBps: number;
     fillAt: FillAt;
+    datasetBundleJson?: DatasetBundle;
   }) => {
     if (!getWorkspaceId()) return;
     setSubmitting(true);


### PR DESCRIPTION
## Summary

Closes the wiring half of `docs/52-T5`: the shared `DatasetBundleSelector` (52-T5a, #335) is plugged into all three Lab forms so users can opt in to multi-TF backtests on top of an existing single-dataset selection.

- **`page.tsx` (BacktestForm)** — selector between Dataset and Strategy version. Bundle is appended to the `POST /lab/backtest` body when set.
- **`OptimisePanel`** — bundle persisted via `POST /lab/backtest/sweep` on `BacktestSweep.datasetBundleJson` and shared across every grid run (52-T4b-2 already loads the bundle once before the grid loop).
- **`WalkForwardPanel`** — bundle persisted on `WalkForwardRun.datasetBundleJson`. The fold runner currently ignores it (still gated by the existing `WalkForwardMtfNotSupportedError` preflight) — bundle-aware fold runner is a deferred follow-up.

In every panel the local `bundle` state is reset to `null` whenever the primary `datasetId` changes, since the bundle's `(symbol, interval)` anchor is invalidated by that switch. When `bundle === null` the request body is byte-identical to the legacy single-TF flow, so all existing single-TF runs continue without behavioural drift.

## Test plan

- [x] `apps/web` `tsc --noEmit` — zero errors.
- [ ] Manual smoke in `/lab/test`:
  - [ ] Single-TF backtest still starts (no bundle in body).
  - [ ] Add a second TF that has a `READY` dataset → backtest starts, server logs `loadCandleBundle` with two intervals.
  - [ ] Switch primary dataset → bundle resets to `null`, selector collapses.
  - [ ] Same flow on `/lab/test` Optimise tab and Walk-forward tab.

https://claude.ai/code/session_01LCaeb3zKUHh5XgZxw38GW7

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCaeb3zKUHh5XgZxw38GW7)_