### PR TITLE
feat(strategy): finalize mtf-scalper DSL via primitives + golden pin (54-T2 partial)

### DIFF
--- a/apps/api/prisma/seed/presets/mtf-scalper.json
+++ b/apps/api/prisma/seed/presets/mtf-scalper.json
@@ -1,16 +1,66 @@
 {
   "name": "MTF Confluence Scalper",
-  "description": "Multi-timeframe confluence scalper aligning M1/M5/M15 trend filters. DSL is a placeholder; the final golden fixture lands in docs/54.",
+  "description": "Long-only multi-timeframe scalper requiring three-way confluence at entry: M15 trend (EMA50>EMA200), M5 above session VWAP (proxied via short EMA8>VWAP), and M1 RSI(3)<30 timing. Tight ATR(14)*1.5 stop, +0.5% take-profit, indicator exit on RSI(3)>70. Bundle: M1 primary + M5 + M15.",
   "dslJson": {
     "id": "mtf-scalper",
     "name": "MTF Confluence Scalper",
-    "dslVersion": 1,
+    "dslVersion": 2,
     "enabled": true,
-    "market": { "exchange": "bybit", "env": "demo", "category": "linear", "symbol": "BTCUSDT" },
-    "entry": { "side": "Buy" },
-    "risk": { "maxPositionSizeUsd": 50, "riskPerTradePct": 0.5, "cooldownSeconds": 30 },
-    "execution": { "orderType": "Market", "clientOrderIdPrefix": "mtf-scalp" },
-    "guards": { "maxOpenPositions": 1, "maxOrdersPerMinute": 20, "pauseOnError": true }
+    "market": {
+      "exchange": "bybit",
+      "env": "demo",
+      "category": "linear",
+      "symbol": "BTCUSDT"
+    },
+    "entry": {
+      "side": "Buy",
+      "signal": {
+        "type": "and",
+        "conditions": [
+          {
+            "type": "compare",
+            "op": ">",
+            "left":  { "blockType": "ema", "length": 50,  "sourceTimeframe": "15m" },
+            "right": { "blockType": "ema", "length": 200, "sourceTimeframe": "15m" }
+          },
+          {
+            "type": "compare",
+            "op": ">",
+            "left":  { "blockType": "ema",  "length": 8, "sourceTimeframe": "5m" },
+            "right": { "blockType": "vwap",              "sourceTimeframe": "5m" }
+          },
+          {
+            "type": "compare",
+            "op": "<",
+            "left":  { "blockType": "rsi", "length": 3 },
+            "right": { "blockType": "constant", "length": 30 }
+          }
+        ]
+      }
+    },
+    "risk": {
+      "maxPositionSizeUsd": 50,
+      "riskPerTradePct": 0.5,
+      "cooldownSeconds": 10
+    },
+    "execution": {
+      "orderType": "Market",
+      "clientOrderIdPrefix": "mtf-scalp"
+    },
+    "guards": {
+      "maxOpenPositions": 1,
+      "maxOrdersPerMinute": 20,
+      "pauseOnError": true
+    },
+    "exit": {
+      "stopLoss":   { "type": "atr_multiple", "value": 1.5, "atrPeriod": 14 },
+      "takeProfit": { "type": "fixed_pct",    "value": 0.5 },
+      "indicatorExit": {
+        "indicator": { "type": "rsi", "length": 3 },
+        "condition": { "op": "gt", "value": 70 },
+        "appliesTo": "long"
+      }
+    }
   },
   "defaultBotConfigJson": {
     "symbol": "BTCUSDT",

--- a/apps/api/tests/fixtures/strategies/mtf-scalper.golden.json
+++ b/apps/api/tests/fixtures/strategies/mtf-scalper.golden.json
@@ -1,0 +1,61 @@
+{
+  "id": "mtf-scalper",
+  "name": "MTF Confluence Scalper",
+  "dslVersion": 2,
+  "enabled": true,
+  "market": {
+    "exchange": "bybit",
+    "env": "demo",
+    "category": "linear",
+    "symbol": "BTCUSDT"
+  },
+  "entry": {
+    "side": "Buy",
+    "signal": {
+      "type": "and",
+      "conditions": [
+        {
+          "type": "compare",
+          "op": ">",
+          "left":  { "blockType": "ema", "length": 50,  "sourceTimeframe": "15m" },
+          "right": { "blockType": "ema", "length": 200, "sourceTimeframe": "15m" }
+        },
+        {
+          "type": "compare",
+          "op": ">",
+          "left":  { "blockType": "ema",  "length": 8, "sourceTimeframe": "5m" },
+          "right": { "blockType": "vwap",              "sourceTimeframe": "5m" }
+        },
+        {
+          "type": "compare",
+          "op": "<",
+          "left":  { "blockType": "rsi", "length": 3 },
+          "right": { "blockType": "constant", "length": 30 }
+        }
+      ]
+    }
+  },
+  "risk": {
+    "maxPositionSizeUsd": 50,
+    "riskPerTradePct": 0.5,
+    "cooldownSeconds": 10
+  },
+  "execution": {
+    "orderType": "Market",
+    "clientOrderIdPrefix": "mtf-scalp"
+  },
+  "guards": {
+    "maxOpenPositions": 1,
+    "maxOrdersPerMinute": 20,
+    "pauseOnError": true
+  },
+  "exit": {
+    "stopLoss":   { "type": "atr_multiple", "value": 1.5, "atrPeriod": 14 },
+    "takeProfit": { "type": "fixed_pct",    "value": 0.5 },
+    "indicatorExit": {
+      "indicator": { "type": "rsi", "length": 3 },
+      "condition": { "op": "gt", "value": 70 },
+      "appliesTo": "long"
+    }
+  }
+}

--- a/apps/api/tests/lib/strategies/mtfScalper.test.ts
+++ b/apps/api/tests/lib/strategies/mtfScalper.test.ts
@@ -1,0 +1,214 @@
+/**
+ * MTF Confluence Scalper — golden DSL pin (docs/54-T2, partial 54-T5).
+ *
+ * Mirrors tests/lib/strategies/{adaptiveRegime,dcaMomentum}.test.ts:
+ *
+ *   1. Seed/golden pin — preset's `dslJson` is byte-equal to the golden.
+ *   2. Schema + parse smoke — validateDsl passes, parseDsl yields a
+ *      v2-shaped ParsedDsl with ATR-based stop and indicatorExit.
+ *   3. No composite types — every `blockType` is supported (or a
+ *      structural keyword) in BLOCK_SUPPORT_MAP. `vwap` block is on
+ *      the supported list.
+ *   4. Sanity evaluator on a synthetic {M1, M5, M15} bundle:
+ *      - Three-way confluence (M15 EMA50>EMA200, M5 close>VWAP, M1
+ *        RSI(3)<30 oversold dip) → entry fires.
+ *      - M15 downtrend (EMA50<EMA200) → no entry.
+ *      - Calm baseline (no trend, RSI ≈ 50) → no entry.
+ *
+ * Walk-forward acceptance, demo smoke, profile-check (54-T2 §2/§3/§4)
+ * need real data and a live runtime — out of scope here.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import {
+  evaluateSignal,
+  parseDsl,
+  createIndicatorCache,
+  type DslSignal,
+  type RuntimeMtfContext,
+} from "../../../src/lib/dslEvaluator.js";
+import { validateDsl } from "../../../src/lib/dslValidator.js";
+import {
+  createCandleBundle,
+  INTERVAL_MS,
+  type Interval,
+  type MtfCandle,
+} from "../../../src/lib/mtf/intervalAlignment.js";
+import { createMtfCache } from "../../../src/lib/mtf/mtfIndicatorResolver.js";
+import { BLOCK_SUPPORT_MAP } from "../../../src/lib/compiler/supportMap.ts";
+
+// ---------------------------------------------------------------------------
+// Fixture / seed loading
+// ---------------------------------------------------------------------------
+
+const here = dirname(fileURLToPath(import.meta.url));
+const loadJson = (rel: string): unknown => JSON.parse(readFileSync(join(here, rel), "utf8"));
+
+const goldenDsl = loadJson("../../fixtures/strategies/mtf-scalper.golden.json") as Record<string, unknown>;
+const seed = loadJson("../../../prisma/seed/presets/mtf-scalper.json") as { dslJson: unknown };
+
+// ---------------------------------------------------------------------------
+// 1. Seed ⇄ golden pin
+// ---------------------------------------------------------------------------
+
+describe("mtf-scalper — seed/golden pin", () => {
+  it("seed.dslJson is byte-equal to the golden fixture", () => {
+    expect(seed.dslJson).toEqual(goldenDsl);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Schema + parse smoke
+// ---------------------------------------------------------------------------
+
+describe("mtf-scalper — DSL validity", () => {
+  it("validates against the v2 strategy schema", () => {
+    const errors = validateDsl(goldenDsl);
+    expect(errors).toBeNull();
+  });
+
+  it("parseDsl yields a v2-shaped ParsedDsl with ATR stop + indicatorExit", () => {
+    const parsed = parseDsl(goldenDsl);
+    expect(parsed.dslVersion).toBe(2);
+    expect(parsed.entry.signal).toBeDefined();
+    expect(parsed.exit?.stopLoss?.type).toBe("atr_multiple");
+    expect(parsed.exit?.takeProfit?.type).toBe("fixed_pct");
+    expect(parsed.exit?.indicatorExit?.condition.op).toBe("gt");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. No composite types — every block in BLOCK_SUPPORT_MAP, supported
+// ---------------------------------------------------------------------------
+
+function collectIndicatorBlockTypes(node: unknown, out = new Set<string>()): Set<string> {
+  if (Array.isArray(node)) {
+    for (const item of node) collectIndicatorBlockTypes(item, out);
+    return out;
+  }
+  if (node && typeof node === "object") {
+    const obj = node as Record<string, unknown>;
+    if (typeof obj.blockType === "string") out.add(obj.blockType);
+    if (typeof obj.type === "string") out.add(obj.type);
+    for (const v of Object.values(obj)) collectIndicatorBlockTypes(v, out);
+  }
+  return out;
+}
+
+const STRUCTURAL_TYPES = new Set([
+  "or", "and", "compare", "crossover", "crossunder", "confirm_n_bars",
+  "fixed_pct", "fixed_price", "atr_multiple",
+]);
+
+const SUPPORT_ALIASES: Record<string, string> = {
+  ema: "EMA", rsi: "RSI", sma: "SMA",
+  bollinger: "bollinger",
+  bollinger_lower: "bollinger", bollinger_upper: "bollinger", bollinger_middle: "bollinger",
+  bb_lower: "bollinger", bb_upper: "bollinger", bb_middle: "bollinger",
+};
+
+describe("mtf-scalper — uses only supported primitives", () => {
+  it("every indicator/block referenced is `supported` in BLOCK_SUPPORT_MAP", () => {
+    const types = collectIndicatorBlockTypes(goldenDsl);
+    const offenders: Array<{ name: string; reason: string }> = [];
+
+    for (const raw of types) {
+      if (STRUCTURAL_TYPES.has(raw)) continue;
+      const canonical = SUPPORT_ALIASES[raw] ?? raw;
+      const entry = BLOCK_SUPPORT_MAP[canonical];
+      if (!entry) {
+        offenders.push({ name: raw, reason: `not in BLOCK_SUPPORT_MAP (looked up as "${canonical}")` });
+        continue;
+      }
+      if (entry.status !== "supported") {
+        offenders.push({ name: raw, reason: `status is "${entry.status}", expected "supported"` });
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Sanity evaluator on a synthetic {M1, M5, M15} bundle
+// ---------------------------------------------------------------------------
+
+const t0 = Date.UTC(2026, 0, 1, 0, 0, 0);
+
+function makeCandles(
+  count: number,
+  intervalMs: number,
+  closeFn: (i: number) => number,
+): MtfCandle[] {
+  return Array.from({ length: count }, (_, i) => {
+    const close = closeFn(i);
+    return {
+      openTime: t0 + i * intervalMs,
+      open: close - 0.05,
+      high: close + 0.5,
+      low: close - 0.5,
+      close,
+      volume: 100,
+    };
+  });
+}
+
+function makeMtfCtx(
+  m1: MtfCandle[], m5: MtfCandle[], m15: MtfCandle[],
+): RuntimeMtfContext {
+  const bundle = createCandleBundle("1m" as Interval, {
+    "1m": m1, "5m": m5, "15m": m15,
+  });
+  return { bundle, mtfCache: createMtfCache() };
+}
+
+function fires(m1: MtfCandle[], m5: MtfCandle[], m15: MtfCandle[]): boolean {
+  const parsed = parseDsl(goldenDsl);
+  const ctx = makeMtfCtx(m1, m5, m15);
+  return evaluateSignal(
+    parsed.entry.signal as DslSignal,
+    m1.length - 1,
+    m1,
+    createIndicatorCache(),
+    0,
+    ctx,
+  );
+}
+
+describe("mtf-scalper — sanity evaluator", () => {
+  it("three-way confluence: M15 uptrend + M5 above VWAP + M1 RSI(3)<30 dip → fires", () => {
+    // M15 needs ≥ 200 bars after the EMA(200) warm-up. m1Count=3500 →
+    // primary openTime = 3499*60s ≈ 58.3h → M15 idx ≈ 233. Good.
+    const m1Count = 3500;
+    const m1 = makeCandles(m1Count, INTERVAL_MS["1m"], (i) => {
+      // Steady uptrend with a sharp last-bars dip on M1 to push RSI(3)
+      // below 30 right at the primary's most recent bar.
+      if (i < m1Count - 6) return 100 + i * 0.005;
+      return 100 + (m1Count - 6) * 0.005 - (i - (m1Count - 6)) * 0.5;
+    });
+    const m5 = makeCandles(700, INTERVAL_MS["5m"], (i) => 100 + i * 0.025);
+    const m15 = makeCandles(240, INTERVAL_MS["15m"], (i) => 100 + i * 0.07);
+    expect(fires(m1, m5, m15)).toBe(true);
+  });
+
+  it("M15 downtrend (EMA50 < EMA200) → no entry even if M1/M5 align", () => {
+    const m1Count = 3500;
+    const m1 = makeCandles(m1Count, INTERVAL_MS["1m"], (i) =>
+      i < m1Count - 6 ? 100 + i * 0.005 : 100 + (m1Count - 6) * 0.005 - (i - (m1Count - 6)) * 0.5
+    );
+    const m5 = makeCandles(700, INTERVAL_MS["5m"], (i) => 100 + i * 0.025);
+    // M15 series: long flat then sharp drop in the second half so the
+    // recent EMA(50) sits below the slower EMA(200).
+    const m15 = makeCandles(240, INTERVAL_MS["15m"], (i) => (i < 100 ? 200 : 200 - (i - 100) * 0.4));
+    expect(fires(m1, m5, m15)).toBe(false);
+  });
+
+  it("calm baseline: flat across all three TFs → no entry", () => {
+    const m1 = makeCandles(3500, INTERVAL_MS["1m"], () => 100);
+    const m5 = makeCandles(700, INTERVAL_MS["5m"], () => 100);
+    const m15 = makeCandles(240, INTERVAL_MS["15m"], () => 100);
+    expect(fires(m1, m5, m15)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the static half of **54-T2** for the third vertical slice (after Adaptive Regime in #339 and DCA Momentum in #340). Replaces the placeholder `mtf-scalper` seed (51-T6) with the final long-only multi-TF DSL through supported primitives.

### DSL shape (M1 primary + M5 + M15 bundle)

```
entry.signal = AND(
  EMA(50, M15) > EMA(200, M15),   // M15 trend filter
  EMA(8,  M5)  > VWAP(M5),         // M5 above session VWAP
  RSI(3, M1) < 30                  // M1 oversold timing
)
exit = {
  stopLoss:        ATR(14) * 1.5  // tight stop for HFT cadence
  takeProfit:      +0.5% fixed_pct
  indicatorExit:   RSI(3) > 70 (long)
}
risk = { maxPositionSizeUsd: 50, riskPerTradePct: 0.5, cooldownSeconds: 10 }
defaultBotConfig = { symbol: BTCUSDT, timeframe: M1, quoteAmount: 50 }
datasetBundleHint = { 1m: true, 5m: true, 15m: true }
```

`EMA(8)` on M5 is a primitive-friendly proxy for "close above VWAP" — `DslSignalRef` has no direct `close` ref. The trend / context / timing decomposition matches the concept doc (`docs/strategies/05-mtf-confluence-scalper.md`).

### Tests

New `tests/lib/strategies/mtfScalper.test.ts` (7 cases):

- **Seed/golden pin** — `tests/fixtures/strategies/mtf-scalper.golden.json` is byte-equal to the seed `dslJson`.
- **`validateDsl`** returns `null`; **`parseDsl`** yields a v2-shaped `ParsedDsl` with ATR stop, `fixed_pct` TP, RSI(3)>70 indicator exit.
- **No composite types** — every `blockType` (including `vwap`) is `supported` in `BLOCK_SUPPORT_MAP` (or a structural keyword).
- **Sanity evaluator** on a synthetic `{M1, M5, M15}` bundle:
  - three-way confluence (M15 uptrend + M5 above VWAP + M1 RSI(3)<30 dip in the last 6 bars) → entry fires;
  - M15 downtrend (EMA50<EMA200 in the recent window) → no entry even with M1/M5 aligned;
  - calm baseline (flat across all three TFs) → no entry.

The synthetic M1 series is sized at 3500 bars (~58h) so the M15 alignment lands past the EMA(200) warm-up boundary at the primary's last bar.

## Test plan

- [x] `apps/api` `tsc --noEmit` — exit 0.
- [x] `vitest run tests/lib tests/integration tests/routes/lab.test.ts tests/prisma` — 931/931 pass (58 test files).

## Out of scope (separate PRs / sessions)

- **54-T2 §2** — walk-forward acceptance on real M1+M5+M15 data.
- **54-T2 §3** — `demoSmoke.mtfScalper.ts` 30-min Bybit demo run.
- **54-T2 §4** — profile-check: `loadCandleBundle({M1, M5, M15})` per-tick stays under polling cadence.
- **54-T2 §5** — `publishPreset.ts --slug mtf-scalper --visibility PUBLIC` + audit log.
- **54-T3** — SMC Liquidity Sweep golden DSL by the same pattern (next slice).

https://claude.ai/code/session_01LCaeb3zKUHh5XgZxw38GW7

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCaeb3zKUHh5XgZxw38GW7)_