### PR TITLE
docs: flagship implementation status — capability matrix + concept docs (53-T5 + 54-T4)

### DIFF
--- a/docs/strategies/01-flagship-overview.md
+++ b/docs/strategies/01-flagship-overview.md
@@ -3,6 +3,25 @@
 > Данный документ описывает 5 флагманских стратегий для Bot Marketplace.  
 > Платформа строится **под стратегии**, а не стратегии под платформу.
 
+## Implementation timeline
+
+> Stage 3 (`docs/50`) launched the 5-flagship implementation track. As of the
+> latest update, **4 of 5 flagships are delivered as PUBLIC presets** in Lab
+> Library. The fifth — Funding Rate Arbitrage — is on a parallel BETA track
+> (`docs/55`) because of its multi-leg execution requirements.
+
+| # | Strategy | Status | Plan | Preset slug |
+|---|---|---|---|---|
+| 🥇 | SMC Liquidity Sweep + FVG + OB | **delivered (PUBLIC)** | `docs/54-T3` | `smc-liquidity-sweep` |
+| 🥈 | Adaptive Regime Bot | **delivered (PUBLIC)** | `docs/53` | `adaptive-regime` |
+| 🥉 | Funding Rate Arbitrage | **in progress (BETA track)** | `docs/55` | `funding-arb` |
+| 4 | MTF Confluence Scalper | **delivered (PUBLIC)** | `docs/54-T2` | `mtf-scalper` |
+| 5 | DCA Momentum Bot | **delivered (PUBLIC)** | `docs/54-T1` | `dca-momentum` |
+
+The capability matrix (`docs/strategies/08-strategy-capability-matrix.md`)
+tracks block-level support for the underlying primitives every preset depends
+on; the table above tracks preset-level delivery status.
+
 ## Критерии отбора
 
 Все стратегии отобраны по трём критериям:

--- a/docs/strategies/02-smc-liquidity-sweep.md
+++ b/docs/strategies/02-smc-liquidity-sweep.md
@@ -4,6 +4,11 @@
 > **Аудитория:** Профессиональные трейдеры  
 > **Edge:** Единственный подход, объясняющий *почему* движется цена — охота за ликвидностью
 
+> **Implementation status:** delivered as `smc-liquidity-sweep` preset — see `docs/54-T3`.
+> DSL: `apps/api/prisma/seed/presets/smc-liquidity-sweep.json`.
+> Golden fixture: `apps/api/tests/fixtures/strategies/smc-liquidity-sweep.golden.json`.
+> Visibility in Lab Library: PUBLIC.
+
 ## Концепция
 
 **Smart Money Concepts (SMC)** основана на том, что институциональные игроки намеренно «охотятся» за стоп-лоссами розничных трейдеров, чтобы получить ликвидность для своих позиций. Liquidity Sweep — это момент, когда цена пробивает значимый уровень (собирает стопы) и резко разворачивается. Именно в этой точке открывается сделка.

--- a/docs/strategies/03-adaptive-regime-bot.md
+++ b/docs/strategies/03-adaptive-regime-bot.md
@@ -4,6 +4,11 @@
 > **Аудитория:** Продвинутые трейдеры  
 > **Edge:** Единственная стратегия, которая не «ломается» при смене режима рынка
 
+> **Implementation status:** delivered as `adaptive-regime` preset — see `docs/53`.
+> DSL: `apps/api/prisma/seed/presets/adaptive-regime.json`.
+> Golden fixture: `apps/api/tests/fixtures/strategies/adaptive-regime.golden.json`.
+> Visibility in Lab Library: PUBLIC.
+
 ## Концепция
 
 Большинство ботов «ломаются» при смене рыночного режима: трендовые стратегии теряют деньги в боковике, и наоборот. Adaptive Regime Bot автоматически определяет текущий режим через ADX и активирует соответствующую подстратегию.

--- a/docs/strategies/05-mtf-confluence-scalper.md
+++ b/docs/strategies/05-mtf-confluence-scalper.md
@@ -4,6 +4,11 @@
 > **Аудитория:** Профессиональные трейдеры  
 > **Edge:** Вход только при совпадении 3 независимых инструментов — highest win rate среди скальп-стратегий
 
+> **Implementation status:** delivered as `mtf-scalper` preset — see `docs/54-T2`.
+> DSL: `apps/api/prisma/seed/presets/mtf-scalper.json`.
+> Golden fixture: `apps/api/tests/fixtures/strategies/mtf-scalper.golden.json`.
+> Visibility in Lab Library: PUBLIC.
+
 ## Концепция
 
 **Конфлюэнс** — это совпадение нескольких независимых инструментов в одной точке. VWAP показывает «справедливую цену» сессии, Volume Profile (POC/VAH/VAL) — зоны максимальной рыночной активности, RSI(3) — мгновенный тайминг перегрева/перепроданности. Вход только когда все три одновременно указывают в одну сторону.

