### PR TITLE
feat(backtest): persist datasetBundleJson on BacktestResult (52 follow-up)

### DIFF
--- a/apps/api/prisma/migrations/20260502000000_backtestresult_dataset_bundle/migration.sql
+++ b/apps/api/prisma/migrations/20260502000000_backtestresult_dataset_bundle/migration.sql
@@ -1,0 +1,12 @@
+-- BacktestResult dataset bundle column (docs/52 follow-up)
+--
+-- Adds a nullable JSONB column to BacktestResult so the bundle a
+-- multi-TF backtest ran against is persisted alongside its report.
+-- Existing rows are unaffected (NULL ⇒ legacy single-TF run driven by
+-- `datasetId` alone). This unblocks accurate multi-TF replay from a
+-- BacktestResult row — previously the bundle was consumed in-flight
+-- and replays silently fell back to single-TF.
+--
+-- Mirrors 20260501000000_dataset_bundle on Bot/BacktestSweep/WalkForwardRun.
+
+ALTER TABLE "BacktestResult" ADD COLUMN "datasetBundleJson" JSONB;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -615,6 +615,10 @@ model BacktestResult {
   engineVersion String         @default("unknown")
   /// Phase 5 — explicit StrategyVersion binding for reproducible backtests
   strategyVersionId String?
+  /// docs/52 follow-up — multi-interval dataset bundle this backtest ran on,
+  /// `Partial<Record<CandleInterval, string | true>>`. NULL ⇒ single-TF run
+  /// driven by `datasetId` alone (legacy + non-MTF strategies).
+  datasetBundleJson Json?
 
   workspace       Workspace       @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
   strategy        Strategy        @relation(fields: [strategyId], references: [id], onDelete: Cascade)

--- a/apps/api/src/routes/lab.ts
+++ b/apps/api/src/routes/lab.ts
@@ -131,6 +131,8 @@ const BACKTEST_SELECT = {
   slippageBps: true,
   fillAt: true,
   engineVersion: true,
+  // docs/52 follow-up — multi-interval bundle the run was executed against.
+  datasetBundleJson: true,
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -543,6 +545,10 @@ export async function labRoutes(app: FastifyInstance) {
         slippageBps,
         fillAt,
         engineVersion,
+        // docs/52 follow-up — persist the bundle so a future replay can
+        // re-run on the exact multi-TF data without inferring from
+        // datasetId alone.
+        ...(resolvedBundle ? { datasetBundleJson: resolvedBundle as unknown as object } : {}),
       },
       select: BACKTEST_SELECT,
     });

--- a/apps/api/tests/routes/lab.test.ts
+++ b/apps/api/tests/routes/lab.test.ts
@@ -595,6 +595,65 @@ describe("POST /api/v1/lab/backtest", () => {
     expect(res.statusCode).toBe(400);
     expect(JSON.stringify(res.json())).toMatch(/primary entry must equal body\.datasetId/);
   });
