### PR TITLE
feat(walk-forward): bundle-aware fold runner unblocks MTF DSLs (52 follow-up)

### DIFF
--- a/apps/api/src/lib/walkForward/run.ts
+++ b/apps/api/src/lib/walkForward/run.ts
@@ -1,27 +1,35 @@
 /**
  * Walk-forward runner — per-fold backtest without aggregation.
  *
- * Given a candle array, a compiled DSL, execution opts, and a FoldConfig,
- * `runWalkForward` produces one (IS, OOS) backtest pair per fold by calling
- * `runBacktest` twice on the slices returned by `split`. The function
- * does not touch the database, has no HTTP layer, and only side-effects
- * via the optional `onProgress` callback (used by the BD wrapper in 48-T5
- * to surface progress to the client).
+ * Two entry points:
  *
- * Multi-timeframe gate: walk-forward for MTF strategies is not yet
- * implemented (slicing the MTF context bundle in sync with the primary
- * candles is non-trivial and out of scope for this version). The runner
- * pre-flights the DSL and throws a `WalkForwardMtfNotSupportedError` when
- * any indicator carries a `sourceTimeframe`. The HTTP layer (48-T5) maps
- * that error to a 400.
+ *   1. `runWalkForward(candles, ...)` — legacy single-TF path. Iterates the
+ *      primary candle array, runs `runBacktest` twice per fold. MTF DSLs
+ *      are rejected up front via `WalkForwardMtfNotSupportedError` because
+ *      no HTF data is available to align against.
+ *
+ *   2. `runWalkForwardWithBundle({ bundle, primaryInterval, ... })` — the
+ *      multi-interval path (docs/52 follow-up). Splits the *primary* TF
+ *      into folds; for each fold, slices every interval in the bundle by
+ *      the primary fold's `[fromTsMs, toTsMs]` window and feeds the
+ *      resulting per-fold bundle into `runBacktestWithBundle`. The
+ *      look-ahead-safe alignment used by `createClosedCandleBundle`
+ *      (inside `runBacktestWithBundle`) ensures HTF candles that have not
+ *      closed by a primary bar's open time are excluded.
+ *
+ * The function is otherwise pure: no I/O, only the optional `onProgress`
+ * callback (used by the BD wrapper in 48-T5 to surface progress).
  *
  * Determinism: mirrors the contracts of `split` (48-T1) and `runBacktest`
  * (docs/44 §Детерминизм). Identical inputs always produce identical output.
  */
 
+import type { MarketCandle } from "@prisma/client";
 import type { Candle } from "../bybitCandles.js";
 import type { DslExecOpts } from "../dslEvaluator.js";