--- a/docs/strategies/06-dca-momentum-bot.md
+++ b/docs/strategies/06-dca-momentum-bot.md
@@ -4,6 +4,11 @@
 > **Аудитория:** Новички и пассивные инвесторы  
 > **Edge:** +245% live за 4 года на BTC при drawdown 12% — работает в любом рынке
 
+> **Implementation status:** delivered as `dca-momentum` preset — see `docs/54-T1`.
+> DSL: `apps/api/prisma/seed/presets/dca-momentum.json`.
+> Golden fixture: `apps/api/tests/fixtures/strategies/dca-momentum.golden.json`.
+> Visibility in Lab Library: PUBLIC.
+
 ## Концепция
 
 **Dollar Cost Averaging (DCA)** с моментум-фильтром — наиболее популярный тип автоматизации среди розничных пользователей. Бот открывает базовую позицию при сигнале входа и автоматически усредняется при движении цены против позиции через «safety orders». По мере усреднения TP автоматически пересчитывается к новой средней цене. Моментум-фильтр (RSI + EMA) предотвращает вход в слишком сильный нисходящий тренд.

--- a/docs/strategies/08-strategy-capability-matrix.md
+++ b/docs/strategies/08-strategy-capability-matrix.md
@@ -88,6 +88,31 @@ enforce that the code and this matrix stay in sync.
 | `order_block` | ✅ | ✅ | ✅ | **supported** | Institutional OB detection #137/#138 |
 | `market_structure_shift` | ✅ | ✅ | ✅ | **supported** | BOS/CHoCH detection #137/#138 |
 
+## Implemented Strategy Presets
+
+> Source of truth: `apps/api/prisma/seed/presets/<slug>.json` (DSL + default config)
+> Golden fixtures: `apps/api/tests/fixtures/strategies/<slug>.golden.json`
+>
+> Each preset below is built entirely on top of the `supported` blocks above —
+> no preset is allowed to depend on a `compile-only` block. The status column
+> tracks delivery into Lab Library, not the underlying block runtime.
+
+| Preset | Visibility | Timeframe(s) | Status | Plan |
+|---|---|---|---|---|
+| `adaptive-regime` | PUBLIC | M5 (single-TF, with H1/H4 regime refs via `sourceTimeframe`) | **delivered** | `docs/53` |
+| `dca-momentum` | PUBLIC | M15 (single-TF) | **delivered** | `docs/54` |
+| `mtf-scalper` | PUBLIC | M1 / M5 / M15 (multi-TF bundle) | **delivered** | `docs/54` |
+| `smc-liquidity-sweep` | PUBLIC | M15 / H1 / H4 (multi-TF bundle, pattern blocks) | **delivered** | `docs/54` |
+| `funding-arb` | _planned BETA_ | n/a (multi-leg perp + spot) | **in progress** | `docs/55` |
+
+**Status legend (preset-level):**
+
+| Status | Meaning |
+|--------|---------|
+| **delivered** | Preset shipped: DSL frozen via golden fixture, primitive-only construction verified by sanity tests, visible in Lab Library at the listed visibility. |
+| **in progress** | DSL or runtime work landed on `main` but at least one closing task (acceptance run, BETA publish, etc.) is still open. See referenced plan for the open T-task list. |
+| **planned** | Spec exists, no implementation work merged. |
+
 ## Summary
 
 | Status | Count | Blocks |


### PR DESCRIPTION
## Summary

Closes the docs side of `docs/53-T5` and `docs/54-T4` in one changeset — both ask for the same thing (flagship preset status surfaced in the matrix + concept docs), so a combined PR keeps the changes coherent.

- `08-strategy-capability-matrix.md` — new **"Implemented Strategy Presets"** section with all 5 flagships, their visibility, timeframe layout, and back-link to the owning plan. Block-level matrix above is unchanged.
- `02-smc-liquidity-sweep.md` / `03-adaptive-regime-bot.md` / `05-mtf-confluence-scalper.md` / `06-dca-momentum-bot.md` — each gains a 4-line Implementation status block pointing at the seed JSON, the golden fixture, and Lab Library visibility.
- `01-flagship-overview.md` — per-flagship status table at the top so readers see "4 of 5 delivered, 1 on BETA track" without opening five concept docs.

## Notes

- Spec referenced `strategies/02-dca-momentum-bot.md` / `05-mtf-scalper.md` / `06-smc-liquidity-sweep.md`, but the actual filenames are `06-dca-momentum-bot.md` / `05-mtf-confluence-scalper.md` / `02-smc-liquidity-sweep.md`. Concept docs were updated at their real locations.
- `docs/16-roadmap.md` has no flagship-tracking section, so the spec's "update Post-MVP statuses" step lands as the `01-flagship-overview` timeline block instead — that doc is the source of truth for flagship-level state.

## Test plan

- [x] No code changed → no tsc / vitest impact.
- [ ] CI green (markdown link / lint stages only).


---
_Generated by [Claude Code](https://claude.ai/code/session_012z5NupTCzRjLgFvW7RDVEx)_