+
+  // ── docs/52 follow-up: BacktestResult.datasetBundleJson round-trip ───────
+  // Pins persistence + read-back of the bundle on the result row so a
+  // future replay path (or any consumer reading BacktestResult back) can
+  // re-run on the exact multi-TF dataset, not just the primary.
+  it("52 follow-up: persists datasetBundleJson on BacktestResult and returns it on GET", async () => {
+    mockStrategyVersions["sv-1"] = { id: "sv-1", strategyId: "strat-1", strategy: { workspaceId: WS_ID }, dslJson: {} };
+    mockDatasets["ds-1"] = { id: "ds-1", workspaceId: WS_ID, exchange: "bybit", symbol: "BTCUSDT", interval: "M15", fromTsMs: BigInt(1704067200000), toTsMs: BigInt(1706745600000), datasetHash: "abc" };
+    mockDatasets["ds-h1"] = { id: "ds-h1", workspaceId: WS_ID, exchange: "bybit", symbol: "BTCUSDT", interval: "H1", fromTsMs: BigInt(1704067200000), toTsMs: BigInt(1706745600000), datasetHash: "def" };
+
+    const post = await app.inject({
+      method: "POST",
+      url: "/api/v1/lab/backtest",
+      headers: bundleHeaders("10.52.4.5"),
+      payload: {
+        strategyVersionId: "sv-1",
+        datasetId: "ds-1",
+        datasetBundleJson: { M15: "ds-1", H1: "ds-h1" },
+      },
+    });
+    expect(post.statusCode).toBe(202);
+    const created = post.json() as { id: string; datasetBundleJson?: Record<string, unknown> };
+    expect(created.datasetBundleJson).toEqual({ M15: "ds-1", H1: "ds-h1" });
+
+    // The bundle survived prisma.backtestResult.create — read it back via
+    // the row so a replay path can re-load the same multi-TF candles.
+    const stored = mockBacktests[created.id] as Record<string, unknown>;
+    expect(stored.datasetBundleJson).toEqual({ M15: "ds-1", H1: "ds-h1" });
+
+    const get = await app.inject({
+      method: "GET",
+      url: `/api/v1/lab/backtest/${created.id}`,
+      headers: authHeaders(),
+    });
+    expect(get.statusCode).toBe(200);
+    expect((get.json() as Record<string, unknown>).datasetBundleJson).toEqual({
+      M15: "ds-1", H1: "ds-h1",
+    });
+  });
+
+  it("52 follow-up: leaves datasetBundleJson NULL when the bundle is omitted (single-TF path)", async () => {
+    mockStrategyVersions["sv-1"] = { id: "sv-1", strategyId: "strat-1", strategy: { workspaceId: WS_ID }, dslJson: {} };
+    mockDatasets["ds-1"] = { id: "ds-1", workspaceId: WS_ID, exchange: "bybit", symbol: "BTCUSDT", interval: "M15", fromTsMs: BigInt(1704067200000), toTsMs: BigInt(1706745600000), datasetHash: "abc" };
+
+    const post = await app.inject({
+      method: "POST",
+      url: "/api/v1/lab/backtest",
+      headers: bundleHeaders("10.52.4.6"),
+      payload: { strategyVersionId: "sv-1", datasetId: "ds-1" },
+    });
+    expect(post.statusCode).toBe(202);
+    const created = post.json() as { id: string; datasetBundleJson?: unknown };
+    // Persisted row carries no bundle key, so the response is undefined
+    // rather than a literal null. Pinning this so the legacy single-TF
+    // shape stays bit-for-bit identical for callers that didn't opt in.
+    expect(created.datasetBundleJson).toBeUndefined();
+    const stored = mockBacktests[created.id] as Record<string, unknown>;
+    expect("datasetBundleJson" in stored).toBe(false);
+  });
 });
 
 // ── GET /lab/backtest/:id ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes the last deferred technical debt from `docs/52`. `POST /lab/backtest` already accepted + validated `datasetBundleJson` and ran the engine through `runBacktestWithBundle`, but the bundle was consumed in-flight: `BacktestResult` had no column for it, so any downstream replay or audit (re-running a saved backtest, comparing two MTF runs, surfacing the bundle in the results UI) silently fell back to the primary dataset alone.

### Schema
- New nullable column **`BacktestResult.datasetBundleJson`** (`Json?`) with migration `20260502000000_backtestresult_dataset_bundle`. Mirrors `20260501000000_dataset_bundle` on `Bot` / `BacktestSweep` / `WalkForwardRun`. Existing rows are unaffected — `NULL` means the legacy single-TF run driven by `datasetId` alone.

### Route
- **`BACKTEST_SELECT`** picks `datasetBundleJson` so `GET /lab/backtest/:id`, `GET /lab/backtests`, and the `POST /lab/backtest` 202 response all carry it.
- **`POST /lab/backtest`** persists `resolvedBundle` on the row when present; absent when omitted (no implicit empty bundle).

### Tests
Extends `tests/routes/lab.test.ts` (122 → 124 cases):
- **Round-trip**: `POST /lab/backtest` with `datasetBundleJson` then `GET /lab/backtest/:id` returns the same bundle; the persisted row carries it verbatim. Pins both the write- and read-back paths.
- **Legacy**: `POST` without a bundle leaves `datasetBundleJson` absent on the row and `undefined` in the response (no implicit serialisation), so single-TF callers see a bit-for-bit identical shape.

## Test plan

- [x] `apps/api` `tsc --noEmit` — exit 0 (post `prisma generate`).
- [x] `vitest run tests/lib tests/integration tests/routes/lab.test.ts tests/prisma` — 940/940 pass (59 test files).

## Out of scope

- A dedicated **replay endpoint** (`POST /lab/backtest/:id/replay`) is a separate UX feature; this PR only ships the persistence so a future replay can read the bundle off the row instead of inferring from `datasetId`.

https://claude.ai/code/session_01LCaeb3zKUHh5XgZxw38GW7

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCaeb3zKUHh5XgZxw38GW7)_