### PR TITLE
feat(runtime): botWorker loads candle bundle and surfaces it to engines (52-T3)

### DIFF
--- a/apps/api/src/lib/botWorker.ts
+++ b/apps/api/src/lib/botWorker.ts
@@ -52,6 +52,24 @@ import {
   type CloseSignal,
   type TrailingStopState,
 } from "./exitEngine.js";
+import {
+  loadCandleBundle,
+  CandleBundleLoadError,
+  type CandlesByInterval,
+} from "./mtf/loadCandleBundle.js";
+import {
+  parseDatasetBundle,
+  type CandleInterval as BundleCandleInterval,
+} from "../types/datasetBundle.js";
+import {
+  createCandleBundle,
+  TIMEFRAME_TO_INTERVAL,
+  type CandleBundle,
+  type Interval as MtfInterval,
+  type MtfCandle,
+} from "./mtf/intervalAlignment.js";
+import { createMtfCache } from "./mtf/mtfIndicatorResolver.js";
+import { type RuntimeMtfContext } from "./dslEvaluator.js";
 import { computeSizing } from "./riskManager.js";
 import { getInstrument, type InstrumentInfo } from "./exchange/instrumentCache.js";
 import { normalizeOrder } from "./exchange/normalizer.js";
@@ -1423,6 +1441,47 @@ const trailingStopStates = new Map<string, TrailingStopState>();
 const lastTradeCloseTimes = new Map<string, number>();
 
 /**
+ * Build a {@link RuntimeMtfContext} from a `loadCandleBundle` result.
+ *
+ * Returns `null` when the primary timeframe has no entry in
+ * {@link TIMEFRAME_TO_INTERVAL} (currently `M30`, which is allowed in
+ * `MarketCandle.interval` but absent from the alignment helper's interval
+ * set). The single-TF path stays correct in that case — only refs with
+ * `sourceTimeframe` would notice, and they would surface their own
+ * `MtfBundleRequiredError` instead of being resolved against an incomplete
+ * bundle.
+ */
+function buildRuntimeMtfContext(
+  bundleByInterval: CandlesByInterval,
+  primaryTimeframe: string,
+): RuntimeMtfContext | null {
+  const primaryAligned = TIMEFRAME_TO_INTERVAL[primaryTimeframe];
+  if (!primaryAligned) return null;
+
+  const candlesByInterval: Record<string, MtfCandle[]> = {};
+  for (const [interval, rows] of bundleByInterval.entries()) {
+    const aligned = TIMEFRAME_TO_INTERVAL[interval];
+    if (!aligned) continue; // skip TFs the alignment helper doesn't know
+    candlesByInterval[aligned] = rows.map((mc) => ({
+      openTime: Number(mc.openTimeMs),
+      open: mc.open.toNumber(),
+      high: mc.high.toNumber(),
+      low: mc.low.toNumber(),
+      close: mc.close.toNumber(),
+      volume: mc.volume.toNumber(),
+    }));
+  }
+
+  if (!candlesByInterval[primaryAligned]) return null;
+
+  const bundle: CandleBundle = createCandleBundle(
+    primaryAligned as MtfInterval,
+    candlesByInterval,
+  );
+  return { bundle, mtfCache: createMtfCache() };
+}
+
+/**
  * Evaluate DSL strategy for all RUNNING runs with compiled DSL.
  *
  * For each run:
@@ -1445,6 +1504,8 @@ async function evaluateStrategies(): Promise<void> {
           select: {
             id: true,
             symbol: true,
+            timeframe: true,
+            datasetBundleJson: true,
             strategyVersion: { select: { dslJson: true } },
           },
         },
@@ -1461,28 +1522,88 @@ async function evaluateStrategies(): Promise<void> {
       if (dsl["enabled"] === false) continue;
 
       const symbol = run.bot.symbol;
+      const timeframe = run.bot.timeframe; // Prisma `Timeframe` enum value
 
       try {
-        // Load recent candles (enough for indicator warm-up, ~200 bars)
-        const recentCandles = await prisma.marketCandle.findMany({
-          where: { symbol },
-          orderBy: { openTimeMs: "desc" },
-          take: 200,
-        });
+        // 52-T3: load candles either through the multi-interval bundle (when
+        // bot.datasetBundleJson is set) or via the legacy single-TF path.
+        //
+        // The legacy branch now filters by `interval: bot.timeframe` —
+        // previously the loader did `where: { symbol }` with no interval
+        // filter, which silently mixed candles across TFs for any symbol that
+        // had several datasets. This is a deliberate bugfix called out in
+        // docs/52-T3 §1; bots whose datasource is correctly synced for their
+        // primary TF are unaffected, but a bot whose only synced data is on a
+        // different TF will now stop receiving candles instead of trading on
+        // mismatched data.
+        const bundleParseResult = run.bot.datasetBundleJson
+          ? parseDatasetBundle(run.bot.datasetBundleJson, { mode: "runtime" })
+          : null;
+        if (bundleParseResult && !bundleParseResult.bundle) {
+          workerLog.error(
+            { runId: run.id, errors: bundleParseResult.errors },
+            "datasetBundleJson failed validation; skipping run tick",
+          );
+          continue;
+        }
+        const parsedBundle = bundleParseResult?.bundle ?? null;
+        if (parsedBundle && !(timeframe in parsedBundle)) {
+          workerLog.error(
+            { runId: run.id, timeframe, bundleIntervals: Object.keys(parsedBundle) },
+            "datasetBundleJson must include the bot's primary timeframe",
+          );
+          continue;
+        }
+
+        let bundleByInterval: CandlesByInterval | null = null;
+        if (parsedBundle) {
+          try {
+            bundleByInterval = await loadCandleBundle({
+              symbol,
+              bundle: parsedBundle,
+              lookbackBars: 200,
+              mode: "runtime",
+              logger: workerLog,
+            });
+          } catch (err) {
+            const detail = err instanceof CandleBundleLoadError
+              ? { field: err.field, message: err.message }
+              : { message: err instanceof Error ? err.message : String(err) };
+            workerLog.error({ runId: run.id, err: detail }, "loadCandleBundle failed");
+            continue;
+          }
+        }
+
+        let recentCandles: { openTimeMs: bigint | number; open: { toNumber(): number }; high: { toNumber(): number }; low: { toNumber(): number }; close: { toNumber(): number }; volume: { toNumber(): number } }[];
+        if (bundleByInterval) {
+          recentCandles = (bundleByInterval.get(timeframe as BundleCandleInterval) ?? []) as typeof recentCandles;
+        } else {
+          const rows = await prisma.marketCandle.findMany({
+            where: { symbol, interval: timeframe },
+            orderBy: { openTimeMs: "desc" },
+            take: 200,
+          });
+          rows.reverse();
+          recentCandles = rows as typeof recentCandles;
+        }
 
         if (recentCandles.length < 2) continue; // not enough data
 
-        // Convert to Candle format and reverse to ascending order
-        const candles = recentCandles
-          .reverse()
-          .map((mc) => ({
-            openTime: Number(mc.openTimeMs),
-            open: mc.open.toNumber(),
-            high: mc.high.toNumber(),
-            low: mc.low.toNumber(),
-            close: mc.close.toNumber(),
-            volume: mc.volume.toNumber(),
-          }));
+        // Convert to Candle format
+        const candles = recentCandles.map((mc) => ({
+          openTime: Number(mc.openTimeMs),
+          open: mc.open.toNumber(),
+          high: mc.high.toNumber(),
+          low: mc.low.toNumber(),
+          close: mc.close.toNumber(),
+          volume: mc.volume.toNumber(),
+        }));
+
+        // Build a runtime MTF context (open-bar-tolerant, NOT closed-safe —
+        // runtime is evaluating "now"). Skipped when no bundle is configured
+        // or the primary TF has no alignment-helper mapping.
+        const mtfContext: RuntimeMtfContext | null =
+          bundleByInterval !== null ? buildRuntimeMtfContext(bundleByInterval, timeframe) : null;
 
         // Get current position
         const position = await getActivePosition(run.id, symbol);
@@ -1528,6 +1649,7 @@ async function evaluateStrategies(): Promise<void> {
             candles,
             dslJson,
             position: null,
+            mtfContext,
           });
 
           if (signal) {
@@ -1707,6 +1829,7 @@ async function evaluateStrategies(): Promise<void> {
             position,
             barsHeld,
             trailingState,
+            mtfContext,
           });
 
           if (closeSignal) {

--- a/apps/api/src/lib/dslEvaluator.ts
+++ b/apps/api/src/lib/dslEvaluator.ts
@@ -445,6 +445,75 @@ export function getIndicatorValues(
   return new Array(candles.length).fill(null);
 }
 
+/**
+ * Multi-TF runtime evaluation context (docs/52-T3).
+ *
+ * When provided to {@link evaluateEntry} / {@link evaluateExit} (and the
+ * primitives they delegate to), DSL indicator refs that carry a
+ * `sourceTimeframe` resolve their values from the bundle's context-TF
+ * candles instead of the primary candle array.
+ *
+ * Mirrors {@link MtfBacktestContext} but is the runtime variant: callers
+ * typically build the bundle via {@link createCandleBundle} (open-bar
+ * tolerant) rather than the closed-safe variant used by backtests, since
+ * the runtime is evaluating "now".
+ */
+export interface RuntimeMtfContext {
+  bundle: import("./mtf/intervalAlignment.js").CandleBundle;
+  mtfCache: import("./mtf/mtfIndicatorResolver.js").MtfIndicatorCache;
+}
+
+/** Thrown when a DSL ref carries `sourceTimeframe` but no bundle was supplied. */
+export class MtfBundleRequiredError extends Error {
+  readonly sourceTimeframe: string;
+  readonly indicatorType: string;
+  constructor(indicatorType: string, sourceTimeframe: string) {
+    super(
+      `Indicator "${indicatorType}" requires a multi-TF bundle ` +
+      `(sourceTimeframe="${sourceTimeframe}"). Configure bot.datasetBundleJson ` +
+      `to include this timeframe.`,
+    );
+    this.name = "MtfBundleRequiredError";
+    this.indicatorType = indicatorType;
+    this.sourceTimeframe = sourceTimeframe;
+  }
+}
+
+/**
+ * Resolve an indicator ref to its value array, branching on
+ * `ref.sourceTimeframe`:
+ *
+ * - No `sourceTimeframe` → standard {@link getIndicatorValues} on `candles`.
+ * - `sourceTimeframe` set + `mtfContext` provided → context-TF resolution
+ *   via {@link resolveMtfIndicator} (alignment-mapped back to primary bars).
+ * - `sourceTimeframe` set + `mtfContext` missing → throws
+ *   {@link MtfBundleRequiredError} so the caller fails loudly instead of
+ *   silently swallowing the cross-TF intent.
+ */
+export function resolveIndicatorRef(
+  ref: DslIndicatorRef,
+  candles: Candle[],
+  cache: IndicatorCache,
+  mtfContext?: RuntimeMtfContext | null,
+): (number | null)[] {
+  if (ref.sourceTimeframe) {
+    if (!mtfContext) {
+      throw new MtfBundleRequiredError(ref.type, ref.sourceTimeframe);
+    }
+    return resolveMtfIndicator(ref, candles, mtfContext.mtfCache, mtfContext.bundle);
+  }
+  return getIndicatorValues(ref.type, {
+    length: ref.length,
+    period: ref.period,
+    atrPeriod: ref.atrPeriod,
+    multiplier: ref.multiplier,
+    fastPeriod: ref.fastPeriod,
+    slowPeriod: ref.slowPeriod,
+    signalPeriod: ref.signalPeriod,
+    bins: ref.bins,
+  }, candles, cache);
+}
+
 function getVolumeProfileCached(
   params: { period?: number; bins?: number },
   candles: Candle[],
@@ -627,6 +696,7 @@ export function determineSide(
   i: number,
   candles: Candle[],
   cache: IndicatorCache,
+  mtfContext?: RuntimeMtfContext | null,
 ): TradeSide | null {
   // Fixed side
   if (entry.side) {
@@ -636,17 +706,8 @@ export function determineSide(
   // Dynamic sideCondition (DSL v2)
   if (entry.sideCondition) {
     const sc = entry.sideCondition;
-    const indValues = getIndicatorValues(
-      sc.indicator.type,
-      {
-        length: sc.indicator.length,
-        period: (sc.indicator as unknown as Record<string, unknown>).period as number | undefined,
-        atrPeriod: sc.indicator.atrPeriod,
-        multiplier: sc.indicator.multiplier,
-      },
-      candles,
-      cache,
-    );
+    // 52-T3: resolveIndicatorRef branches on sc.indicator.sourceTimeframe.
+    const indValues = resolveIndicatorRef(sc.indicator, candles, cache, mtfContext);
 
     const val = indValues[i];
     if (val === null) return null;

--- a/apps/api/src/lib/exitEngine.ts
+++ b/apps/api/src/lib/exitEngine.ts
@@ -21,7 +21,7 @@ import type { PositionSnapshot } from "./positionManager.js";
 import {
   parseDsl,
   evalOp,
-  getIndicatorValues,
+  resolveIndicatorRef,
   computeExitLevels,
   createIndicatorCache,
   type ParsedDsl,
@@ -29,6 +29,7 @@ import {
   type DslExitLevel,
   type DslExit,
   type IndicatorCache,
+  type RuntimeMtfContext,
 } from "./dslEvaluator.js";
 
 // ---------------------------------------------------------------------------
@@ -82,6 +83,13 @@ export interface ExitEngineContext {
   barsHeld: number;
   /** Mutable trailing stop state (updated in-place) */
   trailingState: TrailingStopState;
+  /**
+   * Optional multi-TF runtime context (docs/52-T3). When set, indicator-exit
+   * refs that carry a `sourceTimeframe` resolve from the bundle's context-TF
+   * candles. Refs with `sourceTimeframe` and no bundle throw
+   * {@link MtfBundleRequiredError}.
+   */
+  mtfContext?: RuntimeMtfContext | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -98,7 +106,7 @@ export interface ExitEngineContext {
  * runDslBacktest in dslEvaluator.ts.
  */
 export function evaluateExit(ctx: ExitEngineContext): CloseSignal | null {
-  const { candles, dslJson, position, barsHeld, trailingState } = ctx;
+  const { candles, dslJson, position, barsHeld, trailingState, mtfContext } = ctx;
   if (candles.length < 1) return null;
   if (position.status !== "OPEN") return null;
 
@@ -205,17 +213,9 @@ export function evaluateExit(ctx: ExitEngineContext): CloseSignal | null {
     const ie = exit.indicatorExit;
     const appliesTo = ie.appliesTo ?? "both";
     if (appliesTo === "both" || appliesTo === positionSide) {
-      const indVals = getIndicatorValues(
-        ie.indicator.type,
-        {
-          length: ie.indicator.length,
-          period: (ie.indicator as unknown as Record<string, unknown>).period as number | undefined,
-          atrPeriod: ie.indicator.atrPeriod,
-          multiplier: ie.indicator.multiplier,
-        },
-        candles,
-        cache,
-      );
+      // 52-T3: branch on ie.indicator.sourceTimeframe so indicator exits
+      // declared on a context TF resolve through the bundle.
+      const indVals = resolveIndicatorRef(ie.indicator, candles, cache, mtfContext);
       const val = indVals[i];
       if (val !== null && evalOp(ie.condition.op, val, ie.condition.value)) {
         return {

--- a/apps/api/src/lib/signalEngine.ts
+++ b/apps/api/src/lib/signalEngine.ts
@@ -24,6 +24,7 @@ import {
   type TradeSide,
   type DslExitLevel,
   type IndicatorCache,
+  type RuntimeMtfContext,
 } from "./dslEvaluator.js";
 
 // ---------------------------------------------------------------------------
@@ -56,6 +57,13 @@ export interface SignalEngineContext {
   dslJson: unknown;
   /** Current active position (null if no position) */
   position: PositionSnapshot | null;
+  /**
+   * Optional multi-TF runtime context (docs/52-T3). When set, DSL refs that
+   * carry a `sourceTimeframe` resolve from the bundle's context-TF candles.
+   * When absent, refs without `sourceTimeframe` continue to work; refs with
+   * one throw {@link MtfBundleRequiredError}.
+   */
+  mtfContext?: RuntimeMtfContext | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -77,7 +85,7 @@ export function evaluateEntry(ctx: SignalEngineContext): OpenSignal | null {
     return null;
   }
 
-  const { candles, dslJson } = ctx;
+  const { candles, dslJson, mtfContext } = ctx;
   if (candles.length < 2) return null;
 
   const parsed = parseDsl(dslJson);
@@ -86,8 +94,9 @@ export function evaluateEntry(ctx: SignalEngineContext): OpenSignal | null {
   const cache = createIndicatorCache();
   const i = candles.length - 1; // evaluate on the latest candle
 
-  // Determine side
-  const side = determineSide(entry, i, candles, cache);
+  // Determine side — propagate MTF context so sideCondition.indicator with a
+  // `sourceTimeframe` can resolve from the HTF candles in the bundle.
+  const side = determineSide(entry, i, candles, cache, mtfContext);
   if (!side) return null;
 
   // Evaluate entry signal

--- a/apps/api/tests/lib/multiTfRuntime.test.ts
+++ b/apps/api/tests/lib/multiTfRuntime.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Multi-TF runtime evaluator coverage (docs/52-T3).
+ *
+ * Pure-function tests around the new {@link RuntimeMtfContext} plumbing in
+ * signalEngine + exitEngine + dslEvaluator. The botWorker integration
+ * itself is covered indirectly: it composes these primitives and the
+ * botWorker.test.ts harness already exercises the surrounding state
+ * machine. This file pins the multi-TF semantics:
+ *
+ *   1. `resolveIndicatorRef` falls through to the single-TF path when the
+ *      ref does not declare `sourceTimeframe`.
+ *   2. `resolveIndicatorRef` reads from the bundle's context-TF candles
+ *      (mapped via the alignment map) when `sourceTimeframe` is set.
+ *   3. `resolveIndicatorRef` throws `MtfBundleRequiredError` when a ref
+ *      asks for a context TF but no bundle is provided.
+ *   4. `signalEngine.evaluateEntry` with a `sideCondition.indicator` carrying
+ *      `sourceTimeframe` resolves it through the bundle.
+ *   5. `exitEngine.evaluateExit` with `indicatorExit.indicator` carrying
+ *      `sourceTimeframe` resolves it through the bundle.
+ *   6. The "bundle missing" guard fires from inside `evaluateEntry` /
+ *      `evaluateExit` — i.e. is genuinely invoked, not just defined.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  resolveIndicatorRef,
+  createIndicatorCache,
+  MtfBundleRequiredError,
+  type DslIndicatorRef,
+  type RuntimeMtfContext,
+} from "../../src/lib/dslEvaluator.js";
+import {
+  createCandleBundle,
+  type MtfCandle,
+  type Interval,
+} from "../../src/lib/mtf/intervalAlignment.js";
+import { createMtfCache } from "../../src/lib/mtf/mtfIndicatorResolver.js";
+import { evaluateEntry } from "../../src/lib/signalEngine.js";
+import { evaluateExit, createTrailingStopState } from "../../src/lib/exitEngine.js";
+import type { PositionSnapshot } from "../../src/lib/positionManager.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const M5_MS = 300_000;
+const H1_MS = 3_600_000;
+
+/** Build a 12-hour M5 series (144 bars) with a gentle uptrend on close. */
+function makeM5(): MtfCandle[] {
+  const out: MtfCandle[] = [];
+  const t0 = Date.UTC(2026, 0, 1, 0, 0, 0);
+  for (let i = 0; i < 144; i++) {
+    const close = 100 + i * 0.1;
+    out.push({
+      openTime: t0 + i * M5_MS,
+      open: close - 0.05,
+      high: close + 0.1,
+      low: close - 0.1,
+      close,
+      volume: 10,
+    });
+  }
+  return out;
+}
+
+/** Build the matching 12 H1 bars; close steps in 1.0 increments per hour. */
+function makeH1(): MtfCandle[] {
+  const out: MtfCandle[] = [];
+  const t0 = Date.UTC(2026, 0, 1, 0, 0, 0);
+  for (let i = 0; i < 12; i++) {
+    const close = 50 + i; // 50, 51, ..., 61
+    out.push({
+      openTime: t0 + i * H1_MS,
+      open: close - 0.5,
+      high: close + 0.5,
+      low: close - 0.5,
+      close,
+      volume: 100,
+    });
+  }
+  return out;
+}
+
+function makeRuntimeMtfContext(): RuntimeMtfContext {
+  const bundle = createCandleBundle("5m" as Interval, {
+    "5m": makeM5(),
+    "1h": makeH1(),
+  });
+  return { bundle, mtfCache: createMtfCache() };
+}
+
+// ---------------------------------------------------------------------------
+// 1. resolveIndicatorRef behavioural matrix
+// ---------------------------------------------------------------------------
+
+describe("resolveIndicatorRef (52-T3)", () => {
+  it("uses the primary candle path when no sourceTimeframe is set", () => {
+    const candles = makeM5();
+    const cache = createIndicatorCache();
+    const ref: DslIndicatorRef = { type: "sma", length: 14 };
+
+    const values = resolveIndicatorRef(ref, candles, cache);
+    expect(values).toHaveLength(candles.length);
+    // First (length - 1) entries are null while the SMA window is filling.
+    expect(values[0]).toBeNull();
+    expect(values[12]).toBeNull();
+    expect(values[13]).not.toBeNull();
+  });
+
+  it("resolves through the bundle's context TF when sourceTimeframe is set", () => {
+    const ctx = makeRuntimeMtfContext();
+    const ref: DslIndicatorRef = { type: "sma", length: 3, sourceTimeframe: "1h" };
+    const cache = createIndicatorCache();
+
+    const values = resolveIndicatorRef(ref, ctx.bundle.candles["5m"], cache, ctx);
+    expect(values).toHaveLength(ctx.bundle.candles["5m"].length);
+
+    // The H1 SMA(3) at primary bar i = 35 (M5 02:55Z, contained in H1 02:00Z)
+    // should equal the H1 SMA(3) at H1 idx 2: avg(50, 51, 52) = 51.
+    expect(values[35]).toBeCloseTo(51, 5);
+  });
+
+  it("throws MtfBundleRequiredError when sourceTimeframe is set but no bundle", () => {
+    const ref: DslIndicatorRef = { type: "rsi", length: 14, sourceTimeframe: "H1" };
+    const candles = makeM5();
+    const cache = createIndicatorCache();
+
+    expect(() => resolveIndicatorRef(ref, candles, cache)).toThrow(MtfBundleRequiredError);
+    expect(() => resolveIndicatorRef(ref, candles, cache, null)).toThrow(MtfBundleRequiredError);
+  });
+
+  it("MtfBundleRequiredError carries the offending ref metadata", () => {
+    const ref: DslIndicatorRef = { type: "rsi", length: 14, sourceTimeframe: "H1" };
+    const candles = makeM5();
+    const cache = createIndicatorCache();
+
+    try {
+      resolveIndicatorRef(ref, candles, cache);
+      expect.fail("expected MtfBundleRequiredError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(MtfBundleRequiredError);
+      const e = err as MtfBundleRequiredError;
+      expect(e.indicatorType).toBe("rsi");
+      expect(e.sourceTimeframe).toBe("H1");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. signalEngine.evaluateEntry with a context-TF sideCondition
+// ---------------------------------------------------------------------------
+
+describe("signalEngine.evaluateEntry — multi-TF sideCondition (52-T3)", () => {
+  /** A DSL with a `sideCondition` whose indicator lives on H1. */
+  function mtfSideConditionDsl() {
+    return {
+      id: "mtf-side",
+      name: "MTF side condition",
+      dslVersion: 2,
+      enabled: true,
+      market: { exchange: "bybit", env: "demo", category: "linear", symbol: "BTCUSDT" },
+      entry: {
+        sideCondition: {
+          indicator: { type: "sma", length: 3, sourceTimeframe: "1h" },
+          source: "close",
+          mode: "price_vs_indicator",
+          long: { op: ">" },
+          short: { op: "<" },
+        },
+        signal: {
+          // A trivially-true compare so the side decides the outcome.
+          type: "compare",
+          left: { blockType: "sma", length: 3 },
+          right: { blockType: "sma", length: 3 },
+          op: ">=",
+        },
+        stopLoss: { type: "fixed_pct", value: 1 },
+        takeProfit: { type: "fixed_pct", value: 2 },
+      },
+      risk: { maxPositionSizeUsd: 100, riskPerTradePct: 1, cooldownSeconds: 0 },
+      execution: { orderType: "Market", clientOrderIdPrefix: "t_" },
+      guards: { maxOpenPositions: 1, maxOrdersPerMinute: 10, pauseOnError: true },
+    };
+  }
+
+  it("resolves the H1 indicator via bundle and produces a long signal", () => {
+    const ctx = makeRuntimeMtfContext();
+    // Primary close at the latest M5 bar is ~114.3, H1 SMA(3) ≈ 60 — so
+    // close > SMA => long.
+    const signal = evaluateEntry({
+      candles: ctx.bundle.candles["5m"],
+      dslJson: mtfSideConditionDsl(),
+      position: null,
+      mtfContext: ctx,
+    });
+    expect(signal).not.toBeNull();
+    expect(signal!.side).toBe("long");
+  });
+
+  it("throws MtfBundleRequiredError when the bundle is missing", () => {
+    const m5 = makeM5();
+    expect(() => evaluateEntry({
+      candles: m5,
+      dslJson: mtfSideConditionDsl(),
+      position: null,
+    })).toThrow(MtfBundleRequiredError);
+  });
+
+  it("falls back cleanly when sourceTimeframe is removed", () => {
+    const dsl = mtfSideConditionDsl();
+    // Strip sourceTimeframe — pure single-TF behaviour, no bundle needed.
+    (dsl.entry.sideCondition.indicator as { sourceTimeframe?: string }).sourceTimeframe = undefined;
+    const m5 = makeM5();
+    const signal = evaluateEntry({
+      candles: m5,
+      dslJson: dsl,
+      position: null,
+    });
+    // close (~114) > M5 SMA(3) (~114 - small) → long.
+    expect(signal?.side).toBe("long");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. exitEngine.evaluateExit with a context-TF indicatorExit
+// ---------------------------------------------------------------------------
+
+describe("exitEngine.evaluateExit — multi-TF indicatorExit (52-T3)", () => {
+  function mtfIndicatorExitDsl() {
+    return {
+      id: "mtf-exit",
+      name: "MTF indicator exit",
+      dslVersion: 2,
+      enabled: true,
+      market: { exchange: "bybit", env: "demo", category: "linear", symbol: "BTCUSDT" },
+      entry: {
+        side: "Buy",
+        signal: { type: "direct" },
+        stopLoss: { type: "fixed_pct", value: 99 },
+        takeProfit: { type: "fixed_pct", value: 99 },
+      },
+      exit: {
+        stopLoss: { type: "fixed_pct", value: 99 },
+        takeProfit: { type: "fixed_pct", value: 99 },
+        indicatorExit: {
+          indicator: { type: "sma", length: 3, sourceTimeframe: "1h" },
+          condition: { op: ">", value: 55 },
+          appliesTo: "both",
+        },
+      },
+      risk: { maxPositionSizeUsd: 100, riskPerTradePct: 1, cooldownSeconds: 0 },
+      execution: { orderType: "Market", clientOrderIdPrefix: "t_" },
+      guards: { maxOpenPositions: 1, maxOrdersPerMinute: 10, pauseOnError: true },
+    };
+  }
+
+  function fakeOpenLongPosition(entryPrice: number): PositionSnapshot {
+    return {
+      id: "pos_1",
+      botRunId: "run_1",
+      symbol: "BTCUSDT",
+      side: "LONG",
+      currentQty: 1,
+      avgEntryPrice: entryPrice,
+      slPrice: entryPrice * 0.5,
+      tpPrice: entryPrice * 2,
+      status: "OPEN",
+      openedAt: new Date(0),
+    } as unknown as PositionSnapshot;
+  }
+
+  it("fires the indicator exit when the H1 SMA(3) tail is above the threshold", () => {
+    const ctx = makeRuntimeMtfContext();
+    // Last M5 maps to the last fully-formed H1 (idx 11 — close 61), SMA(3)
+    // tail = avg(59, 60, 61) = 60 > 55 → exit fires.
+    const m5 = ctx.bundle.candles["5m"];
+    const close = evaluateExit({
+      candles: m5,
+      dslJson: mtfIndicatorExitDsl(),
+      position: fakeOpenLongPosition(110),
+      barsHeld: 5,
+      trailingState: createTrailingStopState(110),
+      mtfContext: ctx,
+    });
+    expect(close).not.toBeNull();
+    expect(close!.reason).toBe("indicator_exit");
+  });
+
+  it("throws MtfBundleRequiredError when the bundle is missing", () => {
+    const m5 = makeM5();
+    expect(() => evaluateExit({
+      candles: m5,
+      dslJson: mtfIndicatorExitDsl(),
+      position: fakeOpenLongPosition(110),
+      barsHeld: 5,
+      trailingState: createTrailingStopState(110),
+    })).toThrow(MtfBundleRequiredError);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the runtime half of `docs/52`. `botWorker.evaluateStrategies` now reads `Bot.datasetBundleJson` and feeds the resulting `CandleBundle` into the strategy evaluator so DSL indicator refs that carry a `sourceTimeframe` resolve from a context-TF candle series at runtime — the same way `runBacktestWithBundle` already does for backtests.

### Evaluator changes (additive, opt-in via `mtfContext`)
- **`dslEvaluator.resolveIndicatorRef(ref, candles, cache, mtfContext?)`** — new helper that branches on `ref.sourceTimeframe`. No `sourceTimeframe` ⇒ standard `getIndicatorValues`. Set + bundle ⇒ `resolveMtfIndicator`. Set + no bundle ⇒ throws `MtfBundleRequiredError` so the cross-TF intent fails loudly instead of being silently dropped.
- **`dslEvaluator.determineSide`** — accepts optional `mtfContext` and resolves `sideCondition.indicator` through it.
- **`signalEngine.SignalEngineContext`, `exitEngine.ExitEngineContext`** — gain an optional `mtfContext`; `evaluateEntry` threads it into `determineSide`, `evaluateExit` threads it into the indicator-exit branch.

### botWorker
- `Bot` select pulls `timeframe` + `datasetBundleJson`.
- When `datasetBundleJson` is set, `parseDatasetBundle({ mode: "runtime" })` + `loadCandleBundle` assemble the per-interval candles and a **runtime-safe (non-closed) `CandleBundle`** is built via `createCandleBundle` (runtime evaluates "now"; the look-ahead-safe variant is reserved for backtests).
- Primary candles come from the bundle when present; otherwise the legacy `findMany` now filters by `interval: bot.timeframe`.
- Parse / load failures are logged at error level and the tick is skipped.

### ⚠️ Bugfix called out in docs/52-T3 §1
The legacy single-TF branch in botWorker previously did `findMany({ where: { symbol } })` — no `interval` filter — which silently mixed candles across TFs whenever the symbol had multiple datasets. This PR adds `interval: bot.timeframe`. Bots whose datasource is correctly synced for their primary TF are unaffected. Bots that *previously appeared to work* only because of unfiltered candle reads will now stop receiving candles rather than trading on mismatched data — which is the intended, correct behaviour. **Mitigation:** ensure each bot has a `MarketCandle` series synced for its `bot.timeframe`.

### Deferred
- DSL `signal` `crossover` / `compare` blocks (`DslSignalRef`) intentionally do not gain a `sourceTimeframe` field in this PR — the type does not currently expose one and adding it would balloon the surface. Side-condition + indicator-exit are the two refs that already carry `sourceTimeframe` in `DslIndicatorRef`, and those are wired here.

## Test plan

- [x] `apps/api` `tsc --noEmit` — exit 0 after `prisma generate`.
- [x] `vitest run tests/lib/{signalEngine,exitEngine,dslEvaluator,botWorker,multiTfRuntime,runBacktestWithBundle,mtf} tests/integration/multiTfBacktestFlow` — 173/173 pass locally.
- [x] New `tests/lib/multiTfRuntime.test.ts` (9 tests):
  - `resolveIndicatorRef` matrix — single-TF fallthrough; MTF resolution against an H1 SMA(3) baseline; bundle-missing throws with carried `indicatorType` / `sourceTimeframe`.
  - `signalEngine.evaluateEntry` — H1 `sideCondition.indicator` resolves through the bundle and produces a `long`; bundle removal triggers `MtfBundleRequiredError`; falls back cleanly when `sourceTimeframe` is stripped.
  - `exitEngine.evaluateExit` — H1 `indicatorExit` fires; bundle removal triggers `MtfBundleRequiredError`.
- [ ] Manual smoke not run — botWorker integration is exercised through the existing `botWorker.test.ts` state-machine harness (29 pre-existing tests pass) plus the new MTF unit coverage. Live deployment validation is the appropriate next step before turning on a real MTF bot.

https://claude.ai/code/session_01LCaeb3zKUHh5XgZxw38GW7

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCaeb3zKUHh5XgZxw38GW7)_