### PR TITLE
feat(exchange): Bybit Spot market-data adapter (55-T1)

### DIFF
--- a/apps/api/src/lib/exchange/bybitSpot.ts
+++ b/apps/api/src/lib/exchange/bybitSpot.ts
@@ -1,0 +1,352 @@
+/**
+ * Bybit Spot adapter — public market-data only (docs/55-T1).
+ *
+ * Three read-only helpers used by the funding-arbitrage runtime to size
+ * and price the spot leg of a hedge:
+ *
+ *   - {@link fetchSpotCandles}      — kline series (for diagnostics / UI).
+ *   - {@link fetchSpotTicker}       — last + bid/ask (for spread cost).
+ *   - {@link getSpotInstrumentInfo} — tick / lot / min order size.
+ *
+ * Trading itself goes through the existing `bybitOrder.ts` with
+ * `category: "spot"`. This file is intentionally market-data only — no
+ * private endpoints, no order placement.
+ *
+ * Design notes:
+ *  - Uses `fetch` + the Bybit v5 public surface, mirroring
+ *    `bybitCandles.ts` and `exchange/instrumentCache.ts`.
+ *  - Public market data does not require auth, so a single base URL
+ *    (`BYBIT_PUBLIC_URL`, default `https://api.bybit.com`) covers both
+ *    demo and live runtimes.
+ *  - In-memory caches with TTLs from the docs/55-T1 spec:
+ *      • instrument info — 24h (instruments rarely change),
+ *      • ticker          — 5s  (cuts request volume during a hedge tick).
+ *  - Caches are module-scoped and exported `_reset*ForTests` helpers let
+ *    suites reset between cases.
+ *  - All HTTP error paths funnel through {@link BybitSpotError} so callers
+ *    can branch on `cause` (`http` / `api` / `parse`) instead of inspecting
+ *    free-form messages.
+ */
+
+import { logger } from "../logger.js";
+import type { CandleInterval } from "../../types/datasetBundle.js";
+
+const log = logger.child({ module: "bybitSpot" });
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/** Public market data always lives on the main endpoint — no auth, no
+ *  routing differences between demo and live. Mirrors bybitCandles.ts. */
+function getBaseUrl(): string {
+  return process.env.BYBIT_PUBLIC_URL ?? "https://api.bybit.com";
+}
+
+const USER_AGENT = "botmarketplace-spot/1";
+
+const TICKER_TTL_MS = 5_000;
+const INSTRUMENT_TTL_MS = 24 * 60 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface SpotCandle {
+  /** Open time in ms since the Unix epoch. */
+  openTime: number;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+export interface SpotTicker {
+  symbol: string;
+  lastPrice: number;
+  bidPrice: number;
+  askPrice: number;
+  bidSize: number;
+  askSize: number;
+  /** Server timestamp at the moment of the snapshot. */
+  timestamp: Date;
+}
+
+export interface SpotInstrumentInfo {
+  symbol: string;
+  baseAsset: string;
+  quoteAsset: string;
+  /** Minimum price increment. */
+  tickSize: number;
+  /** Minimum quantity increment. */
+  lotSize: number;
+  /** Minimum order quantity (base units). */
+  minOrderSize: number;
+  /** Minimum order notional (quote units, e.g. USDT). 0 if exchange omits it. */
+  minOrderValue: number;
+  /** When this entry was fetched (ms epoch). */
+  fetchedAt: number;
+}
+
+/** Typed error so callers can branch on `cause` rather than parsing strings. */
+export class BybitSpotError extends Error {
+  readonly cause: "http" | "api" | "parse" | "not_found";
+  readonly statusCode?: number;
+  readonly retCode?: number;
+  constructor(
+    message: string,
+    cause: BybitSpotError["cause"],
+    extras: { statusCode?: number; retCode?: number } = {},
+  ) {
+    super(message);
+    this.name = "BybitSpotError";
+    this.cause = cause;
+    this.statusCode = extras.statusCode;
+    this.retCode = extras.retCode;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Bybit response shapes (only the fields we read)
+// ---------------------------------------------------------------------------
+
+interface BybitKlineResponse {
+  retCode: number;
+  retMsg: string;
+  result: { list: string[][] };
+}
+
+interface BybitTickerResponse {
+  retCode: number;
+  retMsg: string;
+  time?: number;
+  result: {
+    list: Array<{
+      symbol: string;
+      lastPrice: string;
+      bid1Price: string;
+      ask1Price: string;
+      bid1Size?: string;
+      ask1Size?: string;
+    }>;
+  };
+}
+
+interface BybitInstrumentItem {
+  symbol: string;
+  baseCoin: string;
+  quoteCoin: string;
+  status: string;
+  lotSizeFilter: {
+    minOrderQty: string;
+    basePrecision?: string;
+    quotePrecision?: string;
+    minOrderAmt?: string;
+  };
+  priceFilter: { tickSize: string };
+}
+
+interface BybitInstrumentsResponse {
+  retCode: number;
+  retMsg: string;
+  result: { list: BybitInstrumentItem[] };
+}
+
+// ---------------------------------------------------------------------------
+// Caches
+// ---------------------------------------------------------------------------
+
+interface CacheEntry<T> { value: T; expiresAt: number }
+
+const tickerCache = new Map<string, CacheEntry<SpotTicker>>();
+const instrumentCache = new Map<string, SpotInstrumentInfo>();
+
+/** Test helpers — exported so suites can reset state between cases. */
+export function _resetSpotTickerCache(): void { tickerCache.clear(); }
+export function _resetSpotInstrumentCache(): void { instrumentCache.clear(); }
+
+// ---------------------------------------------------------------------------
+// HTTP helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Issue a single GET to the Bybit v5 public surface and surface either a
+ * typed `BybitSpotError` or the parsed JSON body. Centralised so HTTP /
+ * API / parse error branches are uniform across the three public helpers.
+ */
+async function getJson<T extends { retCode: number; retMsg: string }>(
+  path: string,
+  query: Record<string, string | number>,
+): Promise<T> {
+  const url = new URL(getBaseUrl() + path);
+  for (const [k, v] of Object.entries(query)) url.searchParams.set(k, String(v));
+
+  log.debug({ msg: "[bybit-spot] GET", path, query });
+
+  const res = await fetch(url.toString(), { headers: { "User-Agent": USER_AGENT } });
+  if (!res.ok) {
+    throw new BybitSpotError(
+      `Bybit spot HTTP ${res.status} ${res.statusText} for ${path}`,
+      "http",
+      { statusCode: res.status },
+    );
+  }
+
+  let json: T;
+  try {
+    json = (await res.json()) as T;
+  } catch (err) {
+    throw new BybitSpotError(
+      `Bybit spot response parse error for ${path}: ${(err as Error).message}`,
+      "parse",
+    );
+  }
+  if (json.retCode !== 0) {
+    throw new BybitSpotError(
+      `Bybit spot API error ${json.retCode}: ${json.retMsg}`,
+      "api",
+      { retCode: json.retCode },
+    );
+  }
+  return json;
+}
+
+// ---------------------------------------------------------------------------
+// Candles
+// ---------------------------------------------------------------------------
+
+/** Map a {@link CandleInterval} (uppercase enum) to Bybit's kline-interval
+ *  string ("1", "5", ..., "D"). Mirrors the helper in routes/lab.ts —
+ *  duplicated locally to keep the adapter free of route-layer imports. */
+function bybitIntervalCode(interval: CandleInterval): string {
+  switch (interval) {
+    case "M1":  return "1";
+    case "M5":  return "5";
+    case "M15": return "15";
+    case "M30": return "30";
+    case "H1":  return "60";
+    case "H4":  return "240";
+    case "D1":  return "D";
+  }
+}
+
+const MAX_CANDLE_LIMIT = 1000;
+const DEFAULT_CANDLE_LIMIT = 200;
+
+/**
+ * Fetch the latest N spot candles for `symbol` at `interval`.
+ *
+ * Returned candles are sorted ascending by `openTime` (Bybit returns
+ * newest-first; we reverse).
+ *
+ * @throws {@link BybitSpotError} on HTTP / API failure.
+ */
+export async function fetchSpotCandles(args: {
+  symbol: string;
+  interval: CandleInterval;
+  limit?: number;
+}): Promise<SpotCandle[]> {
+  const limit = clampLimit(args.limit, DEFAULT_CANDLE_LIMIT, MAX_CANDLE_LIMIT);
+  const json = await getJson<BybitKlineResponse>("/v5/market/kline", {
+    category: "spot",
+    symbol: args.symbol,
+    interval: bybitIntervalCode(args.interval),
+    limit,
+  });
+
+  const raw = json.result?.list ?? [];
+  const candles: SpotCandle[] = raw.map((row) => ({
+    openTime: Number(row[0]),
+    open:     Number(row[1]),
+    high:     Number(row[2]),
+    low:      Number(row[3]),
+    close:    Number(row[4]),
+    volume:   Number(row[5]),
+  }));
+  // Bybit returns newest-first; sort ascending so callers can append directly.
+  candles.sort((a, b) => a.openTime - b.openTime);
+  return candles;
+}
+
+function clampLimit(raw: number | undefined, fallback: number, max: number): number {
+  if (!Number.isFinite(raw) || raw === undefined) return fallback;
+  if (raw < 1) return 1;
+  if (raw > max) return max;
+  return Math.floor(raw);
+}
+
+// ---------------------------------------------------------------------------
+// Ticker
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch the current spot ticker for `symbol`. Cached for 5s — hedge ticks
+ * may pull the same ticker multiple times per second; the cache cuts
+ * outbound load without hiding meaningful price changes.
+ */
+export async function fetchSpotTicker(symbol: string): Promise<SpotTicker> {
+  const now = Date.now();
+  const hit = tickerCache.get(symbol);
+  if (hit && hit.expiresAt > now) return hit.value;
+
+  const json = await getJson<BybitTickerResponse>("/v5/market/tickers", {
+    category: "spot",
+    symbol,
+  });
+  const item = json.result?.list?.[0];
+  if (!item) {
+    throw new BybitSpotError(`Spot symbol not found: ${symbol}`, "not_found");
+  }
+
+  const ticker: SpotTicker = {
+    symbol: item.symbol,
+    lastPrice: Number(item.lastPrice),
+    bidPrice: Number(item.bid1Price),
+    askPrice: Number(item.ask1Price),
+    bidSize: Number(item.bid1Size ?? "0"),
+    askSize: Number(item.ask1Size ?? "0"),
+    timestamp: new Date(typeof json.time === "number" ? json.time : now),
+  };
+  tickerCache.set(symbol, { value: ticker, expiresAt: now + TICKER_TTL_MS });
+  return ticker;
+}
+
+// ---------------------------------------------------------------------------
+// Instrument info
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch spot instrument metadata (tick / lot / min sizes). Cached for 24h —
+ * Bybit instrument parameters change rarely and a stale entry never makes
+ * order rounding silently wrong (it would just produce a rejected order).
+ */
+export async function getSpotInstrumentInfo(symbol: string): Promise<SpotInstrumentInfo> {
+  const now = Date.now();
+  const cached = instrumentCache.get(symbol);
+  if (cached && now - cached.fetchedAt < INSTRUMENT_TTL_MS) return cached;
+
+  const json = await getJson<BybitInstrumentsResponse>("/v5/market/instruments-info", {
+    category: "spot",
+    symbol,
+  });
+  const item = json.result?.list?.find((i) => i.symbol === symbol);
+  if (!item) {
+    throw new BybitSpotError(`Spot instrument not found: ${symbol}`, "not_found");
+  }
+
+  const info: SpotInstrumentInfo = {
+    symbol: item.symbol,
+    baseAsset: item.baseCoin,
+    quoteAsset: item.quoteCoin,
+    tickSize: Number(item.priceFilter.tickSize),
+    // Spot uses `basePrecision` (string like "0.000001") as the smallest
+    // tradable unit; fall back to `minOrderQty` if absent.
+    lotSize: Number(item.lotSizeFilter.basePrecision ?? item.lotSizeFilter.minOrderQty),
+    minOrderSize: Number(item.lotSizeFilter.minOrderQty),
+    minOrderValue: Number(item.lotSizeFilter.minOrderAmt ?? "0"),
+    fetchedAt: now,
+  };
+  instrumentCache.set(symbol, info);
+  return info;
+}

--- a/apps/api/tests/lib/exchange/bybitSpot.test.ts
+++ b/apps/api/tests/lib/exchange/bybitSpot.test.ts
@@ -1,0 +1,326 @@
+/**
+ * Bybit Spot adapter — unit coverage (docs/55-T1).
+ *
+ * Mocks the global `fetch` to feed canned Bybit v5 responses through the
+ * three public helpers and pin:
+ *
+ *   1. {@link fetchSpotCandles}      — newest-first input → ascending output;
+ *      `limit` clamped to `[1, 1000]`; correct query string.
+ *   2. {@link fetchSpotTicker}       — populated, plus 5s in-memory cache
+ *      (second call within the window does NOT re-hit `fetch`).
+ *   3. {@link getSpotInstrumentInfo} — populated, plus 24h in-memory cache.
+ *   4. Error surface — HTTP non-2xx ⇒ `BybitSpotError {cause:'http'}`,
+ *      `retCode!=0` ⇒ `{cause:'api'}`, missing-symbol ⇒ `{cause:'not_found'}`.
+ *
+ * Reset helpers are exported by the module so each test starts from a
+ * clean cache, matching the behaviour of `instrumentCache.test.ts`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  BybitSpotError,
+  fetchSpotCandles,
+  fetchSpotTicker,
+  getSpotInstrumentInfo,
+  _resetSpotInstrumentCache,
+  _resetSpotTickerCache,
+} from "../../../src/lib/exchange/bybitSpot.js";
+
+// ---------------------------------------------------------------------------
+// Test scaffolding
+// ---------------------------------------------------------------------------
+
+const realFetch = globalThis.fetch;
+
+function mockFetch(impl: typeof fetch) {
+  globalThis.fetch = impl as typeof fetch;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  _resetSpotTickerCache();
+  _resetSpotInstrumentCache();
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+// ---------------------------------------------------------------------------
+// 1. fetchSpotCandles
+// ---------------------------------------------------------------------------
+
+describe("fetchSpotCandles", () => {
+  it("parses Bybit kline rows newest-first into ascending SpotCandle[]", async () => {
+    // Bybit returns newest-first; the adapter must reverse to ascending.
+    const klineList = [
+      ["1730000600000", "100.4", "100.5", "100.3", "100.45", "10", "1004"],
+      ["1730000300000", "100.1", "100.2", "100.0", "100.15", "20", "2003"],
+      ["1730000000000", "99.9",  "100.0", "99.8",  "100.0",  "30", "3000"],
+    ];
+    const calls: string[] = [];
+    mockFetch(vi.fn(async (input) => {
+      calls.push(String(input));
+      return jsonResponse({ retCode: 0, retMsg: "OK", result: { list: klineList } });
+    }) as unknown as typeof fetch);
+
+    const out = await fetchSpotCandles({ symbol: "BTCUSDT", interval: "M5", limit: 3 });
+
+    expect(out).toHaveLength(3);
+    expect(out[0].openTime).toBeLessThan(out[1].openTime);
+    expect(out[2].openTime).toBe(1730000600000);
+    expect(out[0]).toMatchObject({ open: 99.9, high: 100, low: 99.8, close: 100, volume: 30 });
+
+    // Query-string sanity — category / symbol / interval / limit all set.
+    expect(calls[0]).toContain("category=spot");
+    expect(calls[0]).toContain("symbol=BTCUSDT");
+    expect(calls[0]).toContain("interval=5");
+    expect(calls[0]).toContain("limit=3");
+  });
+
+  it("clamps `limit` into [1, 1000]; defaults to 200 when absent", async () => {
+    const calls: string[] = [];
+    mockFetch(vi.fn(async (input) => {
+      calls.push(String(input));
+      return jsonResponse({ retCode: 0, retMsg: "OK", result: { list: [] } });
+    }) as unknown as typeof fetch);
+
+    await fetchSpotCandles({ symbol: "BTCUSDT", interval: "M5" });
+    await fetchSpotCandles({ symbol: "BTCUSDT", interval: "M5", limit: 99999 });
+    await fetchSpotCandles({ symbol: "BTCUSDT", interval: "M5", limit: 0 });
+
+    expect(calls[0]).toContain("limit=200");
+    expect(calls[1]).toContain("limit=1000");
+    expect(calls[2]).toContain("limit=1");
+  });
+
+  it("maps every CandleInterval to the correct Bybit interval code", async () => {
+    const captured: string[] = [];
+    mockFetch(vi.fn(async (input) => {
+      captured.push(String(input));
+      return jsonResponse({ retCode: 0, retMsg: "OK", result: { list: [] } });
+    }) as unknown as typeof fetch);
+
+    const cases: Array<[Parameters<typeof fetchSpotCandles>[0]["interval"], string]> = [
+      ["M1", "interval=1"],
+      ["M5", "interval=5"],
+      ["M15", "interval=15"],
+      ["M30", "interval=30"],
+      ["H1", "interval=60"],
+      ["H4", "interval=240"],
+      ["D1", "interval=D"],
+    ];
+    for (const [iv] of cases) {
+      await fetchSpotCandles({ symbol: "BTCUSDT", interval: iv });
+    }
+    for (let i = 0; i < cases.length; i++) {
+      expect(captured[i]).toContain(cases[i][1]);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. fetchSpotTicker
+// ---------------------------------------------------------------------------
+
+describe("fetchSpotTicker", () => {
+  function tickerResponse() {
+    return jsonResponse({
+      retCode: 0,
+      retMsg: "OK",
+      time: 1_730_000_000_000,
+      result: {
+        list: [{
+          symbol: "BTCUSDT",
+          lastPrice: "65000.5",
+          bid1Price: "64999.5",
+          ask1Price: "65001.5",
+          bid1Size: "0.123",
+          ask1Size: "0.456",
+        }],
+      },
+    });
+  }
+
+  it("returns parsed numbers + a Date timestamp", async () => {
+    mockFetch(vi.fn(async () => tickerResponse()) as unknown as typeof fetch);
+
+    const t = await fetchSpotTicker("BTCUSDT");
+    expect(t).toMatchObject({
+      symbol: "BTCUSDT",
+      lastPrice: 65000.5,
+      bidPrice: 64999.5,
+      askPrice: 65001.5,
+      bidSize: 0.123,
+      askSize: 0.456,
+    });
+    expect(t.timestamp).toBeInstanceOf(Date);
+    expect(t.timestamp.getTime()).toBe(1_730_000_000_000);
+  });
+
+  it("caches subsequent calls within the 5s TTL (one HTTP request total)", async () => {
+    const fetchMock = vi.fn(async () => tickerResponse());
+    mockFetch(fetchMock as unknown as typeof fetch);
+
+    const a = await fetchSpotTicker("BTCUSDT");
+    const b = await fetchSpotTicker("BTCUSDT");
+    expect(b).toEqual(a);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-fetches after the TTL expires (manual cache reset stand-in)", async () => {
+    const fetchMock = vi.fn(async () => tickerResponse());
+    mockFetch(fetchMock as unknown as typeof fetch);
+
+    await fetchSpotTicker("BTCUSDT");
+    _resetSpotTickerCache();
+    await fetchSpotTicker("BTCUSDT");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws BybitSpotError(cause='not_found') when symbol is absent", async () => {
+    mockFetch(vi.fn(async () =>
+      jsonResponse({ retCode: 0, retMsg: "OK", result: { list: [] } }),
+    ) as unknown as typeof fetch);
+
+    await expect(fetchSpotTicker("NOPE")).rejects.toMatchObject({
+      name: "BybitSpotError",
+      cause: "not_found",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. getSpotInstrumentInfo
+// ---------------------------------------------------------------------------
+
+describe("getSpotInstrumentInfo", () => {
+  function instrumentResponse(extras: Record<string, string> = {}) {
+    return jsonResponse({
+      retCode: 0,
+      retMsg: "OK",
+      result: {
+        list: [{
+          symbol: "BTCUSDT",
+          baseCoin: "BTC",
+          quoteCoin: "USDT",
+          status: "Trading",
+          lotSizeFilter: {
+            minOrderQty: "0.0001",
+            basePrecision: "0.000001",
+            minOrderAmt: "5",
+            ...extras,
+          },
+          priceFilter: { tickSize: "0.01" },
+        }],
+      },
+    });
+  }
+
+  it("returns parsed instrument metadata with numeric fields", async () => {
+    mockFetch(vi.fn(async () => instrumentResponse()) as unknown as typeof fetch);
+
+    const info = await getSpotInstrumentInfo("BTCUSDT");
+    expect(info).toMatchObject({
+      symbol: "BTCUSDT",
+      baseAsset: "BTC",
+      quoteAsset: "USDT",
+      tickSize: 0.01,
+      lotSize: 0.000001,
+      minOrderSize: 0.0001,
+      minOrderValue: 5,
+    });
+    expect(typeof info.fetchedAt).toBe("number");
+  });
+
+  it("falls back to minOrderQty for lotSize when basePrecision is omitted", async () => {
+    mockFetch(vi.fn(async () => jsonResponse({
+      retCode: 0,
+      retMsg: "OK",
+      result: {
+        list: [{
+          symbol: "BTCUSDT",
+          baseCoin: "BTC",
+          quoteCoin: "USDT",
+          status: "Trading",
+          lotSizeFilter: { minOrderQty: "0.0001" },
+          priceFilter: { tickSize: "0.01" },
+        }],
+      },
+    })) as unknown as typeof fetch);
+
+    const info = await getSpotInstrumentInfo("BTCUSDT");
+    expect(info.lotSize).toBe(0.0001);
+    expect(info.minOrderValue).toBe(0); // exchange omitted minOrderAmt
+  });
+
+  it("caches subsequent calls (one HTTP request total)", async () => {
+    const fetchMock = vi.fn(async () => instrumentResponse());
+    mockFetch(fetchMock as unknown as typeof fetch);
+
+    await getSpotInstrumentInfo("BTCUSDT");
+    await getSpotInstrumentInfo("BTCUSDT");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws BybitSpotError(cause='not_found') when the symbol is absent", async () => {
+    mockFetch(vi.fn(async () =>
+      jsonResponse({ retCode: 0, retMsg: "OK", result: { list: [] } }),
+    ) as unknown as typeof fetch);
+
+    await expect(getSpotInstrumentInfo("ZZZ")).rejects.toMatchObject({
+      name: "BybitSpotError",
+      cause: "not_found",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Error surface — uniform across all three helpers
+// ---------------------------------------------------------------------------
+
+describe("BybitSpotError", () => {
+  it("HTTP non-2xx maps to cause='http' with statusCode", async () => {
+    mockFetch(vi.fn(async () =>
+      new Response("rate limit", { status: 429, statusText: "Too Many Requests" }),
+    ) as unknown as typeof fetch);
+
+    await expect(fetchSpotTicker("BTCUSDT")).rejects.toMatchObject({
+      name: "BybitSpotError",
+      cause: "http",
+      statusCode: 429,
+    });
+  });
+
+  it("retCode != 0 maps to cause='api' with retCode", async () => {
+    mockFetch(vi.fn(async () =>
+      jsonResponse({ retCode: 10001, retMsg: "Invalid request", result: { list: [] } }),
+    ) as unknown as typeof fetch);
+
+    await expect(getSpotInstrumentInfo("BTCUSDT")).rejects.toMatchObject({
+      name: "BybitSpotError",
+      cause: "api",
+      retCode: 10001,
+    });
+  });
+
+  it("BybitSpotError is an instance of Error so existing handlers still catch it", async () => {
+    mockFetch(vi.fn(async () =>
+      new Response("bad", { status: 500, statusText: "Server Error" }),
+    ) as unknown as typeof fetch);
+
+    try {
+      await fetchSpotCandles({ symbol: "BTCUSDT", interval: "M5" });
+      expect.fail("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(BybitSpotError);
+      expect(err).toBeInstanceOf(Error);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes **55-T1** — first task of the Funding Arbitrage track. Introduces `apps/api/src/lib/exchange/bybitSpot.ts` with three read-only helpers needed by the funding-arb runtime to size and price the spot leg of a hedge. Trading itself goes through the existing `bybitOrder.ts` (already parametrised by `category: "spot"`).

### Helpers
- **`fetchSpotCandles({ symbol, interval, limit? })`** — kline series for diagnostics / UI. Bybit returns newest-first; the adapter sorts ascending so callers can append directly. `limit` clamped to `[1, 1000]`, default 200. `CandleInterval` enum mapped to Bybit interval codes (`M1→1`, ..., `D1→D`) via a local helper that mirrors the duplicate in `routes/lab.ts`.
- **`fetchSpotTicker(symbol)`** — last + bid/ask + sizes + server timestamp. Cached for 5s in a module-scoped Map so a hedge tick that pulls the same ticker repeatedly does not hammer the public endpoint.
- **`getSpotInstrumentInfo(symbol)`** — `tickSize`, `lotSize` (`basePrecision` with `minOrderQty` fallback), `minOrderSize`, `minOrderValue`. Cached for 24h — instruments rarely change and a stale entry only ever yields a rejected order, never a silently wrong fill.

### Design
- Pure `fetch` + Bybit v5 public endpoints, mirroring `bybitCandles.ts` / `exchange/instrumentCache.ts`. No new HTTP stack, no auth (public market data covers both demo and live).
- All HTTP / API / parse error paths funnel through a typed **`BybitSpotError { cause: 'http' | 'api' | 'parse' | 'not_found' }`** so callers can branch on `cause` instead of parsing free-form messages. `statusCode` + `retCode` preserved on the instance.
- Module-scoped caches with exported `_resetSpot{Ticker,Instrument}Cache` test helpers, matching the pattern in `instrumentCache.ts`.
- Logger with `module='bybitSpot'`, debug per request — discoverable in prod logs without flipping log level.

### Tests
New `tests/lib/exchange/bybitSpot.test.ts` (14 cases):
- **`fetchSpotCandles`**: newest-first input → ascending output; `limit` clamping (default 200, max 1000, min 1); every `CandleInterval` maps to the right Bybit code.
- **`fetchSpotTicker`**: parsed numbers + `Date` timestamp; second call within 5s reuses cache (one fetch); reset helper allows re-fetch.
- **`getSpotInstrumentInfo`**: parsed metadata; `basePrecision`-missing fallback to `minOrderQty`; cache pin (one fetch on repeat).
- **Error surface**: HTTP non-2xx → `cause='http'` with `statusCode`; `retCode!=0` → `cause='api'` with `retCode`; missing-symbol → `cause='not_found'`; instance-of `Error` so existing handlers still catch.

## Test plan

- [x] `apps/api` `tsc --noEmit` — exit 0.
- [x] `vitest run tests/lib tests/integration tests/routes/lab.test.ts tests/prisma` — 954/954 pass (60 test files).

## Out of scope (next 55 tasks)

- **55-T2** — wire spot-leg execution in `/hedges/:id/{execute,exit}` through `bybitOrder` with `category='spot'` and dual API key.
- **55-T3** — funding scanner UI table.
- **55-T4** — dedicated `hedgeBotWorker`.
- **55-T5** — spot/perp balance reconciliation + dual API key schema.
- **55-T6** — acceptance gate (60-min Bybit demo run pinned to a funding event).

https://claude.ai/code/session_01LCaeb3zKUHh5XgZxw38GW7

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCaeb3zKUHh5XgZxw38GW7)_