-import { runBacktest } from "../backtest.js";
+import { runBacktest, runBacktestWithBundle } from "../backtest.js";
+import type { CandlesByInterval } from "../mtf/loadCandleBundle.js";
+import type { CandleInterval } from "../../types/datasetBundle.js";
 import { split } from "./split.js";
 import { aggregate } from "./aggregate.js";
 import type {
@@ -32,13 +40,16 @@ import type {
 
 /**
  * Thrown when a DSL contains at least one indicator with a non-empty
- * `sourceTimeframe`. The HTTP layer (48-T5) translates this into a 400
- * with the prescribed user-facing message.
+ * `sourceTimeframe` and no bundle is supplied. The HTTP layer (48-T5)
+ * translates this into a 400 with the prescribed user-facing message.
+ *
+ * Bundle-aware walk-forward (`runWalkForwardWithBundle`) does *not*
+ * throw this — MTF DSLs are first-class on that path.
  */
 export class WalkForwardMtfNotSupportedError extends Error {
   constructor(public readonly indicatorType: string, public readonly sourceTimeframe: string) {
     super(
-      `Walk-forward для MTF-стратегий не реализован: индикатор '${indicatorType}' использует sourceTimeframe='${sourceTimeframe}'. См. follow-up к docs/48.`,
+      `Walk-forward для MTF-стратегий требует datasetBundleJson: индикатор '${indicatorType}' использует sourceTimeframe='${sourceTimeframe}'. Передайте bundle в запрос.`,
     );
     this.name = "WalkForwardMtfNotSupportedError";
   }
@@ -83,9 +94,10 @@ export function runWalkForward(
   foldCfg: FoldConfig,
   onProgress?: (done: number, total: number) => void,
 ): WalkForwardReport {
-  // MTF pre-flight: walk-forward does not slice MTF contexts yet, so a
+  // Single-TF path: walk-forward does not slice MTF contexts here, so a
   // strategy that references another timeframe would silently fall back
-  // to the primary TF and produce different signals. Reject up front.
+  // to the primary TF and produce different signals. Reject up front and
+  // direct the caller to the bundle-aware path below.
   const mtfHit = findMtfIndicator(dslJson);
   if (mtfHit) {
     throw new WalkForwardMtfNotSupportedError(mtfHit.type, mtfHit.sourceTimeframe);
@@ -101,6 +113,112 @@ export function runWalkForward(
     const isReport = runBacktest(fold.isSlice, dslJson, opts, undefined);
     const oosReport = runBacktest(fold.oosSlice, dslJson, opts, undefined);
     onProgress?.(fold.foldIndex + 1, folds.length);
+    return {
+      foldIndex: fold.foldIndex,
+      isReport,
+      oosReport,
+      isRange: fold.isRange,
+      oosRange: fold.oosRange,
+    };
+  });
+
+  return { folds: folded, aggregate: aggregate(folded) };
+}
+
+// ---------------------------------------------------------------------------
+// Bundle-aware path
+// ---------------------------------------------------------------------------
+
+export interface RunWalkForwardWithBundleArgs {
+  /** Candles per interval, as returned by `loadCandleBundle({mode:'backtest'})`. */
+  bundle: CandlesByInterval;
+  /** Drives fold iteration; must be a key of `bundle`. */
+  primaryInterval: CandleInterval;
+  dslJson: unknown;
+  opts: Partial<DslExecOpts>;
+  foldCfg: FoldConfig;
+  onProgress?: (done: number, total: number) => void;
+}
+
+/**
+ * Slice a bundle by the [fromTsMs, toTsMs] window of a primary fold.
+ *
+ * Inclusive on both ends — the window comes from {@link FoldRange} which
+ * stores the open time of the first and last primary candle. Each
+ * interval is filtered independently; HTF candles whose open time falls
+ * within the primary window are kept. Look-ahead safety is delegated to
+ * {@link runBacktestWithBundle}, which builds a closed-bundle alignment
+ * map internally.
+ */
+function sliceBundleByWindow(
+  bundle: CandlesByInterval,
+  fromTsMs: number,
+  toTsMs: number,
+): CandlesByInterval {
+  const out: CandlesByInterval = new Map();
+  const fromBig = BigInt(fromTsMs);
+  const toBig = BigInt(toTsMs);
+  for (const [interval, rows] of bundle.entries()) {
+    const sliced: MarketCandle[] = [];
+    for (const c of rows) {
+      const t = c.openTimeMs;
+      if (t >= fromBig && t <= toBig) sliced.push(c);
+    }
+    out.set(interval, sliced);
+  }
+  return out;
+}
+
+/** Convert a `MarketCandle` row to the {@link Candle} shape consumed by `split`.
+ *
+ *  Mirrors the OHLCV decoding in `backtest.ts:toMtfCandle` so the wrapper
+ *  is robust to test fixtures that pass plain numbers in place of Prisma
+ *  Decimals. */
+function toCandle(row: MarketCandle): Candle {
+  const num = (v: { toString(): string } | number): number =>
+    typeof v === "number" ? v : Number(v.toString());
+  return {
+    openTime: Number(row.openTimeMs),
+    open: num(row.open),
+    high: num(row.high),
+    low: num(row.low),
+    close: num(row.close),
+    volume: num(row.volume),
+  };
+}
+
+export function runWalkForwardWithBundle(args: RunWalkForwardWithBundleArgs): WalkForwardReport {
+  const primaryRows = args.bundle.get(args.primaryInterval);
+  if (!primaryRows) {
+    throw new Error(
+      `runWalkForwardWithBundle: primary interval "${args.primaryInterval}" missing from bundle`,
+    );
+  }
+
+  // Use the primary candles as the splitting axis — fold count and
+  // ranges are determined entirely by primary-TF bars, exactly as in
+  // the single-TF path.
+  const primaryCandles = primaryRows.map(toCandle);
+  const folds = split(primaryCandles, args.foldCfg);
+
+  const folded: FoldReport[] = folds.map((fold) => {
+    const isBundle = sliceBundleByWindow(args.bundle, fold.isRange.fromTsMs, fold.isRange.toTsMs);
+    const oosBundle = sliceBundleByWindow(args.bundle, fold.oosRange.fromTsMs, fold.oosRange.toTsMs);
+
+    const isReport = runBacktestWithBundle({
+      bundle: isBundle,
+      primaryInterval: args.primaryInterval,
+      dslJson: args.dslJson,
+      opts: args.opts,
+    });
+    const oosReport = runBacktestWithBundle({
+      bundle: oosBundle,
+      primaryInterval: args.primaryInterval,
+      dslJson: args.dslJson,
+      opts: args.opts,
+    });
+
+    args.onProgress?.(fold.foldIndex + 1, folds.length);
     return {
       foldIndex: fold.foldIndex,
       isReport,

--- a/apps/api/src/routes/lab.ts
+++ b/apps/api/src/routes/lab.ts
@@ -13,6 +13,7 @@ import {
 } from "../types/datasetBundle.js";
 import {
   runWalkForward,
+  runWalkForwardWithBundle,
   WalkForwardMtfNotSupportedError,
 } from "../lib/walkForward/run.js";
 import { split as splitFolds } from "../lib/walkForward/split.js";
@@ -1233,11 +1234,12 @@ export async function labRoutes(app: FastifyInstance) {
       return problem(reply, 404, "Not Found", "Dataset not found");
     }
 
-    // ── Optional multi-interval bundle (docs/52-T4b-3, persistence-only) ─
-    // Validation rules mirror /lab/backtest and /lab/backtest/sweep. The
-    // bundle is persisted for round-trip integrity but the fold runner still
-    // honours the existing MTF preflight (rejects MTF DSLs); a follow-up PR
-    // will slice the bundle per-fold and run runBacktestWithBundle for IS/OOS.
+    // ── Optional multi-interval bundle (docs/52 follow-up: bundle-aware) ─
+    // Validation rules mirror /lab/backtest and /lab/backtest/sweep. When a
+    // bundle is supplied, the fold runner slices each interval per fold and
+    // runs `runBacktestWithBundle` for IS/OOS — MTF DSLs are first-class on
+    // this path (no MTF preflight). Without a bundle the legacy single-TF
+    // runner still rejects MTF DSLs upfront.
     let resolvedBundle: DatasetBundle | null = null;
     if (datasetBundleJson !== undefined && datasetBundleJson !== null) {
       const parsed = parseDatasetBundle(datasetBundleJson, { mode: "backtest" });
@@ -1323,16 +1325,27 @@ export async function labRoutes(app: FastifyInstance) {
         status: "PENDING",
         foldConfigJson: cfg as object,
         foldCount,
-        // 52-T4b-3 (persistence-only): bundle is stored on the row so a
-        // follow-up that implements bundle-aware folding can pick it up
-        // without a schema change. Today's runner ignores it.
+        // The bundle is persisted both for round-trip integrity and so the
+        // fold runner can re-load identical candles on retry.
         ...(resolvedBundle ? { datasetBundleJson: resolvedBundle as unknown as object } : {}),
       },
     });
 
-    runWalkForwardAsync(run.id, candles, strategyVersion.dslJson, {
-      feeBps, slippageBps, fillAt: fillAt as FillAt,
-    }, cfg).catch(() => {});
+    runWalkForwardAsync(
+      run.id,
+      candles,
+      strategyVersion.dslJson,
+      { feeBps, slippageBps, fillAt: fillAt as FillAt },
+      cfg,
+      resolvedBundle
+        ? {
+            bundle: resolvedBundle,
+            primaryInterval: dataset.interval as BundleCandleInterval,
+            symbol: dataset.symbol,
+            untilMs: Number(dataset.toTsMs),
+          }
+        : null,
+    ).catch(() => {});
 
     return reply.status(202).send({
       id: run.id,
@@ -2070,6 +2083,12 @@ async function runWalkForwardAsync(
   dslJson: unknown,
   opts: { feeBps: number; slippageBps: number; fillAt: FillAt },
   cfg: FoldConfig,
+  bundleCtx: {
+    bundle: DatasetBundle;
+    primaryInterval: BundleCandleInterval;
+    symbol: string;
+    untilMs: number;
+  } | null,
 ): Promise<void> {
   try {
     await prisma.walkForwardRun.update({
@@ -2091,10 +2110,37 @@ async function runWalkForwardAsync(
       }
     };
 
-    const report = runWalkForward(candles, dslJson, opts, cfg, (done, total) => {
-      // fire-and-forget so the runner is not awaited
-      onProgress(done, total).catch(() => {});
-    });
+    let report;
+    if (bundleCtx) {
+      // Bundle-aware path: load every interval's candles up to the dataset's
+      // upper bound, then split + slice per fold inside the runner.
+      const candlesByInterval = await loadCandleBundle({
+        symbol: bundleCtx.symbol,
+        bundle: bundleCtx.bundle,
+        // Soft cap: M5 over 5 years ≈ 525k bars, H1 over 10 years ≈ 87k —
+        // 1M comfortably covers any practical walk-forward window without
+        // truncating the dataset (loadCandleBundle uses ORDER BY desc +
+        // take, so a low cap would drop the oldest candles).
+        lookbackBars: 1_000_000,
+        mode: "backtest",
+        until: new Date(bundleCtx.untilMs),
+      });
+      report = runWalkForwardWithBundle({
+        bundle: candlesByInterval,
+        primaryInterval: bundleCtx.primaryInterval,
+        dslJson,
+        opts,
+        foldCfg: cfg,
+        onProgress: (done, total) => {
+          onProgress(done, total).catch(() => {});
+        },
+      });
+    } else {
+      report = runWalkForward(candles, dslJson, opts, cfg, (done, total) => {
+        // fire-and-forget so the runner is not awaited
+        onProgress(done, total).catch(() => {});
+      });
+    }
 
     // Store a truncated FoldReport[] without per-fold tradeLog (size discipline,
     // docs/48-T4 §4). The full tradeLog only existed in memory during the run.

--- a/apps/api/tests/lib/walkForward/runWithBundle.test.ts
+++ b/apps/api/tests/lib/walkForward/runWithBundle.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Walk-forward bundle-aware runner — coverage (docs/52 follow-up).
+ *
+ * Pins the contract of {@link runWalkForwardWithBundle}:
+ *
+ *   1. Single-TF bundle (primary only) reproduces {@link runWalkForward}
+ *      report bit-for-bit on the same candles.
+ *   2. Multi-TF bundle ({M5,H1}) accepts an MTF DSL — no preflight throw,
+ *      every fold gets a non-null IS/OOS report.
+ *   3. Look-ahead guard at the fold boundary: perturbing an HTF candle that
+ *      lives in fold N's OOS window does not change fold N's IS report.
+ *   4. The split axis is the primary TF — fold count and ranges match the
+ *      single-TF split() contract.
+ *
+ * Trade-engine semantics (fees, slippage, fillAt) are deliberately not
+ * exercised here — they are covered by tests/lib/backtest.test.ts and
+ * tests/lib/runBacktestWithBundle.test.ts. This file focuses on the
+ * fold-slicing plumbing the new wrapper introduces.
+ */
+
+import { describe, it, expect } from "vitest";
+import { runWalkForward, runWalkForwardWithBundle } from "../../../src/lib/walkForward/run.js";
+import { INTERVAL_MS, type MtfCandle } from "../../../src/lib/mtf/intervalAlignment.js";
+import type { CandleInterval } from "../../../src/types/datasetBundle.js";
+import type { MarketCandle } from "@prisma/client";
+import type { Candle } from "../../../src/lib/bybitCandles.js";
+
+// ---------------------------------------------------------------------------
+// Fixture helpers — mirror tests/lib/runBacktestWithBundle.test.ts
+// ---------------------------------------------------------------------------
+
+function toRow(c: MtfCandle, interval: CandleInterval): MarketCandle {
+  return {
+    id: `c-${interval}-${c.openTime}`,
+    exchange: "bybit",
+    symbol: "BTCUSDT",
+    interval,
+    openTimeMs: BigInt(c.openTime),
+    open: c.open as unknown as MarketCandle["open"],
+    high: c.high as unknown as MarketCandle["high"],
+    low: c.low as unknown as MarketCandle["low"],
+    close: c.close as unknown as MarketCandle["close"],
+    volume: c.volume as unknown as MarketCandle["volume"],
+    createdAt: new Date(c.openTime),
+  };
+}
+
+function makeBundle(input: Partial<Record<CandleInterval, MtfCandle[]>>): Map<CandleInterval, MarketCandle[]> {
+  const out = new Map<CandleInterval, MarketCandle[]>();
+  for (const [interval, candles] of Object.entries(input)) {
+    if (!candles) continue;
+    out.set(interval as CandleInterval, candles.map((c) => toRow(c, interval as CandleInterval)));
+  }
+  return out;
+}
+
+function makeM5(count: number): MtfCandle[] {
+  const start = Date.UTC(2026, 0, 1, 0, 0, 0);
+  const ms = INTERVAL_MS["5m"];
+  return Array.from({ length: count }, (_, i) => {
+    const close = 100 + i * 0.05;
+    return {
+      openTime: start + i * ms,
+      open: close - 0.02,
+      high: close + 0.05,
+      low: close - 0.05,
+      close,
+      volume: 10,
+    };
+  });
+}
+
+function makeH1(count: number): MtfCandle[] {
+  const start = Date.UTC(2026, 0, 1, 0, 0, 0);
+  const ms = INTERVAL_MS["1h"];
+  return Array.from({ length: count }, (_, i) => {
+    const close = 50 + i * 0.5;
+    return {
+      openTime: start + i * ms,
+      open: close - 0.2,
+      high: close + 0.3,
+      low: close - 0.3,
+      close,
+      volume: 100,
+    };
+  });
+}
+
+function toCandle(row: MarketCandle): Candle {
+  return {
+    openTime: Number(row.openTimeMs),
+    open: Number(row.open),
+    high: Number(row.high),
+    low: Number(row.low),
+    close: Number(row.close),
+    volume: Number(row.volume),
+  };
+}
+
+/** A neutral DSL that never trades but exercises the full evaluator path. */
+const NEUTRAL_DSL = {
+  dslVersion: 1,
+  name: "neutral-walk",
+  market: { exchange: "bybit", env: "demo", category: "linear", symbol: "BTCUSDT" },
+  entry: { side: "Buy" },
+  risk: { maxPositionSizeUsd: 100, riskPerTradePct: 1, cooldownSeconds: 60 },
+  execution: { orderType: "Market", clientOrderIdPrefix: "neutral" },
+  guards: { maxOpenPositions: 1, maxOrdersPerMinute: 10, pauseOnError: true },
+};
+
+/**
+ * MTF DSL — references H1 indicator via `sourceTimeframe`. Single-TF
+ * `runWalkForward` rejects this with `WalkForwardMtfNotSupportedError`;
+ * `runWalkForwardWithBundle` must accept it.
+ */
+const MTF_DSL = {
+  ...NEUTRAL_DSL,
+  name: "neutral-mtf-walk",
+  entry: {
+    sideCondition: {
+      indicator: { type: "sma", length: 3, sourceTimeframe: "1h" },
+      source: "close",
+      mode: "price_vs_indicator",
+      long: { op: ">" },
+      short: { op: "<" },
+    },
+    signal: { type: "direct" },
+    stopLoss: { type: "fixed_pct", value: 1 },
+    takeProfit: { type: "fixed_pct", value: 2 },
+  },
+};
+
+const FOLD_CFG = { isBars: 200, oosBars: 60, step: 60, anchored: false };
+
+// ---------------------------------------------------------------------------
+// 1. Backwards compat: primary-only bundle ≡ runWalkForward
+// ---------------------------------------------------------------------------
+
+describe("runWalkForwardWithBundle — single-TF parity", () => {
+  it("primary-only bundle reproduces runWalkForward report on identical candles", () => {
+    const m5Rows = makeM5(400);
+    const bundle = makeBundle({ M5: m5Rows });
+    const candles = m5Rows.map(toCandle);
+
+    const fromBundle = runWalkForwardWithBundle({
+      bundle,
+      primaryInterval: "M5",
+      dslJson: NEUTRAL_DSL,
+      opts: {},
+      foldCfg: FOLD_CFG,
+    });
+    const fromLegacy = runWalkForward(candles, NEUTRAL_DSL, {}, FOLD_CFG);
+
+    expect(fromBundle.folds).toHaveLength(fromLegacy.folds.length);
+    expect(fromBundle.folds[0].isReport).toEqual(fromLegacy.folds[0].isReport);
+    expect(fromBundle.folds[0].oosReport).toEqual(fromLegacy.folds[0].oosReport);
+    expect(fromBundle.aggregate).toEqual(fromLegacy.aggregate);
+  });
+
+  it("invokes onProgress once per fold", () => {
+    const bundle = makeBundle({ M5: makeM5(400) });
+    const seen: Array<{ done: number; total: number }> = [];
+    const report = runWalkForwardWithBundle({
+      bundle,
+      primaryInterval: "M5",
+      dslJson: NEUTRAL_DSL,
+      opts: {},
+      foldCfg: FOLD_CFG,
+      onProgress: (done, total) => { seen.push({ done, total }); },
+    });
+    expect(seen).toHaveLength(report.folds.length);
+    expect(seen[seen.length - 1]).toEqual({ done: report.folds.length, total: report.folds.length });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Multi-TF bundle accepts an MTF DSL without preflight throws
+// ---------------------------------------------------------------------------
+
+describe("runWalkForwardWithBundle — MTF DSL acceptance", () => {
+  it("runs an MTF DSL across all folds and produces non-null IS/OOS reports", () => {
+    const bundle = makeBundle({
+      M5: makeM5(400),
+      // 400 M5 bars × 5min = 2000min ≈ 33h ⇒ at least 34 H1 bars cover the
+      // window. Generate 40 to give the SMA(3) at least 3 bars in the
+      // earliest fold.
+      H1: makeH1(40),
+    });
+
+    const report = runWalkForwardWithBundle({
+      bundle,
+      primaryInterval: "M5",
+      dslJson: MTF_DSL,
+      opts: {},
+      foldCfg: FOLD_CFG,
+    });
+
+    expect(report.folds.length).toBeGreaterThan(0);
+    for (const f of report.folds) {
+      expect(f.isReport).not.toBeNull();
+      expect(f.oosReport).not.toBeNull();
+      // Each IS slice has exactly isBars primary candles by construction.
+      expect(f.isReport.candles).toBe(FOLD_CFG.isBars);
+      expect(f.oosReport.candles).toBe(FOLD_CFG.oosBars);
+    }
+  });
+
+  it("is deterministic — identical inputs ⇒ identical aggregate", () => {
+    const fixture = () => makeBundle({ M5: makeM5(400), H1: makeH1(40) });
+    const a = runWalkForwardWithBundle({
+      bundle: fixture(), primaryInterval: "M5", dslJson: MTF_DSL, opts: {}, foldCfg: FOLD_CFG,
+    });
+    const b = runWalkForwardWithBundle({
+      bundle: fixture(), primaryInterval: "M5", dslJson: MTF_DSL, opts: {}, foldCfg: FOLD_CFG,
+    });
+    expect(a.aggregate).toEqual(b.aggregate);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Look-ahead guard at the fold boundary
+// ---------------------------------------------------------------------------
+
+describe("runWalkForwardWithBundle — fold-boundary look-ahead guard", () => {
+  it("perturbing an HTF candle in fold N's OOS window leaves fold N's IS report unchanged", () => {
+    const m5 = makeM5(400);
+    const h1Base = makeH1(40);
+
+    const baseReport = runWalkForwardWithBundle({
+      bundle: makeBundle({ M5: m5, H1: h1Base }),
+      primaryInterval: "M5", dslJson: MTF_DSL, opts: {}, foldCfg: FOLD_CFG,
+    });
+
+    // Pick fold 0; locate H1 indices that fall inside its OOS window only.
+    const fold = baseReport.folds[0];
+    const oosFromMs = fold.oosRange.fromTsMs;
+    const oosToMs = fold.oosRange.toTsMs;
+    const offendingIdx = h1Base.findIndex((c) => c.openTime >= oosFromMs && c.openTime <= oosToMs);
+    expect(offendingIdx).toBeGreaterThanOrEqual(0);
+
+    const h1Perturbed = h1Base.map((c, i) => (
+      i === offendingIdx ? { ...c, close: c.close + 1000, high: c.high + 1000 } : c
+    ));
+    const perturbedReport = runWalkForwardWithBundle({
+      bundle: makeBundle({ M5: m5, H1: h1Perturbed }),
+      primaryInterval: "M5", dslJson: MTF_DSL, opts: {}, foldCfg: FOLD_CFG,
+    });
+
+    // Hard equality on fold 0 IS — the OOS perturbation cannot leak back.
+    expect(perturbedReport.folds[0].isReport).toEqual(fold.isReport);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the deferred walk-forward bundle follow-up to docs/52. `POST /lab/backtest/walk-forward` has accepted + persisted `datasetBundleJson` on `WalkForwardRun` since 52-T4b-3, but the fold runner ignored it: any DSL with `sourceTimeframe` was rejected by `WalkForwardMtfNotSupportedError` with HTTP 400. This PR replaces that gate with a real bundle-aware runner so MTF strategies like Adaptive Regime can finally hit the walk-forward acceptance gate (unblocks `docs/53-T2`).

### Library
- **`lib/walkForward/run.ts`** — new `runWalkForwardWithBundle({ bundle, primaryInterval, dslJson, opts, foldCfg, onProgress })`:
  - Splits the **primary** TF through the existing pure `split()` helper.
  - Per fold, slices every interval in the bundle by the primary fold's `[fromTsMs, toTsMs]` window and feeds the per-fold bundle into `runBacktestWithBundle` once for IS and once for OOS.
  - Look-ahead safety is delegated to `createClosedCandleBundle` inside `runBacktestWithBundle` — HTF candles that haven't closed by a primary bar's `openTime` are never visible to indicator resolution.
- **`WalkForwardMtfNotSupportedError`** message changed from "not implemented" to "requires `datasetBundleJson` — pass a bundle with the request". The single-TF preflight still throws when no bundle is supplied (the older error path stays correct).

### Route
- **`lab.ts /lab/backtest/walk-forward`** forwards the resolved bundle to `runWalkForwardAsync`, which `loadCandleBundle({mode:'backtest'})`s every interval up to `dataset.toTsMs` and switches to the bundle-aware runner. Without a bundle the legacy single-TF path is unchanged.
- `lookbackBars: 1_000_000` cap is generous enough for any practical walk-forward window (M5 over 5y ≈ 525k bars, H1 over 10y ≈ 87k) — `loadCandleBundle` uses `ORDER BY desc + take`, so a low cap would silently drop the oldest candles.

### Tests
New `tests/lib/walkForward/runWithBundle.test.ts` (5 cases):
- **Single-TF parity** — primary-only bundle reproduces `runWalkForward` report bit-for-bit on identical candles.
- **`onProgress`** fires once per fold; final tick is `{ done: total, total }`.
- **MTF DSL acceptance** — `{M5, H1}` bundle + `sideCondition.indicator` with `sourceTimeframe="1h"` runs across every fold without throwing; per-fold IS/OOS reports populated, candle counts match `isBars`/`oosBars`.
- **Determinism** — two identical inputs produce identical aggregates.
- **Look-ahead guard at fold boundary** — perturbing an H1 candle that falls in fold 0's OOS window leaves fold 0's IS report bit-equal. This is the regression I most worried about.

## Test plan

- [x] `apps/api` `tsc --noEmit` — exit 0.
- [x] `vitest run tests/lib tests/integration tests/routes/lab.test.ts` — 898/898 pass (53 test files).
- [x] Existing walk-forward suite unchanged: `tests/lib/walkForward/{split,run,aggregate}.test.ts` 23/23 pass; `runWithBundle.test.ts` adds 5/5.
- [ ] Manual smoke against a live MTF DSL not run — that's the next-session step toward `docs/53-T2` Adaptive Regime acceptance.

## Follow-ups still deferred from docs/52

- `BacktestResult.datasetBundleJson` column for replay (multi-TF replay still falls back to single-TF — separate, smaller PR).

https://claude.ai/code/session_01LCaeb3zKUHh5XgZxw38GW7

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCaeb3zKUHh5XgZxw38GW7)_