### PR TITLE
feat(funding-arb): hedgeBotWorker skeleton + state machine (55-T4)

### DIFF
--- a/apps/api/src/lib/hedgeBotWorker.ts
+++ b/apps/api/src/lib/hedgeBotWorker.ts
@@ -1,0 +1,430 @@
+/**
+ * Funding-arbitrage runtime skeleton (docs/55-T4).
+ *
+ * A dedicated worker that runs alongside `botWorker.ts` (it does NOT replace
+ * or compete with it) and progresses each `HedgePosition` through the
+ * funding-arb state machine on a 60-second cadence.
+ *
+ * Stage names (this file)   ↔ persisted `HedgeStatus` (Prisma):
+ *   PENDING       ↔ PLANNED   — hedge created, awaiting funding window.
+ *   ENTRY_PLACED  ↔ OPENING   — entry BotIntents emitted, awaiting fills.
+ *   BOTH_FILLED   ↔ OPEN      — both entry legs FILLED; transient → ACTIVE.
+ *   ACTIVE        ↔ OPEN      — hedge live, awaiting funding payment.
+ *   EXIT_PLACED   ↔ CLOSING   — exit BotIntents emitted, awaiting fills.
+ *   CLOSED        ↔ CLOSED    — both exit legs FILLED.
+ *   ERRORED       ↔ FAILED    — partial fill / unrecoverable error.
+ *
+ * What this skeleton DOES today:
+ *   * Finds eligible hedges (status ∈ PLANNED/OPENING/OPEN/CLOSING).
+ *   * Reads input signals (`fundingWindowOpen`, `fundingPaymentReceived`)
+ *     from the caller and decides the next stage.
+ *   * Emits `BotIntent` rows with `metaJson.category = "spot" | "linear"` —
+ *     funding-arb's two-leg pattern, mirroring `routes/hedges.ts`.
+ *   * Advances persisted `HedgeStatus` based on `BotIntent.state` of the
+ *     emitted legs (FILLED on both ⇒ progress; CANCELLED/FAILED on either
+ *     ⇒ ERRORED).
+ *   * Isolates per-hedge errors: one bad hedge does not crash the loop.
+ *   * Boots only when `ENABLE_HEDGE_WORKER === "true"` is set, so the
+ *     mainline `botWorker.ts` runtime is unaffected by this skeleton.
+ *
+ * What this skeleton DOES NOT do (deferred to 55-T2):
+ *   * Place actual Bybit orders. The fills used to drive the state machine
+ *     come from `BotIntent.state` written by the existing `intentExecutor`
+ *     pipeline — once 55-T2 wires `bybitOrder.ts` with category dispatch,
+ *     the spot leg will execute end-to-end with no changes here.
+ *   * Run a Bybit balance reconciliation. 55-T5 introduced
+ *     `balanceReconciler.ts` for that; this skeleton intentionally does
+ *     not call it yet to keep the diff minimal.
+ *   * Resolve the funding window itself. Callers pass that signal in via
+ *     `HedgeAdvanceInput`; the live wiring (Bybit funding scanner) lands
+ *     with 55-T3 / 55-T4 follow-up.
+ */
+
+import { randomUUID } from "node:crypto";
+import { prisma } from "./prisma.js";
+import { logger } from "./logger.js";
+import { classifyExecutionError } from "./errorClassifier.js";
+
+const log = logger.child({ module: "hedgeBotWorker" });
+
+const DEFAULT_TICK_INTERVAL_MS = 60_000;
+
+function getTickIntervalMs(): number {
+  const raw = parseInt(process.env.HEDGE_WORKER_TICK_MS ?? "", 10);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_TICK_INTERVAL_MS;
+}
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type HedgeStage =
+  | "PENDING"
+  | "ENTRY_PLACED"
+  | "BOTH_FILLED"
+  | "ACTIVE"
+  | "EXIT_PLACED"
+  | "CLOSED"
+  | "ERRORED";
+
+/** `HedgeStatus` enum values — duplicated here to avoid importing the
+ *  generated Prisma enum object (keeps the skeleton agnostic of the
+ *  generator-output layout). */
+export type PersistedHedgeStatus =
+  | "PLANNED"
+  | "OPENING"
+  | "OPEN"
+  | "CLOSING"
+  | "CLOSED"
+  | "FAILED";
+
+const STAGE_TO_STATUS: Record<HedgeStage, PersistedHedgeStatus> = {
+  PENDING: "PLANNED",
+  ENTRY_PLACED: "OPENING",
+  BOTH_FILLED: "OPEN",
+  ACTIVE: "OPEN",
+  EXIT_PLACED: "CLOSING",
+  CLOSED: "CLOSED",
+  ERRORED: "FAILED",
+};
+
+/** Inputs the caller (or test) supplies for one `advanceHedge` call. */
+export interface HedgeAdvanceInput {
+  /** True when the upstream funding scanner says we're inside the entry
+   *  window for this hedge — drives PENDING → ENTRY_PLACED. */
+  fundingWindowOpen?: boolean;
+  /** True when the Bybit funding-payment ledger shows the payment landed —
+   *  drives ACTIVE → EXIT_PLACED. */
+  fundingPaymentReceived?: boolean;
+  /** Quantity to size each leg with on entry (base units). */
+  entryQty?: number;
+  /** Quantity to size each leg with on exit (base units). Defaults to
+   *  whatever was used on entry. */
+  exitQty?: number;
+}
+
+export interface HedgeAdvanceResult {
+  hedgeId: string;
+  /** Stage the hedge was in BEFORE this tick. */
+  fromStage: HedgeStage;
+  /** Stage the hedge is in AFTER this tick. */
+  toStage: HedgeStage;
+  /** True if `toStage !== fromStage`. */
+  changed: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Stage helpers
+// ---------------------------------------------------------------------------
+
+/** Map persisted `HedgeStatus` → stage label.
+ *
+ *  `OPEN` maps to `ACTIVE` here — `BOTH_FILLED` is a transient intra-tick
+ *  marker that callers see in the return value of a tick that just
+ *  advanced from ENTRY_PLACED. */
+function statusToStage(status: PersistedHedgeStatus): HedgeStage {
+  switch (status) {
+    case "PLANNED": return "PENDING";
+    case "OPENING": return "ENTRY_PLACED";
+    case "OPEN":    return "ACTIVE";
+    case "CLOSING": return "EXIT_PLACED";
+    case "CLOSED":  return "CLOSED";
+    case "FAILED":  return "ERRORED";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Intent emission
+// ---------------------------------------------------------------------------
+
+interface EmitArgs {
+  hedgeId: string;
+  botRunId: string;
+  symbol: string;
+  qty: number;
+  /** "ENTRY" emits perp short + spot long; "EXIT" emits perp close + spot sell. */
+  type: "ENTRY" | "EXIT";
+}
+
+/** Persist two `BotIntent` rows + bump `HedgeStatus`. Mirrors the
+ *  hedges-route `/execute` and `/exit` payload shape so 55-T2 can wire
+ *  real execution without touching this code. */
+async function emitHedgeIntents(args: EmitArgs): Promise<void> {
+  const isEntry = args.type === "ENTRY";
+  const spotIntentId = `hedge-${args.hedgeId}-spot-${isEntry ? "entry" : "exit"}`;
+  const perpIntentId = `hedge-${args.hedgeId}-perp-${isEntry ? "entry" : "exit"}`;
+
+  const nextStatus: PersistedHedgeStatus = isEntry ? "OPENING" : "CLOSING";
+
+  await prisma.$transaction([
+    prisma.botIntent.create({
+      data: {
+        botRunId: args.botRunId,
+        intentId: spotIntentId,
+        orderLinkId: randomUUID(),
+        type: args.type,
+        state: "PENDING",
+        side: isEntry ? "BUY" : "SELL",
+        qty: args.qty,
+        metaJson: {
+          hedgeId: args.hedgeId,
+          legSide: isEntry ? "SPOT_BUY" : "SPOT_SELL",
+          // TODO(55-T2): wire bybitOrder.ts with category dispatch — the
+          // spot leg is the one this category routing unlocks.
+          category: "spot",
+        },
+      },
+    }),
+    prisma.botIntent.create({
+      data: {
+        botRunId: args.botRunId,
+        intentId: perpIntentId,
+        orderLinkId: randomUUID(),
+        type: args.type,
+        state: "PENDING",
+        side: isEntry ? "SELL" : "BUY",
+        qty: args.qty,
+        metaJson: {
+          hedgeId: args.hedgeId,
+          legSide: isEntry ? "PERP_SHORT" : "PERP_CLOSE",
+          category: "linear",
+        },
+      },
+    }),
+    prisma.hedgePosition.update({
+      where: { id: args.hedgeId },
+      data: { status: nextStatus },
+    }),
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+// Intent state inspection
+// ---------------------------------------------------------------------------
+
+interface LegStateSummary {
+  /** Both legs FILLED. */
+  bothFilled: boolean;
+  /** Any leg in a terminal failure state (CANCELLED | FAILED). */
+  anyTerminalFailure: boolean;
+  /** Total intents found for this hedge + stage. */
+  count: number;
+}
+
+async function summariseLegStates(
+  hedgeId: string,
+  botRunId: string,
+  type: "ENTRY" | "EXIT",
+): Promise<LegStateSummary> {
+  const intents = await prisma.botIntent.findMany({
+    where: { botRunId, type },
+    select: { state: true, metaJson: true, intentId: true },
+  });
+  // Filter to the two intents created for this hedge — `metaJson.hedgeId`
+  // is the canonical link.
+  const matching = intents.filter((i) => {
+    const meta = i.metaJson as { hedgeId?: string } | null;
+    return meta?.hedgeId === hedgeId;
+  });
+  const filled = matching.filter((i) => i.state === "FILLED").length;
+  const failed = matching.filter((i) => i.state === "CANCELLED" || i.state === "FAILED").length;
+  return {
+    bothFilled: matching.length === 2 && filled === 2,
+    anyTerminalFailure: failed > 0,
+    count: matching.length,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Single-hedge advance
+// ---------------------------------------------------------------------------
+
+/**
+ * Advance one hedge by at most one stage based on persisted state +
+ * caller-provided signals. Pure-ish: every side-effect goes through
+ * `prisma`, so tests mock that surface and exercise the state machine
+ * without standing up a database.
+ */
+export async function advanceHedge(
+  hedgeId: string,
+  input: HedgeAdvanceInput = {},
+): Promise<HedgeAdvanceResult> {
+  const hedge = await prisma.hedgePosition.findUnique({
+    where: { id: hedgeId },
+  });
+  if (!hedge) {
+    log.warn({ hedgeId }, "advanceHedge: hedge not found");
+    return { hedgeId, fromStage: "ERRORED", toStage: "ERRORED", changed: false };
+  }
+
+  const fromStage = statusToStage(hedge.status as PersistedHedgeStatus);
+
+  switch (hedge.status as PersistedHedgeStatus) {
+    case "PLANNED": {
+      if (!input.fundingWindowOpen) {
+        return { hedgeId, fromStage, toStage: fromStage, changed: false };
+      }
+      const qty = input.entryQty ?? 0;
+      if (qty <= 0) {
+        log.warn({ hedgeId, qty }, "PENDING → ENTRY_PLACED skipped: entryQty must be > 0");
+        return { hedgeId, fromStage, toStage: fromStage, changed: false };
+      }
+      await emitHedgeIntents({
+        hedgeId,
+        botRunId: hedge.botRunId,
+        symbol: hedge.symbol,
+        qty,
+        type: "ENTRY",
+      });
+      log.info({ hedgeId, qty }, "PENDING → ENTRY_PLACED");
+      return { hedgeId, fromStage, toStage: "ENTRY_PLACED", changed: true };
+    }
+
+    case "OPENING": {
+      const summary = await summariseLegStates(hedgeId, hedge.botRunId, "ENTRY");
+      if (summary.anyTerminalFailure) {
+        await prisma.hedgePosition.update({
+          where: { id: hedgeId },
+          data: { status: STAGE_TO_STATUS.ERRORED },
+        });
+        log.error({ hedgeId, summary }, "ENTRY_PLACED → ERRORED (partial fill / failure)");
+        return { hedgeId, fromStage, toStage: "ERRORED", changed: true };
+      }
+      if (summary.bothFilled) {
+        await prisma.hedgePosition.update({
+          where: { id: hedgeId },
+          data: { status: STAGE_TO_STATUS.ACTIVE },
+        });
+        log.info({ hedgeId }, "ENTRY_PLACED → BOTH_FILLED → ACTIVE");
+        return { hedgeId, fromStage, toStage: "ACTIVE", changed: true };
+      }
+      return { hedgeId, fromStage, toStage: fromStage, changed: false };
+    }
+
+    case "OPEN": {
+      if (!input.fundingPaymentReceived) {
+        return { hedgeId, fromStage, toStage: fromStage, changed: false };
+      }
+      const exitQty = input.exitQty ?? input.entryQty ?? 0;
+      if (exitQty <= 0) {
+        log.warn({ hedgeId, exitQty }, "ACTIVE → EXIT_PLACED skipped: exitQty must be > 0");
+        return { hedgeId, fromStage, toStage: fromStage, changed: false };
+      }
+      await emitHedgeIntents({
+        hedgeId,
+        botRunId: hedge.botRunId,
+        symbol: hedge.symbol,
+        qty: exitQty,
+        type: "EXIT",
+      });
+      log.info({ hedgeId, exitQty }, "ACTIVE → EXIT_PLACED");
+      return { hedgeId, fromStage, toStage: "EXIT_PLACED", changed: true };
+    }
+
+    case "CLOSING": {
+      const summary = await summariseLegStates(hedgeId, hedge.botRunId, "EXIT");
+      if (summary.anyTerminalFailure) {
+        await prisma.hedgePosition.update({
+          where: { id: hedgeId },
+          data: { status: STAGE_TO_STATUS.ERRORED },
+        });
+        log.error({ hedgeId, summary }, "EXIT_PLACED → ERRORED (exit fill failure)");
+        return { hedgeId, fromStage, toStage: "ERRORED", changed: true };
+      }
+      if (summary.bothFilled) {
+        await prisma.hedgePosition.update({
+          where: { id: hedgeId },
+          data: { status: STAGE_TO_STATUS.CLOSED, closedAt: new Date() },
+        });
+        log.info({ hedgeId }, "EXIT_PLACED → CLOSED");
+        return { hedgeId, fromStage, toStage: "CLOSED", changed: true };
+      }
+      return { hedgeId, fromStage, toStage: fromStage, changed: false };
+    }
+
+    case "CLOSED":
+    case "FAILED":
+      return { hedgeId, fromStage, toStage: fromStage, changed: false };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tick loop
+// ---------------------------------------------------------------------------
+
+/** One pass: advance every non-terminal hedge. Per-hedge errors are
+ *  logged + classified but NEVER bubble — funding-arb errors must not
+ *  take down the worker. */
+export async function tickHedgeBotWorker(
+  inputResolver?: (hedgeId: string) => HedgeAdvanceInput | Promise<HedgeAdvanceInput>,
+): Promise<HedgeAdvanceResult[]> {
+  const candidates = await prisma.hedgePosition.findMany({
+    where: { status: { in: ["PLANNED", "OPENING", "OPEN", "CLOSING"] } },
+    select: { id: true },
+  });
+
+  const out: HedgeAdvanceResult[] = [];
+  for (const c of candidates) {
+    try {
+      const input = inputResolver ? await inputResolver(c.id) : {};
+      const res = await advanceHedge(c.id, input);
+      out.push(res);
+    } catch (err) {
+      const classification = classifyExecutionError(err);
+      log.error({ err, hedgeId: c.id, classification }, "hedge advance failed (isolated)");
+      // Swallow — funding-arb tick must keep ticking for other hedges.
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Boot — env-gated, intentionally NOT wired into server.ts yet
+// ---------------------------------------------------------------------------
+
+interface HedgeWorkerHandle {
+  stop(): Promise<void>;
+}
+
+/**
+ * Boot the funding-arb runtime. Only starts a tick timer when
+ * `ENABLE_HEDGE_WORKER === "true"`; otherwise returns a no-op handle so
+ * the call site is safe to add to `server.ts` without changing default
+ * behaviour. The mainline `botWorker.ts` is untouched by this skeleton.
+ */
+export function startHedgeBotWorker(
+  inputResolver?: (hedgeId: string) => HedgeAdvanceInput | Promise<HedgeAdvanceInput>,
+): HedgeWorkerHandle {
+  if (process.env.ENABLE_HEDGE_WORKER !== "true") {
+    log.info("ENABLE_HEDGE_WORKER not set — hedgeBotWorker skipped (default off)");
+    return { stop: async () => {} };
+  }
+
+  const tickMs = getTickIntervalMs();
+  log.info({ tickMs }, "hedgeBotWorker started");
+
+  let stopped = false;
+  let inFlight: Promise<unknown> | null = null;
+
+  async function wrappedTick() {
+    if (stopped || inFlight) return;
+    inFlight = tickHedgeBotWorker(inputResolver).catch((err) => {
+      log.error({ err }, "tickHedgeBotWorker top-level failure");
+    });
+    await inFlight;
+    inFlight = null;
+  }
+
+  const timer = setInterval(wrappedTick, tickMs);
+  // Run once immediately so the first hedge doesn't wait a full tick.
+  wrappedTick();
+
+  return {
+    stop: async () => {
+      stopped = true;
+      clearInterval(timer);
+      if (inFlight) await inFlight;
+      log.info("hedgeBotWorker stopped");
+    },
+  };
+}

--- a/apps/api/tests/lib/hedgeBotWorker.test.ts
+++ b/apps/api/tests/lib/hedgeBotWorker.test.ts
@@ -1,0 +1,350 @@
+/**
+ * hedgeBotWorker — unit coverage (docs/55-T4).
+ *
+ * Mocks `prisma` + `errorClassifier` so the state machine can be
+ * exercised without a database. Each test fixes a `HedgePosition`
+ * status + a small set of `BotIntent` rows, calls `advanceHedge`,
+ * and asserts on the return value AND the prisma writes the worker
+ * issued.
+ *
+ * Coverage:
+ *   1. PENDING + fundingWindowOpen ⇒ ENTRY_PLACED  (two BotIntents created
+ *      with category="spot" + "linear", HedgeStatus → OPENING).
+ *   2. PENDING + window closed     ⇒ no-op (hedge stays PLANNED).
+ *   3. ENTRY_PLACED + both FILLED  ⇒ ACTIVE (status → OPEN).
+ *   4. ENTRY_PLACED + one FAILED   ⇒ ERRORED (status → FAILED).
+ *   5. ACTIVE + funding payment    ⇒ EXIT_PLACED (two BotIntents, status → CLOSING).
+ *   6. EXIT_PLACED + both FILLED   ⇒ CLOSED (status → CLOSED + closedAt set).
+ *   7. tickHedgeBotWorker isolates a per-hedge throw (other hedges still advance).
+ *   8. startHedgeBotWorker honours ENABLE_HEDGE_WORKER off-by-default.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks (must come before importing the module under test)
+// ---------------------------------------------------------------------------
+
+interface FakeHedge {
+  id: string;
+  botRunId: string;
+  symbol: string;
+  status: "PLANNED" | "OPENING" | "OPEN" | "CLOSING" | "CLOSED" | "FAILED";
+}
+
+interface FakeIntent {
+  botRunId: string;
+  type: "ENTRY" | "EXIT";
+  state: "PENDING" | "PLACED" | "PARTIALLY_FILLED" | "FILLED" | "CANCELLED" | "FAILED";
+  metaJson: { hedgeId: string; legSide: string; category: string };
+  intentId: string;
+}
+
+const hedgesById = new Map<string, FakeHedge>();
+const intents: FakeIntent[] = [];
+const created: Array<Partial<FakeIntent> & { qty?: number; orderLinkId?: string; side?: string }> = [];
+const updates: Array<{ id: string; data: Record<string, unknown> }> = [];
+
+function resetState() {
+  hedgesById.clear();
+  intents.length = 0;
+  created.length = 0;
+  updates.length = 0;
+}
+
+vi.mock("../../src/lib/prisma.js", () => ({
+  prisma: {
+    hedgePosition: {
+      findUnique: vi.fn(async ({ where }: { where: { id: string } }) => {
+        return hedgesById.get(where.id) ?? null;
+      }),
+      findMany: vi.fn(async ({ where }: { where: { status: { in: string[] } } }) => {
+        const statuses = new Set(where.status.in);
+        return [...hedgesById.values()]
+          .filter((h) => statuses.has(h.status))
+          .map((h) => ({ id: h.id }));
+      }),
+      update: vi.fn(async ({ where, data }: { where: { id: string }; data: Record<string, unknown> }) => {
+        const h = hedgesById.get(where.id);
+        if (h) {
+          if (typeof data.status === "string") h.status = data.status as FakeHedge["status"];
+        }
+        updates.push({ id: where.id, data });
+        return h;
+      }),
+    },
+    botIntent: {
+      create: vi.fn(async ({ data }: { data: Record<string, unknown> }) => {
+        created.push(data as never);
+        // Reflect into the intent store so subsequent findMany sees it
+        intents.push({
+          botRunId: data.botRunId as string,
+          type: data.type as FakeIntent["type"],
+          state: data.state as FakeIntent["state"],
+          metaJson: data.metaJson as FakeIntent["metaJson"],
+          intentId: data.intentId as string,
+        });
+        return data;
+      }),
+      findMany: vi.fn(async ({ where }: { where: { botRunId: string; type: string } }) => {
+        return intents
+          .filter((i) => i.botRunId === where.botRunId && i.type === where.type)
+          .map((i) => ({ state: i.state, metaJson: i.metaJson, intentId: i.intentId }));
+      }),
+    },
+    $transaction: vi.fn(async (ops: unknown[]) => {
+      // Each op is already a Promise (the .create / .update calls have
+      // executed eagerly because our mocks resolve the data immediately).
+      return Promise.all(ops as Promise<unknown>[]);
+    }),
+  },
+}));
+
+vi.mock("../../src/lib/logger.js", () => ({
+  logger: {
+    child: () => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock("../../src/lib/errorClassifier.js", () => ({
+  classifyExecutionError: () => ({ errorClass: "unknown", retryable: false, reason: "test-stub" }),
+}));
+
+import {
+  advanceHedge,
+  startHedgeBotWorker,
+  tickHedgeBotWorker,
+  type HedgeStage,
+} from "../../src/lib/hedgeBotWorker.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function seedHedge(overrides: Partial<FakeHedge> & { id: string }): FakeHedge {
+  const h: FakeHedge = {
+    id: overrides.id,
+    botRunId: overrides.botRunId ?? `run-${overrides.id}`,
+    symbol: overrides.symbol ?? "BTCUSDT",
+    status: overrides.status ?? "PLANNED",
+  };
+  hedgesById.set(h.id, h);
+  return h;
+}
+
+function seedIntent(args: {
+  hedgeId: string;
+  botRunId: string;
+  type: "ENTRY" | "EXIT";
+  legSide: string;
+  category: "spot" | "linear";
+  state: FakeIntent["state"];
+}): void {
+  intents.push({
+    botRunId: args.botRunId,
+    type: args.type,
+    state: args.state,
+    metaJson: { hedgeId: args.hedgeId, legSide: args.legSide, category: args.category },
+    intentId: `seed-${args.hedgeId}-${args.legSide}-${args.type}`,
+  });
+}
+
+beforeEach(() => {
+  resetState();
+});
+
+afterEach(() => {
+  delete process.env.ENABLE_HEDGE_WORKER;
+});
+
+// ---------------------------------------------------------------------------
+// 1. PENDING → ENTRY_PLACED on funding window
+// ---------------------------------------------------------------------------
+
+describe("PENDING → ENTRY_PLACED", () => {
+  it("emits two BotIntents (spot + linear) and bumps status to OPENING", async () => {
+    seedHedge({ id: "h1" });
+
+    const res = await advanceHedge("h1", { fundingWindowOpen: true, entryQty: 1.0 });
+
+    expect(res).toMatchObject({
+      hedgeId: "h1",
+      fromStage: "PENDING",
+      toStage: "ENTRY_PLACED",
+      changed: true,
+    });
+
+    expect(created).toHaveLength(2);
+    const categories = created.map((c) => (c.metaJson as { category: string }).category).sort();
+    expect(categories).toEqual(["linear", "spot"]);
+
+    // Both intents are ENTRY type, qty = 1.0
+    expect(created.every((c) => c.type === "ENTRY")).toBe(true);
+    expect(created.every((c) => c.qty === 1.0)).toBe(true);
+
+    // Spot leg buys, perp leg sells
+    const spotLeg = created.find((c) => (c.metaJson as { category: string }).category === "spot")!;
+    const perpLeg = created.find((c) => (c.metaJson as { category: string }).category === "linear")!;
+    expect(spotLeg.side).toBe("BUY");
+    expect(perpLeg.side).toBe("SELL");
+
+    // HedgeStatus advanced
+    expect(hedgesById.get("h1")?.status).toBe("OPENING");
+    expect(updates.some((u) => u.id === "h1" && u.data.status === "OPENING")).toBe(true);
+  });
+
+  it("no-ops when funding window is closed", async () => {
+    seedHedge({ id: "h2" });
+
+    const res = await advanceHedge("h2", { fundingWindowOpen: false, entryQty: 1.0 });
+
+    expect(res).toMatchObject({ fromStage: "PENDING", toStage: "PENDING", changed: false });
+    expect(created).toHaveLength(0);
+    expect(hedgesById.get("h2")?.status).toBe("PLANNED");
+  });
+
+  it("no-ops when entryQty is missing or non-positive", async () => {
+    seedHedge({ id: "h3" });
+
+    const res = await advanceHedge("h3", { fundingWindowOpen: true, entryQty: 0 });
+
+    expect(res.changed).toBe(false);
+    expect(created).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. ENTRY_PLACED → ACTIVE / ERRORED
+// ---------------------------------------------------------------------------
+
+describe("ENTRY_PLACED → ACTIVE / ERRORED", () => {
+  it("transitions ENTRY_PLACED → ACTIVE when both entry intents are FILLED", async () => {
+    seedHedge({ id: "h4", status: "OPENING" });
+    seedIntent({ hedgeId: "h4", botRunId: "run-h4", type: "ENTRY", legSide: "SPOT_BUY",   category: "spot",   state: "FILLED" });
+    seedIntent({ hedgeId: "h4", botRunId: "run-h4", type: "ENTRY", legSide: "PERP_SHORT", category: "linear", state: "FILLED" });
+
+    const res = await advanceHedge("h4");
+
+    expect(res.toStage).toBe<HedgeStage>("ACTIVE");
+    expect(hedgesById.get("h4")?.status).toBe("OPEN");
+  });
+
+  it("escalates ENTRY_PLACED → ERRORED when one leg is FAILED (partial fill)", async () => {
+    seedHedge({ id: "h5", status: "OPENING" });
+    seedIntent({ hedgeId: "h5", botRunId: "run-h5", type: "ENTRY", legSide: "SPOT_BUY",   category: "spot",   state: "FILLED" });
+    seedIntent({ hedgeId: "h5", botRunId: "run-h5", type: "ENTRY", legSide: "PERP_SHORT", category: "linear", state: "FAILED" });
+
+    const res = await advanceHedge("h5");
+
+    expect(res.toStage).toBe<HedgeStage>("ERRORED");
+    expect(hedgesById.get("h5")?.status).toBe("FAILED");
+  });
+
+  it("stays in ENTRY_PLACED while a leg is still PENDING", async () => {
+    seedHedge({ id: "h6", status: "OPENING" });
+    seedIntent({ hedgeId: "h6", botRunId: "run-h6", type: "ENTRY", legSide: "SPOT_BUY",   category: "spot",   state: "FILLED" });
+    seedIntent({ hedgeId: "h6", botRunId: "run-h6", type: "ENTRY", legSide: "PERP_SHORT", category: "linear", state: "PENDING" });
+
+    const res = await advanceHedge("h6");
+
+    expect(res.changed).toBe(false);
+    expect(res.toStage).toBe<HedgeStage>("ENTRY_PLACED");
+    expect(hedgesById.get("h6")?.status).toBe("OPENING");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. ACTIVE → EXIT_PLACED
+// ---------------------------------------------------------------------------
+
+describe("ACTIVE → EXIT_PLACED", () => {
+  it("emits exit BotIntents and sets HedgeStatus to CLOSING when funding payment is received", async () => {
+    seedHedge({ id: "h7", status: "OPEN" });
+
+    const res = await advanceHedge("h7", { fundingPaymentReceived: true, exitQty: 0.5 });
+
+    expect(res.toStage).toBe<HedgeStage>("EXIT_PLACED");
+    expect(hedgesById.get("h7")?.status).toBe("CLOSING");
+
+    expect(created).toHaveLength(2);
+    expect(created.every((c) => c.type === "EXIT")).toBe(true);
+    const spotLeg = created.find((c) => (c.metaJson as { category: string }).category === "spot")!;
+    const perpLeg = created.find((c) => (c.metaJson as { category: string }).category === "linear")!;
+    expect(spotLeg.side).toBe("SELL");
+    expect(perpLeg.side).toBe("BUY");
+    expect(spotLeg.qty).toBe(0.5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. EXIT_PLACED → CLOSED
+// ---------------------------------------------------------------------------
+
+describe("EXIT_PLACED → CLOSED", () => {
+  it("transitions to CLOSED + closedAt when both exit legs FILLED", async () => {
+    seedHedge({ id: "h8", status: "CLOSING" });
+    seedIntent({ hedgeId: "h8", botRunId: "run-h8", type: "EXIT", legSide: "SPOT_SELL",  category: "spot",   state: "FILLED" });
+    seedIntent({ hedgeId: "h8", botRunId: "run-h8", type: "EXIT", legSide: "PERP_CLOSE", category: "linear", state: "FILLED" });
+
+    const res = await advanceHedge("h8");
+
+    expect(res.toStage).toBe<HedgeStage>("CLOSED");
+    expect(hedgesById.get("h8")?.status).toBe("CLOSED");
+    const closedUpdate = updates.find((u) => u.id === "h8" && u.data.status === "CLOSED");
+    expect(closedUpdate?.data.closedAt).toBeInstanceOf(Date);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. tick — error isolation across hedges
+// ---------------------------------------------------------------------------
+
+describe("tickHedgeBotWorker", () => {
+  it("isolates a per-hedge throw — other hedges still advance", async () => {
+    seedHedge({ id: "good", status: "PLANNED" });
+    seedHedge({ id: "bad",  status: "PLANNED" });
+
+    const res = await tickHedgeBotWorker((hedgeId) => {
+      if (hedgeId === "bad") {
+        throw new Error("synthetic");
+      }
+      return { fundingWindowOpen: true, entryQty: 1.0 };
+    });
+
+    // Only the good hedge produced a result; the bad one was swallowed.
+    expect(res).toHaveLength(1);
+    expect(res[0]).toMatchObject({ hedgeId: "good", toStage: "ENTRY_PLACED" });
+
+    // good advanced; bad stayed PLANNED.
+    expect(hedgesById.get("good")?.status).toBe("OPENING");
+    expect(hedgesById.get("bad")?.status).toBe("PLANNED");
+  });
+
+  it("returns empty when there are no eligible hedges", async () => {
+    seedHedge({ id: "terminal", status: "CLOSED" });
+    const res = await tickHedgeBotWorker();
+    expect(res).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. startHedgeBotWorker — env gating
+// ---------------------------------------------------------------------------
+
+describe("startHedgeBotWorker", () => {
+  it("returns a no-op handle when ENABLE_HEDGE_WORKER is not set", async () => {
+    delete process.env.ENABLE_HEDGE_WORKER;
+    const handle = startHedgeBotWorker();
+    expect(handle).toBeDefined();
+    await handle.stop();
+    // No tick should have run — no candidates queried.
+    // We can't assert the timer count directly; the absence of a tick
+    // means no hedges were created.
+    expect(created).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- New `apps/api/src/lib/hedgeBotWorker.ts` — dedicated funding-arb runtime that runs **alongside** the existing `botWorker.ts`, never replacing or competing with it.
- State machine `PENDING → ENTRY_PLACED → BOTH_FILLED → ACTIVE → EXIT_PLACED → CLOSED` (plus `ERRORED` for partial fills) is mapped onto the existing `HedgeStatus` enum — **no Prisma migration required**.
- Entry / exit transitions emit two `BotIntent` rows mirroring the hedges-route shape: spot leg with `metaJson.category="spot"`, linear leg with `category="linear"`.
- Real exchange execution is intentionally stubbed — `// TODO(55-T2): wire bybitOrder.ts with category dispatch`. Fills are read off `BotIntent.state` written today by the existing `intentExecutor`; once 55-T2 lands, the spot leg executes end-to-end with no changes in this file.
- `startHedgeBotWorker` is gated by `ENABLE_HEDGE_WORKER === "true"` (default off). `server.ts` is **not** wired up yet, so the production runtime is unaffected.
- Per-hedge errors are classified via the existing `errorClassifier` and swallowed at the tick level — one bad hedge cannot crash the loop.
- 11 unit tests, all passing locally.

## State machine ↔ persisted status

| Stage | `HedgeStatus` |
|---|---|
| PENDING | PLANNED |
| ENTRY_PLACED | OPENING |
| BOTH_FILLED / ACTIVE | OPEN |
| EXIT_PLACED | CLOSING |
| CLOSED | CLOSED |
| ERRORED | FAILED |

## Test plan

- [x] `pnpm --filter @botmarketplace/api exec prisma generate` ✓
- [x] `pnpm --filter @botmarketplace/api exec tsc --noEmit` ✓ (EXIT 0)
- [x] `pnpm --filter @botmarketplace/web exec tsc --noEmit` ✓ (EXIT 0)
- [x] `pnpm --filter @botmarketplace/api test` ✓ (2056/2056 — baseline 2045 + 11 new hedgeBotWorker tests)
- [ ] CI green
- [ ] follow-up 55-T2: replace stubbed fills with real `bybitOrder({ category: "spot" })` calls


---
_Generated by [Claude Code](https://claude.ai/code/session_012z5NupTCzRjLgFvW7RDVEx)_