### PR TITLE
feat(exchange): dual API key + balance reconciler for funding-arb (55-T5)

### DIFF
--- a/apps/api/prisma/migrations/20260502100000_exchange_connection_spot_credentials/migration.sql
+++ b/apps/api/prisma/migrations/20260502100000_exchange_connection_spot_credentials/migration.sql
@@ -1,0 +1,21 @@
+-- ExchangeConnection — optional dedicated spot credentials (docs/55-T5).
+--
+-- Funding-arbitrage requires Bybit access to BOTH the linear (perp) and the
+-- spot wallet. Bybit unified accounts can issue a single API key with both
+-- scopes — but operators may prefer separate keys (smaller blast radius if
+-- one is compromised). These three columns let `ExchangeConnection` carry an
+-- optional second key/secret pair for the spot wallet.
+--
+-- Backwards compatibility:
+--   * All three columns are NULL on existing rows.
+--   * Single-key fallback: when `spotApiKey` / `spotEncryptedSecret` are NULL,
+--     the linear `apiKey` / `encryptedSecret` is reused for spot API calls
+--     (see `apps/api/src/lib/exchange/balanceReconciler.ts`).
+--
+-- Encryption format: `spotEncryptedSecret` mirrors `encryptedSecret` —
+-- AES-256-GCM, base64 colon-joined `iv:authTag:ciphertext`, decrypted via
+-- `decryptWithFallback` (apps/api/src/lib/crypto.ts).
+
+ALTER TABLE "ExchangeConnection" ADD COLUMN "spotApiKey" TEXT;
+ALTER TABLE "ExchangeConnection" ADD COLUMN "spotEncryptedSecret" TEXT;
+ALTER TABLE "ExchangeConnection" ADD COLUMN "spotKeyLabel" TEXT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -397,6 +397,14 @@ model ExchangeConnection {
   name             String
   apiKey           String
   encryptedSecret  String
+  /// Optional dedicated API key for the spot scope (docs/55-T5).
+  /// When NULL, the linear `apiKey` is reused for spot calls (single-key fallback).
+  spotApiKey           String?
+  /// Optional encrypted secret paired with `spotApiKey`. Same AES-256-GCM
+  /// payload format as `encryptedSecret`; decrypted via `decryptWithFallback`.
+  spotEncryptedSecret  String?
+  /// Optional UI label shown next to the spot key (e.g. "Funding-arb spot key").
+  spotKeyLabel         String?
   status           ExchangeConnectionStatus  @default(UNKNOWN)
   createdAt        DateTime                  @default(now())
   updatedAt        DateTime                  @updatedAt

--- a/apps/api/src/lib/exchange/balanceReconciler.ts
+++ b/apps/api/src/lib/exchange/balanceReconciler.ts
@@ -1,0 +1,305 @@
+/**
+ * Balance reconciler for funding-arbitrage hedges (docs/55-T5).
+ *
+ * Calls two Bybit private endpoints in parallel and produces a per-symbol
+ * hedge classification used by `hedgeBotWorker` (55-T4):
+ *
+ *   1. `GET /v5/position/list?category=linear&settleCoin=USDT` — perp side.
+ *   2. `GET /v5/account/wallet-balance?accountType=UNIFIED`     — spot side.
+ *
+ * Dual API key (docs/55-T5):
+ *   * If `connection.spotApiKey` AND `connection.spotEncryptedSecret` are
+ *     both set, the spot call is signed with that pair.
+ *   * Otherwise the spot call is signed with the linear pair — Bybit unified
+ *     accounts can issue a single key with both scopes (single-key fallback).
+ *     A warning is logged so operators know they're running unified.
+ *
+ * Hedge classification (per symbol):
+ *   - 'flat'        — no position on either side.
+ *   - 'perp_only'   — perp position exists, no matching spot holding.
+ *   - 'spot_only'   — spot holding exists, no matching perp position.
+ *   - 'balanced'    — both legs present and `||perp| - spot| / max ≤ 0.5%`.
+ *   - 'imbalanced'  — both legs present, sizes diverge above tolerance.
+ *
+ * Funding-arb expects perp-short + spot-long, so 'balanced' is the success
+ * state for an OPEN hedge; 'flat' is the success state for an idle slot.
+ *
+ * Errors funnel through `BalanceReconcilerError` with a `cause` discriminator
+ * so callers can branch without parsing free-form messages.
+ */
+
+import { createHmac } from "node:crypto";
+import { logger } from "../logger.js";
+import { decryptWithFallback } from "../crypto.js";
+import { getBybitBaseUrl } from "../bybitOrder.js";
+
+const log = logger.child({ module: "balanceReconciler" });
+
+const RECV_WINDOW = "5000";
+const USER_AGENT = "botmarketplace-reconciler/1";
+/** `||perp| - spot| / max(|perp|, spot)` accepted as 'balanced'. */
+const HEDGE_BALANCE_TOLERANCE = 0.005;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface ExchangeConnectionCreds {
+  apiKey: string;
+  encryptedSecret: string;
+  /** Optional dedicated spot API key (docs/55-T5). NULL ⇒ single-key fallback. */
+  spotApiKey?: string | null;
+  /** Optional dedicated spot encrypted secret. NULL ⇒ single-key fallback. */
+  spotEncryptedSecret?: string | null;
+}
+
+export type HedgeBalanceClassification =
+  | "flat"
+  | "perp_only"
+  | "spot_only"
+  | "balanced"
+  | "imbalanced";
+
+export interface HedgeBalanceStatus {
+  symbol: string;
+  /** Signed perp position size (positive = long, negative = short). 0 if absent. */
+  perpQty: number;
+  /** Spot base-asset holding inferred from `walletBalance`. 0 if absent. */
+  spotQty: number;
+  status: HedgeBalanceClassification;
+  /** `|perpQty| - spotQty` when both legs present; `undefined` otherwise. */
+  delta?: number;
+}
+
+export interface ReconcileResult {
+  /** symbol → signed perp size. */
+  perp: Map<string, number>;
+  /** baseAsset (e.g. "BTC") → spot wallet balance. */
+  spot: Map<string, number>;
+  hedgeStatus: HedgeBalanceStatus[];
+  /** False ⇒ spot call was signed with linear creds (single-key fallback). */
+  spotKeyAvailable: boolean;
+}
+
+export class BalanceReconcilerError extends Error {
+  readonly cause: "http" | "api" | "parse";
+  readonly statusCode?: number;
+  readonly retCode?: number;
+  constructor(
+    message: string,
+    cause: BalanceReconcilerError["cause"],
+    extras: { statusCode?: number; retCode?: number } = {},
+  ) {
+    super(message);
+    this.name = "BalanceReconcilerError";
+    this.cause = cause;
+    this.statusCode = extras.statusCode;
+    this.retCode = extras.retCode;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Bybit response shapes (only the fields we read)
+// ---------------------------------------------------------------------------
+
+interface PositionListResponse {
+  retCode: number;
+  retMsg: string;
+  result: {
+    list: Array<{
+      symbol: string;
+      side: string; // "Buy" | "Sell" | "" (empty when flat)
+      size: string;
+    }>;
+  };
+}
+
+interface WalletBalanceResponse {
+  retCode: number;
+  retMsg: string;
+  result: {
+    list: Array<{
+      coin: Array<{
+        coin: string;
+        walletBalance: string;
+      }>;
+    }>;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Signing — mirrors apps/api/src/lib/bybitOrder.ts
+// ---------------------------------------------------------------------------
+
+function sign(secret: string, timestamp: string, apiKey: string, payload: string): string {
+  return createHmac("sha256", secret)
+    .update(`${timestamp}${apiKey}${RECV_WINDOW}${payload}`)
+    .digest("hex");
+}
+
+function authHeaders(
+  apiKey: string,
+  secret: string,
+  timestamp: string,
+  payload: string,
+): Record<string, string> {
+  return {
+    "X-BAPI-API-KEY": apiKey,
+    "X-BAPI-SIGN": sign(secret, timestamp, apiKey, payload),
+    "X-BAPI-TIMESTAMP": timestamp,
+    "X-BAPI-RECV-WINDOW": RECV_WINDOW,
+    "User-Agent": USER_AGENT,
+  };
+}
+
+async function bybitGet<T extends { retCode: number; retMsg: string }>(
+  apiKey: string,
+  secret: string,
+  path: string,
+  query: Record<string, string>,
+): Promise<T> {
+  const qs = new URLSearchParams(query).toString();
+  const timestamp = Date.now().toString();
+  const url = `${getBybitBaseUrl()}${path}?${qs}`;
+
+  const res = await fetch(url, {
+    headers: authHeaders(apiKey, secret, timestamp, qs),
+  });
+  if (!res.ok) {
+    throw new BalanceReconcilerError(
+      `Bybit reconciler HTTP ${res.status} ${res.statusText} for ${path}`,
+      "http",
+      { statusCode: res.status },
+    );
+  }
+  let json: T;
+  try {
+    json = (await res.json()) as T;
+  } catch (err) {
+    throw new BalanceReconcilerError(
+      `Bybit reconciler parse error for ${path}: ${(err as Error).message}`,
+      "parse",
+    );
+  }
+  if (json.retCode !== 0) {
+    throw new BalanceReconcilerError(
+      `Bybit API error ${json.retCode}: ${json.retMsg}`,
+      "api",
+      { retCode: json.retCode },
+    );
+  }
+  return json;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** BTCUSDT → BTC, ETHUSD → ETH, etc. Funding-arb is positive-funding only,
+ *  so quote stable-coins are stripped to recover the base asset matching the
+ *  spot wallet entry. */
+export function baseAssetOf(symbol: string): string {
+  if (symbol.endsWith("USDT")) return symbol.slice(0, -4);
+  if (symbol.endsWith("USDC")) return symbol.slice(0, -4);
+  if (symbol.endsWith("USD")) return symbol.slice(0, -3);
+  return symbol;
+}
+
+function classify(perpQty: number, spotQty: number): HedgeBalanceClassification {
+  const hasPerp = Math.abs(perpQty) > 0;
+  const hasSpot = spotQty > 0;
+  if (!hasPerp && !hasSpot) return "flat";
+  if (hasPerp && !hasSpot) return "perp_only";
+  if (!hasPerp && hasSpot) return "spot_only";
+  const absPerp = Math.abs(perpQty);
+  const denom = Math.max(absPerp, spotQty);
+  const mismatch = Math.abs(absPerp - spotQty) / denom;
+  return mismatch <= HEDGE_BALANCE_TOLERANCE ? "balanced" : "imbalanced";
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Reconcile perp + spot balances for `symbols` against Bybit.
+ *
+ * Calls (in parallel) `/v5/position/list?category=linear` and
+ * `/v5/account/wallet-balance?accountType=UNIFIED`. The spot call is signed
+ * with `connection.spotApiKey` / `spotEncryptedSecret` when both are set,
+ * otherwise with `connection.apiKey` / `encryptedSecret` (single-key
+ * fallback — Bybit unified scope).
+ *
+ * @param connection — credentials; the linear pair is required.
+ * @param symbols    — list of perp symbols (e.g. ["BTCUSDT"]) to classify.
+ * @returns parsed maps + per-symbol `hedgeStatus`.
+ * @throws {@link BalanceReconcilerError} on HTTP / API / parse failure.
+ */
+export async function reconcileBalances(
+  connection: ExchangeConnectionCreds,
+  symbols: string[],
+): Promise<ReconcileResult> {
+  const useDualKeys = !!(connection.spotApiKey && connection.spotEncryptedSecret);
+
+  const linearSecret = decryptWithFallback(connection.encryptedSecret);
+  const spotApiKey = useDualKeys ? connection.spotApiKey! : connection.apiKey;
+  const spotSecret = useDualKeys
+    ? decryptWithFallback(connection.spotEncryptedSecret!)
+    : linearSecret;
+
+  if (!useDualKeys) {
+    log.warn(
+      { apiKey: connection.apiKey },
+      "Dual API key absent — falling back to linear creds for spot wallet (single-key mode)",
+    );
+  }
+
+  const [perpJson, spotJson] = await Promise.all([
+    bybitGet<PositionListResponse>(
+      connection.apiKey,
+      linearSecret,
+      "/v5/position/list",
+      { category: "linear", settleCoin: "USDT" },
+    ),
+    bybitGet<WalletBalanceResponse>(
+      spotApiKey,
+      spotSecret,
+      "/v5/account/wallet-balance",
+      { accountType: "UNIFIED" },
+    ),
+  ]);
+
+  const perp = new Map<string, number>();
+  for (const pos of perpJson.result?.list ?? []) {
+    const size = Number(pos.size);
+    if (!Number.isFinite(size) || size === 0) continue;
+    const signed = pos.side === "Sell" ? -size : size;
+    perp.set(pos.symbol, signed);
+  }
+
+  const spot = new Map<string, number>();
+  for (const bucket of spotJson.result?.list ?? []) {
+    for (const c of bucket.coin ?? []) {
+      const qty = Number(c.walletBalance);
+      if (!Number.isFinite(qty) || qty <= 0) continue;
+      // Sum across buckets — Bybit may return one entry per account-type bucket.
+      spot.set(c.coin, (spot.get(c.coin) ?? 0) + qty);
+    }
+  }
+
+  const hedgeStatus: HedgeBalanceStatus[] = symbols.map((symbol) => {
+    const perpQty = perp.get(symbol) ?? 0;
+    const spotQty = spot.get(baseAssetOf(symbol)) ?? 0;
+    const status = classify(perpQty, spotQty);
+    const both = Math.abs(perpQty) > 0 && spotQty > 0;
+    return {
+      symbol,
+      perpQty,
+      spotQty,
+      status,
+      delta: both ? Math.abs(perpQty) - spotQty : undefined,
+    };
+  });
+
+  return { perp, spot, hedgeStatus, spotKeyAvailable: useDualKeys };
+}

--- a/apps/api/tests/lib/exchange/balanceReconciler.test.ts
+++ b/apps/api/tests/lib/exchange/balanceReconciler.test.ts
@@ -1,0 +1,275 @@
+/**
+ * balanceReconciler — unit coverage (docs/55-T5).
+ *
+ * Mocks `decryptWithFallback` (so encrypted-secret payloads can be plain
+ * strings in fixtures) and `globalThis.fetch` (so each test feeds canned
+ * Bybit `/v5/position/list` + `/v5/account/wallet-balance` JSON). Pins:
+ *
+ *   1. Dual-key path  — both spot creds present ⇒ spot call uses spotApiKey,
+ *      perp call uses linear apiKey, `spotKeyAvailable === true`.
+ *   2. Single-key fallback — spot creds absent ⇒ both calls signed with the
+ *      same linear apiKey, `spotKeyAvailable === false`.
+ *   3. Classification — balanced / imbalanced / perp_only / spot_only / flat
+ *      cover the five branches; tolerance = 0.5%.
+ *   4. Error surface — non-zero `retCode` ⇒ `BalanceReconcilerError {cause:"api"}`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../src/lib/crypto.js", () => ({
+  decryptWithFallback: (payload: string) => {
+    // Convention used in this test: encrypted payloads are prefixed with
+    // "enc:" — strip it to recover the "plaintext" the reconciler will
+    // hand to HMAC. Anything else is returned verbatim.
+    return payload.startsWith("enc:") ? payload.slice(4) : payload;
+  },
+}));
+
+import {
+  BalanceReconcilerError,
+  baseAssetOf,
+  reconcileBalances,
+  type ExchangeConnectionCreds,
+} from "../../../src/lib/exchange/balanceReconciler.js";
+
+// ---------------------------------------------------------------------------
+// Test scaffolding
+// ---------------------------------------------------------------------------
+
+const realFetch = globalThis.fetch;
+
+interface FetchCall {
+  url: string;
+  apiKeyHeader: string;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/**
+ * Routes by URL: `/v5/position/list` ⇒ perp body, `/v5/account/wallet-balance`
+ * ⇒ spot body. Records every call so each test can assert which apiKey
+ * signed which request.
+ */
+function installFetch(opts: {
+  perp: unknown;
+  spot: unknown;
+  perpStatus?: number;
+  spotStatus?: number;
+}): FetchCall[] {
+  const calls: FetchCall[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    calls.push({ url, apiKeyHeader: headers["X-BAPI-API-KEY"] ?? "" });
+    if (url.includes("/v5/position/list")) {
+      return jsonResponse(opts.perp, opts.perpStatus ?? 200);
+    }
+    if (url.includes("/v5/account/wallet-balance")) {
+      return jsonResponse(opts.spot, opts.spotStatus ?? 200);
+    }
+    return jsonResponse({ retCode: -1, retMsg: `Unhandled URL ${url}` }, 404);
+  }) as typeof fetch;
+  return calls;
+}
+
+beforeEach(() => {
+  // No-op — each test installs its own fetch.
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+function dualKeyCreds(): ExchangeConnectionCreds {
+  return {
+    apiKey: "linear-key",
+    encryptedSecret: "enc:linear-secret",
+    spotApiKey: "spot-key",
+    spotEncryptedSecret: "enc:spot-secret",
+  };
+}
+
+function singleKeyCreds(): ExchangeConnectionCreds {
+  return {
+    apiKey: "linear-key",
+    encryptedSecret: "enc:linear-secret",
+    spotApiKey: null,
+    spotEncryptedSecret: null,
+  };
+}
+
+function perpListBody(items: Array<{ symbol: string; side: string; size: string }>) {
+  return { retCode: 0, retMsg: "OK", result: { list: items } };
+}
+
+function walletBody(coins: Array<{ coin: string; walletBalance: string }>) {
+  return { retCode: 0, retMsg: "OK", result: { list: [{ coin: coins }] } };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("baseAssetOf", () => {
+  it("strips USDT/USDC/USD suffixes; passes through unknown", () => {
+    expect(baseAssetOf("BTCUSDT")).toBe("BTC");
+    expect(baseAssetOf("ETHUSDC")).toBe("ETH");
+    expect(baseAssetOf("XRPUSD")).toBe("XRP");
+    expect(baseAssetOf("DOGEEUR")).toBe("DOGEEUR");
+  });
+});
+
+describe("reconcileBalances — dual-key path", () => {
+  it("signs perp call with linear key + spot call with spot key; classifies balanced hedge", async () => {
+    const calls = installFetch({
+      perp: perpListBody([{ symbol: "BTCUSDT", side: "Sell", size: "1.0" }]),
+      spot: walletBody([{ coin: "BTC", walletBalance: "1.0" }]),
+    });
+
+    const out = await reconcileBalances(dualKeyCreds(), ["BTCUSDT"]);
+
+    expect(out.spotKeyAvailable).toBe(true);
+
+    // Perp call signed with linear key; spot call with spot key.
+    const perpCall = calls.find((c) => c.url.includes("/v5/position/list"))!;
+    const spotCall = calls.find((c) => c.url.includes("/v5/account/wallet-balance"))!;
+    expect(perpCall.apiKeyHeader).toBe("linear-key");
+    expect(spotCall.apiKeyHeader).toBe("spot-key");
+
+    // Maps populated.
+    expect(out.perp.get("BTCUSDT")).toBe(-1.0); // Sell ⇒ negative
+    expect(out.spot.get("BTC")).toBe(1.0);
+
+    // Hedge status: -1 perp + 1 spot ⇒ balanced.
+    expect(out.hedgeStatus).toHaveLength(1);
+    expect(out.hedgeStatus[0]).toMatchObject({
+      symbol: "BTCUSDT",
+      perpQty: -1.0,
+      spotQty: 1.0,
+      status: "balanced",
+      delta: 0,
+    });
+  });
+
+  it("flags imbalanced hedge when |perp| - spot exceeds tolerance", async () => {
+    installFetch({
+      perp: perpListBody([{ symbol: "BTCUSDT", side: "Sell", size: "1.0" }]),
+      spot: walletBody([{ coin: "BTC", walletBalance: "0.5" }]),
+    });
+
+    const out = await reconcileBalances(dualKeyCreds(), ["BTCUSDT"]);
+
+    expect(out.hedgeStatus[0]).toMatchObject({
+      symbol: "BTCUSDT",
+      perpQty: -1.0,
+      spotQty: 0.5,
+      status: "imbalanced",
+      delta: 0.5,
+    });
+  });
+});
+
+describe("reconcileBalances — single-key fallback", () => {
+  it("signs both calls with linear key when spot creds are NULL; warns operator", async () => {
+    const calls = installFetch({
+      perp: perpListBody([{ symbol: "BTCUSDT", side: "Sell", size: "0.5" }]),
+      spot: walletBody([{ coin: "BTC", walletBalance: "0.5" }]),
+    });
+
+    const out = await reconcileBalances(singleKeyCreds(), ["BTCUSDT"]);
+
+    expect(out.spotKeyAvailable).toBe(false);
+    expect(calls).toHaveLength(2);
+    expect(calls[0].apiKeyHeader).toBe("linear-key");
+    expect(calls[1].apiKeyHeader).toBe("linear-key");
+    expect(out.hedgeStatus[0].status).toBe("balanced");
+  });
+});
+
+describe("reconcileBalances — classification branches", () => {
+  it("perp_only — perp open, no matching spot holding", async () => {
+    installFetch({
+      perp: perpListBody([{ symbol: "BTCUSDT", side: "Sell", size: "1.0" }]),
+      spot: walletBody([]), // no BTC holding
+    });
+
+    const out = await reconcileBalances(dualKeyCreds(), ["BTCUSDT"]);
+
+    expect(out.hedgeStatus[0]).toMatchObject({
+      symbol: "BTCUSDT",
+      perpQty: -1.0,
+      spotQty: 0,
+      status: "perp_only",
+    });
+    expect(out.hedgeStatus[0].delta).toBeUndefined();
+  });
+
+  it("spot_only — spot held, no matching perp position", async () => {
+    installFetch({
+      perp: perpListBody([]),
+      spot: walletBody([{ coin: "ETH", walletBalance: "10" }]),
+    });
+
+    const out = await reconcileBalances(dualKeyCreds(), ["ETHUSDT"]);
+
+    expect(out.hedgeStatus[0]).toMatchObject({
+      symbol: "ETHUSDT",
+      perpQty: 0,
+      spotQty: 10,
+      status: "spot_only",
+    });
+  });
+
+  it("flat — neither side holds the symbol", async () => {
+    installFetch({
+      perp: perpListBody([]),
+      spot: walletBody([{ coin: "USDT", walletBalance: "1000" }]),
+    });
+
+    const out = await reconcileBalances(dualKeyCreds(), ["BTCUSDT"]);
+
+    expect(out.hedgeStatus[0].status).toBe("flat");
+    expect(out.hedgeStatus[0].perpQty).toBe(0);
+    expect(out.hedgeStatus[0].spotQty).toBe(0);
+  });
+});
+
+describe("reconcileBalances — error surface", () => {
+  it("throws BalanceReconcilerError {cause:'api'} when Bybit returns non-zero retCode", async () => {
+    installFetch({
+      perp: { retCode: 10003, retMsg: "Invalid signature", result: { list: [] } },
+      spot: walletBody([]),
+    });
+
+    await expect(reconcileBalances(dualKeyCreds(), ["BTCUSDT"]))
+      .rejects.toMatchObject({
+        name: "BalanceReconcilerError",
+        cause: "api",
+        retCode: 10003,
+      });
+  });
+
+  it("throws BalanceReconcilerError {cause:'http'} on non-2xx", async () => {
+    installFetch({
+      perp: perpListBody([]),
+      spot: { whatever: true },
+      spotStatus: 503,
+    });
+
+    await expect(reconcileBalances(dualKeyCreds(), ["BTCUSDT"]))
+      .rejects.toMatchObject({
+        name: "BalanceReconcilerError",
+        cause: "http",
+        statusCode: 503,
+      });
+  });
+});


### PR DESCRIPTION
## Summary

- `ExchangeConnection` gets three nullable columns — `spotApiKey`, `spotEncryptedSecret`, `spotKeyLabel` — so funding-arb (`docs/55`) can hold a dedicated key/secret pair for the spot wallet alongside the existing linear pair.
- Migration is purely additive (`ALTER TABLE … ADD COLUMN`), existing rows get NULL → single-key fallback.
- New `apps/api/src/lib/exchange/balanceReconciler.ts` calls `/v5/position/list?category=linear` and `/v5/account/wallet-balance?accountType=UNIFIED` in parallel, returns `Map<symbol, signedQty>` + `Map<baseAsset, qty>` and a per-symbol classification (`flat | perp_only | spot_only | balanced | imbalanced`, tolerance 0.5%).
- Single-key fallback: when `spotApiKey` / `spotEncryptedSecret` are NULL the spot call is signed with the linear creds — Bybit unified-account scope behaviour. A warning is logged so operators know.
- Errors funnel through `BalanceReconcilerError { cause: 'http' | 'api' | 'parse' }` so callers branch on the discriminator instead of parsing strings.
- 9 unit tests covering dual-key signing, single-key fallback, all five classification branches, and HTTP / API error surface.
- No consumers wired yet — `hedgeBotWorker` (55-T4) is the next step.

## Naming note

User brief proposed `spotApiKeyEncrypted` / `spotApiSecretEncrypted`. I followed the existing `ExchangeConnection` convention instead (`apiKey` plaintext + `encryptedSecret` encrypted via `decryptWithFallback`) — keeps the model internally consistent and the encryption pattern unchanged.

## Test plan

- [x] `pnpm --filter @botmarketplace/api exec prisma generate` ✓
- [x] `pnpm --filter @botmarketplace/api exec tsc --noEmit` ✓ (EXIT 0)
- [x] `pnpm --filter @botmarketplace/web exec tsc --noEmit` ✓ (EXIT 0)
- [x] `pnpm --filter @botmarketplace/api test` ✓ (2054/2054 passed, including new 9 reconciler tests)
- [ ] CI green


---
_Generated by [Claude Code](https://claude.ai/code/session_012z5NupTCzRjLgFvW7RDVEx)_