### PR TITLE
feat(strategy): finalize adaptive-regime DSL via primitives + golden pin (53-T1+T6)

### DIFF
--- a/apps/api/prisma/seed/presets/adaptive-regime.json
+++ b/apps/api/prisma/seed/presets/adaptive-regime.json
@@ -1,25 +1,92 @@
 {
   "name": "Adaptive Regime",
-  "description": "Trend-following + mean-reversion regime switcher. DSL is a placeholder; the final golden fixture lands in docs/53-T1.",
+  "description": "Long-only multi-timeframe strategy that switches between trend-following and mean-reversion regimes. Trend branch enters when H1 EMA(50)>EMA(200) and ADX(H1)>20 align with a positive M5 supertrend. Mean-reversion branch enters when ADX(H1)<20 (flat regime) and M5 RSI(14)<30 (oversold). Exits on ATR(14)*2 stop-loss or +4% take-profit. Bundle: M5 primary + H1 context.",
   "dslJson": {
     "id": "adaptive-regime",
     "name": "Adaptive Regime",
-    "dslVersion": 1,
+    "dslVersion": 2,
     "enabled": true,
-    "market": { "exchange": "bybit", "env": "demo", "category": "linear", "symbol": "BTCUSDT" },
-    "entry": { "side": "Buy" },
-    "risk": { "maxPositionSizeUsd": 100, "riskPerTradePct": 1, "cooldownSeconds": 60 },
-    "execution": { "orderType": "Market", "clientOrderIdPrefix": "adaptive" },
-    "guards": { "maxOpenPositions": 1, "maxOrdersPerMinute": 10, "pauseOnError": true }
+    "market": {
+      "exchange": "bybit",
+      "env": "demo",
+      "category": "linear",
+      "symbol": "BTCUSDT"
+    },
+    "entry": {
+      "side": "Buy",
+      "signal": {
+        "type": "or",
+        "conditions": [
+          {
+            "type": "and",
+            "conditions": [
+              {
+                "type": "compare",
+                "op": ">",
+                "left":  { "blockType": "ema", "length": 50,  "sourceTimeframe": "1h" },
+                "right": { "blockType": "ema", "length": 200, "sourceTimeframe": "1h" }
+              },
+              {
+                "type": "compare",
+                "op": ">",
+                "left":  { "blockType": "supertrend", "period": 10, "multiplier": 3 },
+                "right": { "blockType": "constant", "length": 0 }
+              },
+              {
+                "type": "compare",
+                "op": ">",
+                "left":  { "blockType": "adx", "period": 14, "sourceTimeframe": "1h" },
+                "right": { "blockType": "constant", "length": 20 }
+              }
+            ]
+          },
+          {
+            "type": "and",
+            "conditions": [
+              {
+                "type": "compare",
+                "op": "<",
+                "left":  { "blockType": "rsi", "length": 14 },
+                "right": { "blockType": "constant", "length": 30 }
+              },
+              {
+                "type": "compare",
+                "op": "<",
+                "left":  { "blockType": "adx", "period": 14, "sourceTimeframe": "1h" },
+                "right": { "blockType": "constant", "length": 20 }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "risk": {
+      "maxPositionSizeUsd": 100,
+      "riskPerTradePct": 1,
+      "cooldownSeconds": 60
+    },
+    "execution": {
+      "orderType": "Market",
+      "clientOrderIdPrefix": "adaptive"
+    },
+    "guards": {
+      "maxOpenPositions": 1,
+      "maxOrdersPerMinute": 10,
+      "pauseOnError": true
+    },
+    "exit": {
+      "stopLoss":   { "type": "atr_multiple", "value": 2, "atrPeriod": 14 },
+      "takeProfit": { "type": "fixed_pct",    "value": 4 }
+    }
   },
   "defaultBotConfigJson": {
     "symbol": "BTCUSDT",
-    "timeframe": "M15",
+    "timeframe": "M5",
     "quoteAmount": 100,
     "maxOpenPositions": 1
   },
   "datasetBundleHintJson": {
     "5m": true,
-    "1H": true
+    "1h": true
   }
 }

--- a/apps/api/src/lib/dslEvaluator.ts
+++ b/apps/api/src/lib/dslEvaluator.ts
@@ -141,6 +141,11 @@ export interface DslSignalRef {
   length?: number;
   period?: number;
   multiplier?: number;
+  /** Optional: resolve this signal-ref's indicator from a different timeframe.
+   *  Mirrors {@link DslIndicatorRef.sourceTimeframe} (52-T3). When set,
+   *  {@link evaluateSignal} resolves through the supplied {@link RuntimeMtfContext};
+   *  with no context, the call surfaces {@link MtfBundleRequiredError}. */
+  sourceTimeframe?: string;
 }
 
 export interface DslSignal {
@@ -514,6 +519,35 @@ export function resolveIndicatorRef(
   }, candles, cache);
 }
 
+/**
+ * Same branching as {@link resolveIndicatorRef} but for a {@link DslSignalRef}.
+ * Signal refs use `blockType` (not `type`) and lack the indicator-only fields,
+ * so the conversion is mechanical. Threading `mtfContext` lets DSL signal
+ * blocks (`crossover`, `crossunder`, `compare`) reference an HTF series via
+ * `sourceTimeframe` exactly like indicator refs do.
+ */
+export function resolveSignalRef(
+  ref: DslSignalRef,
+  candles: Candle[],
+  cache: IndicatorCache,
+  mtfContext?: RuntimeMtfContext | null,
+): (number | null)[] {
+  if (ref.sourceTimeframe) {
+    if (!mtfContext) {
+      throw new MtfBundleRequiredError(ref.blockType, ref.sourceTimeframe);
+    }
+    const indRef: DslIndicatorRef = {
+      type: ref.blockType,
+      length: ref.length,
+      period: ref.period,
+      multiplier: ref.multiplier,
+      sourceTimeframe: ref.sourceTimeframe,
+    };
+    return resolveMtfIndicator(indRef, candles, mtfContext.mtfCache, mtfContext.bundle);
+  }
+  return getIndicatorValues(ref.blockType, ref, candles, cache);
+}
+
 function getVolumeProfileCached(
   params: { period?: number; bins?: number },
   candles: Candle[],
@@ -593,18 +627,22 @@ export function evaluateSignal(
   candles: Candle[],
   cache: IndicatorCache,
   _depth = 0,
+  mtfContext?: RuntimeMtfContext | null,
 ): boolean {
   if (!signal) return false;
   if (_depth >= MAX_SIGNAL_DEPTH) return false;
 
-  // Composed conditions: and / or
+  // Composed conditions: and / or — propagate mtfContext through recursion
+  // so any nested compare/crossover with sourceTimeframe still resolves
+  // through the bundle (53-T1 adaptive-regime needs and_gate(M5 supertrend +
+  // close > EMA200(H1) + ADX(H1) > 20)).
   if (signal.type === "and") {
     if (!signal.conditions || signal.conditions.length === 0) return false;
-    return signal.conditions.every((sub) => evaluateSignal(sub, i, candles, cache, _depth + 1));
+    return signal.conditions.every((sub) => evaluateSignal(sub, i, candles, cache, _depth + 1, mtfContext));
   }
   if (signal.type === "or") {
     if (!signal.conditions || signal.conditions.length === 0) return false;
-    return signal.conditions.some((sub) => evaluateSignal(sub, i, candles, cache, _depth + 1));
+    return signal.conditions.some((sub) => evaluateSignal(sub, i, candles, cache, _depth + 1, mtfContext));
   }
 
   // Confirm N Bars: sub-signal must be true for N consecutive bars
@@ -613,7 +651,7 @@ export function evaluateSignal(
     const nBars = signal.bars ?? 3;
     if (i < nBars - 1) return false;
     for (let j = i - nBars + 1; j <= i; j++) {
-      if (!evaluateSignal(signal.conditions[0], j, candles, cache, _depth + 1)) return false;
+      if (!evaluateSignal(signal.conditions[0], j, candles, cache, _depth + 1, mtfContext)) return false;
     }
     return true;
   }
@@ -621,8 +659,8 @@ export function evaluateSignal(
   if (signal.type === "crossover" || signal.type === "crossunder") {
     // Cross signal: fast crosses over/under slow
     if (!signal.fast || !signal.slow || i < 1) return false;
-    const fastVals = getIndicatorValues(signal.fast.blockType, signal.fast, candles, cache);
-    const slowVals = getIndicatorValues(signal.slow.blockType, signal.slow, candles, cache);
+    const fastVals = resolveSignalRef(signal.fast, candles, cache, mtfContext);
+    const slowVals = resolveSignalRef(signal.slow, candles, cache, mtfContext);
 
     const curFast = fastVals[i];
     const curSlow = slowVals[i];
@@ -640,8 +678,8 @@ export function evaluateSignal(
 
   if (signal.type === "compare") {
     if (!signal.left || !signal.right) return false;
-    const leftVals = getIndicatorValues(signal.left.blockType, signal.left, candles, cache);
-    const rightVals = getIndicatorValues(signal.right.blockType, signal.right, candles, cache);
+    const leftVals = resolveSignalRef(signal.left, candles, cache, mtfContext);
+    const rightVals = resolveSignalRef(signal.right, candles, cache, mtfContext);
 
     const l = leftVals[i];
     const r = rightVals[i];
@@ -1149,8 +1187,14 @@ export function runDslBacktest(
       }
       if (!side) continue;
 
-      // Evaluate entry signal
-      const signalFired = evaluateSignal(entry.signal, i, candles, cache);
+      // Evaluate entry signal — when a backtest mtfContext is in play we
+      // surface the same bundle to evaluateSignal so signal compare/cross
+      // blocks with `sourceTimeframe` resolve through the HTF series
+      // exactly like sideCondition / indicatorExit already do (52-T3).
+      const signalMtfCtx: RuntimeMtfContext | null = mtfContext && mtfCache
+        ? { bundle: mtfContext.bundle, mtfCache }
+        : null;
+      const signalFired = evaluateSignal(entry.signal, i, candles, cache, 0, signalMtfCtx);
       if (!signalFired) continue;
 
       // Proximity filter gate

--- a/apps/api/src/lib/signalEngine.ts
+++ b/apps/api/src/lib/signalEngine.ts
@@ -99,8 +99,11 @@ export function evaluateEntry(ctx: SignalEngineContext): OpenSignal | null {
   const side = determineSide(entry, i, candles, cache, mtfContext);
   if (!side) return null;
 
-  // Evaluate entry signal
-  const signalFired = evaluateSignal(entry.signal, i, candles, cache);
+  // Evaluate entry signal — propagate MTF context so signal compare /
+  // crossover blocks with `sourceTimeframe` resolve through the bundle
+  // (53-T1 adaptive-regime: trend branch needs `compare(close, '>',
+  // EMA200(H1))` plus `compare(ADX(H1), '>', 20)`).
+  const signalFired = evaluateSignal(entry.signal, i, candles, cache, 0, mtfContext);
   if (!signalFired) return null;
 
   // Proximity filter gate: block signal if price is too far from reference level

--- a/apps/api/tests/fixtures/strategies/adaptive-regime.golden.json
+++ b/apps/api/tests/fixtures/strategies/adaptive-regime.golden.json
@@ -1,0 +1,78 @@
+{
+  "id": "adaptive-regime",
+  "name": "Adaptive Regime",
+  "dslVersion": 2,
+  "enabled": true,
+  "market": {
+    "exchange": "bybit",
+    "env": "demo",
+    "category": "linear",
+    "symbol": "BTCUSDT"
+  },
+  "entry": {
+    "side": "Buy",
+    "signal": {
+      "type": "or",
+      "conditions": [
+        {
+          "type": "and",
+          "conditions": [
+            {
+              "type": "compare",
+              "op": ">",
+              "left":  { "blockType": "ema", "length": 50,  "sourceTimeframe": "1h" },
+              "right": { "blockType": "ema", "length": 200, "sourceTimeframe": "1h" }
+            },
+            {
+              "type": "compare",
+              "op": ">",
+              "left":  { "blockType": "supertrend", "period": 10, "multiplier": 3 },
+              "right": { "blockType": "constant", "length": 0 }
+            },
+            {
+              "type": "compare",
+              "op": ">",
+              "left":  { "blockType": "adx", "period": 14, "sourceTimeframe": "1h" },
+              "right": { "blockType": "constant", "length": 20 }
+            }
+          ]
+        },
+        {
+          "type": "and",
+          "conditions": [
+            {
+              "type": "compare",
+              "op": "<",
+              "left":  { "blockType": "rsi", "length": 14 },
+              "right": { "blockType": "constant", "length": 30 }
+            },
+            {
+              "type": "compare",
+              "op": "<",
+              "left":  { "blockType": "adx", "period": 14, "sourceTimeframe": "1h" },
+              "right": { "blockType": "constant", "length": 20 }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "risk": {
+    "maxPositionSizeUsd": 100,
+    "riskPerTradePct": 1,
+    "cooldownSeconds": 60
+  },
+  "execution": {
+    "orderType": "Market",
+    "clientOrderIdPrefix": "adaptive"
+  },
+  "guards": {
+    "maxOpenPositions": 1,
+    "maxOrdersPerMinute": 10,
+    "pauseOnError": true
+  },
+  "exit": {
+    "stopLoss":   { "type": "atr_multiple", "value": 2, "atrPeriod": 14 },
+    "takeProfit": { "type": "fixed_pct",    "value": 4 }
+  }
+}

--- a/apps/api/tests/lib/strategies/adaptiveRegime.test.ts
+++ b/apps/api/tests/lib/strategies/adaptiveRegime.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Adaptive Regime — golden DSL pin (docs/53-T1 + 53-T6).
+ *
+ * The golden fixture is the single source of truth for the
+ * `adaptive-regime` preset. Tests here lock down four invariants:
+ *
+ *   1. The seed file's `dslJson` and the golden fixture stay byte-equal —
+ *      any change to the preset must be a deliberate update of the
+ *      golden, not an accidental drift.
+ *   2. The golden DSL is structurally valid against the v2 schema
+ *      (`validateDsl`) and parses cleanly via `parseDsl`.
+ *   3. Every block referenced by the golden is in {@link BLOCK_SUPPORT_MAP}
+ *      with status `supported`. No "composite signal types" sneak in —
+ *      the strategy must be expressible through primitives, per
+ *      docs/50 §Решение 3 / docs/53 §Решение 1.
+ *   4. Sanity-evaluator on a synthetic {M5, H1} bundle:
+ *      - Trend-up branch fires when EMA50(H1) > EMA200(H1), supertrend(M5) > 0,
+ *        ADX(H1) > 20.
+ *      - Mean-reversion branch fires when RSI(M5) < 30 and ADX(H1) < 20.
+ *      - Neither fires on a calm baseline (RSI ≈ 50, ADX flat).
+ *
+ * The acceptance gate (full walk-forward on real data) lives in
+ * docs/53-T2 — that needs market data and is out of scope here.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import {
+  evaluateSignal,
+  parseDsl,
+  createIndicatorCache,
+  type DslSignal,
+  type RuntimeMtfContext,
+} from "../../../src/lib/dslEvaluator.js";
+import { validateDsl } from "../../../src/lib/dslValidator.js";
+import {
+  createCandleBundle,
+  INTERVAL_MS,
+  type Interval,
+  type MtfCandle,
+} from "../../../src/lib/mtf/intervalAlignment.js";
+import { createMtfCache } from "../../../src/lib/mtf/mtfIndicatorResolver.js";
+import { BLOCK_SUPPORT_MAP } from "../../../src/lib/compiler/supportMap.ts";
+
+// ---------------------------------------------------------------------------
+// Fixture / seed loading
+// ---------------------------------------------------------------------------
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+function loadJson(rel: string): unknown {
+  const abs = join(here, rel);
+  return JSON.parse(readFileSync(abs, "utf8"));
+}
+
+const goldenDsl = loadJson("../../fixtures/strategies/adaptive-regime.golden.json") as Record<string, unknown>;
+const seed = loadJson("../../../prisma/seed/presets/adaptive-regime.json") as { dslJson: unknown };
+
+// ---------------------------------------------------------------------------
+// 1. Seed ⇄ golden pin
+// ---------------------------------------------------------------------------
+
+describe("adaptive-regime — seed/golden pin", () => {
+  it("seed.dslJson is byte-equal to the golden fixture", () => {
+    expect(seed.dslJson).toEqual(goldenDsl);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Schema + parse smoke
+// ---------------------------------------------------------------------------
+
+describe("adaptive-regime — DSL validity", () => {
+  it("validates against the v2 strategy schema", () => {
+    const errors = validateDsl(goldenDsl);
+    expect(errors).toBeNull();
+  });
+
+  it("parseDsl yields a v2-shaped ParsedDsl with non-empty signal/exit", () => {
+    const parsed = parseDsl(goldenDsl);
+    expect(parsed.dslVersion).toBe(2);
+    expect(parsed.entry.signal).toBeDefined();
+    expect(parsed.exit?.stopLoss?.type).toBe("atr_multiple");
+    expect(parsed.exit?.takeProfit?.type).toBe("fixed_pct");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. No composite types — every block is in BLOCK_SUPPORT_MAP, supported
+// ---------------------------------------------------------------------------
+
+/** Recursively collect every `blockType` and `type: "<indicator>"`-style
+ *  reference present in the DSL — anything the evaluator will hit on the
+ *  hot path needs to be either a structural keyword (compare, and, or,
+ *  …) or a supported block. */
+function collectIndicatorBlockTypes(node: unknown, out = new Set<string>()): Set<string> {
+  if (Array.isArray(node)) {
+    for (const item of node) collectIndicatorBlockTypes(item, out);
+    return out;
+  }
+  if (node && typeof node === "object") {
+    const obj = node as Record<string, unknown>;
+    if (typeof obj.blockType === "string") out.add(obj.blockType);
+    // `type` strings appear both as structural keywords (or/and/compare)
+    // and as indicator names (atr inside exit.stopLoss). Capture them
+    // here and filter the structural ones below.
+    if (typeof obj.type === "string") out.add(obj.type);
+    for (const v of Object.values(obj)) collectIndicatorBlockTypes(v, out);
+  }
+  return out;
+}
+
+const STRUCTURAL_TYPES = new Set([
+  "or", "and", "compare", "crossover", "crossunder", "confirm_n_bars",
+  "fixed_pct", "fixed_price", "atr_multiple",
+]);
+
+/** Map runtime block-name aliases (lowercase / shorthands) back to the
+ *  canonical key in `BLOCK_SUPPORT_MAP`. The evaluator's getIndicatorValues
+ *  lower-cases its input, so the seed legitimately uses lowercase names —
+ *  the support map keys are case-sensitive. */
+const SUPPORT_ALIASES: Record<string, string> = {
+  ema:        "EMA",
+  rsi:        "RSI",
+  sma:        "SMA",
+  // bollinger_lower/upper/middle / bb_* all resolve through the
+  // `bollinger` runtime entry; treat them as the same supported block.
+  bollinger:        "bollinger",
+  bollinger_lower:  "bollinger",
+  bollinger_upper:  "bollinger",
+  bollinger_middle: "bollinger",
+  bb_lower:         "bollinger",
+  bb_upper:         "bollinger",
+  bb_middle:        "bollinger",
+};
+
+describe("adaptive-regime — uses only supported primitives", () => {
+  it("every indicator/block referenced is `supported` in BLOCK_SUPPORT_MAP", () => {
+    const types = collectIndicatorBlockTypes(goldenDsl);
+    const offenders: Array<{ name: string; reason: string }> = [];
+
+    for (const raw of types) {
+      if (STRUCTURAL_TYPES.has(raw)) continue; // structural keyword, not a block
+      const canonical = SUPPORT_ALIASES[raw] ?? raw;
+      const entry = BLOCK_SUPPORT_MAP[canonical];
+      if (!entry) {
+        offenders.push({ name: raw, reason: `not in BLOCK_SUPPORT_MAP (looked up as "${canonical}")` });
+        continue;
+      }
+      if (entry.status !== "supported") {
+        offenders.push({ name: raw, reason: `status is "${entry.status}", expected "supported"` });
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Sanity evaluator on a synthetic {M5, H1} bundle
+// ---------------------------------------------------------------------------
+
+const t0 = Date.UTC(2026, 0, 1, 0, 0, 0);
+
+/** Build M5 candles with a closed-form `closeFn(i)`; OHLC is symmetric
+ *  around the close so the synthetic series stays simple to reason about. */
+function makeM5(count: number, closeFn: (i: number) => number): MtfCandle[] {
+  return Array.from({ length: count }, (_, i) => {
+    const close = closeFn(i);
+    return {
+      openTime: t0 + i * INTERVAL_MS["5m"],
+      open: close - 0.05,
+      high: close + 0.5,
+      low: close - 0.5,
+      close,
+      volume: 10,
+    };
+  });
+}
+
+function makeH1(count: number, closeFn: (i: number) => number): MtfCandle[] {
+  return Array.from({ length: count }, (_, i) => {
+    const close = closeFn(i);
+    return {
+      openTime: t0 + i * INTERVAL_MS["1h"],
+      open: close - 0.5,
+      high: close + 1,
+      low: close - 1,
+      close,
+      volume: 100,
+    };
+  });
+}
+
+function makeMtfCtx(m5: MtfCandle[], h1: MtfCandle[]): RuntimeMtfContext {
+  const bundle = createCandleBundle("5m" as Interval, { "5m": m5, "1h": h1 });
+  return { bundle, mtfCache: createMtfCache() };
+}
+
+/** Evaluate the golden DSL's entry.signal at the latest primary bar. */
+function fires(m5: MtfCandle[], h1: MtfCandle[]): boolean {
+  const parsed = parseDsl(goldenDsl);
+  const ctx = makeMtfCtx(m5, h1);
+  return evaluateSignal(
+    parsed.entry.signal as DslSignal,
+    m5.length - 1,
+    m5,
+    createIndicatorCache(),
+    0,
+    ctx,
+  );
+}
+
+describe("adaptive-regime — sanity evaluator", () => {
+  it("trend branch: H1 strong uptrend + supertrend(M5) > 0 + ADX(H1) > 20 → fires", () => {
+    // Need enough H1 bars for EMA(200) + ADX(14) to warm up at the
+    // primary's last bar. Primary openTime = (m5Count-1) * 5min, so an
+    // M5 series of 3600 bars maps to H1 ≈ 299 — comfortably past the
+    // EMA(200) warm-up boundary.
+    const m5 = makeM5(3600, (i) => 100 + i * 0.05);
+    const h1 = makeH1(300, (i) => 100 + i * 0.5);
+    expect(fires(m5, h1)).toBe(true);
+  });
+
+  it("flat regime: RSI(M5) < 30 + ADX(H1) < 20 → fires (mean-reversion branch)", () => {
+    // Long flat at 100 followed by a sharp drop in the last ~25 bars
+    // to push RSI(14) below 30. H1 stays dead-flat so ADX never
+    // crosses 20 — only the mean-reversion branch should match.
+    const m5 = makeM5(400, (i) => (i < 375 ? 100 : 100 - (i - 375) * 0.5));
+    const h1 = makeH1(120, () => 100);
+    expect(fires(m5, h1)).toBe(true);
+  });
+
+  it("calm baseline: neither branch fires (RSI ≈ 50, ADX flat, no trend)", () => {
+    const m5 = makeM5(400, () => 100);
+    const h1 = makeH1(120, () => 100);
+    expect(fires(m5, h1)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes **53-T1** (final golden DSL) + the static half of **53-T6** (compile + sanity-evaluator coverage). Replaces the placeholder `adaptive-regime` seed (left over from 51-T6) with the long-only multi-TF DSL composed entirely of supported primitives — no composite signal types, per `docs/50 §Решение 3` / `docs/53 §Решение 1`.

### DSL shape (M5 primary + H1 context)

```
entry.signal = OR(
  AND( EMA(50,H1) > EMA(200,H1),  supertrend(M5,p=10,m=3) > 0,  ADX(14,H1) > 20 ),
  AND( RSI(14,M5) < 30,           ADX(14,H1) < 20 )
)
exit = { stopLoss: ATR(14)*2, takeProfit: +4% }
bundle hint = { 5m: true, 1h: true }
defaultBotConfig.timeframe = M5
```

The first branch is the trend-following regime (HTF EMA filter + M5 supertrend in long mode + trending ADX). The second is mean-reversion in a flat H1 (oversold M5 RSI). Long-only by design.

### Evaluator extension (52-T3 follow-up — required by the trend branch)

The trend branch needs `compare(EMA(50,H1) > EMA(200,H1))` — i.e. signal-level refs that carry `sourceTimeframe`. 52-T3 wired MTF for `sideCondition.indicator` and `indicatorExit.indicator` (both `DslIndicatorRef`), but not for `signal.left/right/fast/slow` (`DslSignalRef`). This PR closes the gap:

- **`DslSignalRef`** gains optional `sourceTimeframe`.
- **`resolveSignalRef`** mirrors `resolveIndicatorRef`: bundle-aware when set, single-TF otherwise; throws `MtfBundleRequiredError` when a ref asks for a context TF with no bundle in scope.
- **`evaluateSignal`** threads an optional `mtfContext` through `and`/`or`/`confirm_n_bars` recursion and resolves `crossover`/`crossunder`/`compare` refs through `resolveSignalRef`. Single-TF behaviour stays bit-equal when no context is supplied.
- **`signalEngine.evaluateEntry`** passes its existing `mtfContext` down to `evaluateSignal`. **`runDslBacktest`** synthesises a `RuntimeMtfContext` from its existing `MtfBacktestContext` + `mtfCache`, so the backtest path is consistent with runtime.

### Tests

New `tests/lib/strategies/adaptiveRegime.test.ts` (7 cases):
- **Seed/golden pin** — `tests/fixtures/strategies/adaptive-regime.golden.json` is byte-equal to the seed `dslJson`. Any drift in the seed without a golden update is a hard failure.
- **`validateDsl`** returns `null`; **`parseDsl`** yields a v2-shaped `ParsedDsl` with non-empty signal + ATR-based stop-loss + `fixed_pct` take-profit.
- **No composite types** — every `blockType` referenced is `supported` in `BLOCK_SUPPORT_MAP` (or a structural keyword like `or`/`and`/`compare`).
- **Sanity evaluator** on a synthetic `{M5, H1}` bundle:
  - trend branch fires on a steady H1 uptrend with positive supertrend and ADX > 20;
  - mean-reversion branch fires on a long flat with a sharp drop in the last bars (RSI < 30) and a dead-flat H1 (ADX < 20);
  - calm baseline (RSI ≈ 50, ADX flat, no trend) fires neither.

## Test plan

- [x] `apps/api` `tsc --noEmit` — exit 0.
- [x] `vitest run tests/lib tests/integration tests/routes/lab.test.ts tests/prisma` — 917/917 pass (56 test files). Existing `signalEngine`/`exitEngine`/`dslEvaluator`/`multiTfRuntime`/`runBacktestWithBundle`/`multiTfBacktestFlow` suites unchanged.
- [ ] Walk-forward acceptance on real data — that's `docs/53-T2` (separate session, needs synced 6 months of M5+H1 candles).

## Out of scope (next sessions, in order)

- **53-T2** — full walk-forward acceptance on real M5+H1 data; gated only by data sync now that the bundle-aware walk-forward runner shipped in PR #338.
- **53-T3** — demo smoke harness, requires Bybit demo credentials.
- **53-T4** — admin-only `PRIVATE → PUBLIC` flip with audit log.
- **53-T5** — capability matrix + concept doc update.

https://claude.ai/code/session_01LCaeb3zKUHh5XgZxw38GW7

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCaeb3zKUHh5XgZxw38GW7)_