### PR TITLE
test(strategies): describeGoldenStrategyContract helper (54-T5 partial)

### DIFF
--- a/apps/api/tests/_helpers/strategyAcceptance.ts
+++ b/apps/api/tests/_helpers/strategyAcceptance.ts
@@ -1,0 +1,211 @@
+/**
+ * Shared contract assertions for flagship preset golden tests (docs/54-T5).
+ *
+ * Every flagship preset (adaptive-regime, dca-momentum, mtf-scalper,
+ * smc-liquidity-sweep, …) has a golden fixture pinned against its seed
+ * `dslJson`, and four contract checks are identical across them:
+ *
+ *   1. seed.dslJson is byte-equal to the golden fixture.
+ *   2. validateDsl(golden) returns null (schema-valid).
+ *   3. parseDsl(golden) yields dslVersion=2 with a defined entry.signal.
+ *   4. Every blockType / type referenced by the golden is `supported`
+ *      in BLOCK_SUPPORT_MAP, after structural-keyword + alias normalisation.
+ *
+ * Strategy-specific assertions (deep parseDsl checks, synthetic-candle
+ * sanity-evaluator runs, DCA-exposure planner checks, etc.) stay in the
+ * per-strategy test file. The helper covers the four invariants that
+ * every preset shares — drift in any of them shouts loudly without the
+ * boilerplate being duplicated four ways.
+ *
+ * Smoke-replay support is intentionally NOT here yet — recording a
+ * deterministic JSON of a 30-min Bybit-demo run requires the
+ * acceptance-gate paths in docs/53-T3 / docs/54-T1..T3 / docs/55-T6 to
+ * have actually run. Those need credentials this repository's CI does
+ * not have. The helper will grow a `describeSmokeReplay` once the
+ * recordings exist.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseDsl } from "../../src/lib/dslEvaluator.js";
+import { validateDsl } from "../../src/lib/dslValidator.js";
+import { BLOCK_SUPPORT_MAP } from "../../src/lib/compiler/supportMap.ts";
+
+// ---------------------------------------------------------------------------
+// Shared keyword + alias tables
+// ---------------------------------------------------------------------------
+
+/** DSL nodes whose `type` field is a structural keyword, not a block name. */
+export const STRUCTURAL_TYPES = new Set([
+  "or",
+  "and",
+  "compare",
+  "crossover",
+  "crossunder",
+  "confirm_n_bars",
+  "fixed_pct",
+  "fixed_price",
+  "atr_multiple",
+]);
+
+/** Lower-case / shorthand block-name aliases → canonical key in
+ *  `BLOCK_SUPPORT_MAP`. The runtime evaluator lowercases its input so the
+ *  seed legitimately uses lowercase names; the support map keys are
+ *  case-sensitive. Add aliases here as new presets land. */
+export const SUPPORT_ALIASES: Record<string, string> = {
+  ema: "EMA",
+  rsi: "RSI",
+  sma: "SMA",
+  bollinger: "bollinger",
+  bollinger_lower: "bollinger",
+  bollinger_upper: "bollinger",
+  bollinger_middle: "bollinger",
+  bb_lower: "bollinger",
+  bb_upper: "bollinger",
+  bb_middle: "bollinger",
+};
+
+// ---------------------------------------------------------------------------
+// Golden fixture / seed loading
+// ---------------------------------------------------------------------------
+
+export interface GoldenLoadArgs {
+  /** Test file's directory — pass `dirname(fileURLToPath(import.meta.url))`. */
+  baseDir: string;
+  /** Relative path from `baseDir` to the golden JSON fixture. */
+  goldenPath: string;
+  /** Relative path from `baseDir` to the preset seed JSON. */
+  seedPath: string;
+}
+
+export interface LoadedGolden {
+  golden: Record<string, unknown>;
+  seed: { dslJson: unknown };
+}
+
+/** Read both fixtures into memory. Used both inside the helper's
+ *  describe blocks and returned to the caller so strategy-specific
+ *  assertions can reuse the exact same JSON without re-reading. */
+export function loadGoldenAndSeed(args: GoldenLoadArgs): LoadedGolden {
+  const golden = JSON.parse(
+    readFileSync(join(args.baseDir, args.goldenPath), "utf8"),
+  ) as Record<string, unknown>;
+  const seed = JSON.parse(
+    readFileSync(join(args.baseDir, args.seedPath), "utf8"),
+  ) as { dslJson: unknown };
+  return { golden, seed };
+}
+
+// ---------------------------------------------------------------------------
+// Block-type collector — recursive walk over the DSL tree
+// ---------------------------------------------------------------------------
+
+/**
+ * Recursively collect every `blockType` and indicator-style `type` field
+ * present in the DSL — anything the evaluator will hit on the hot path
+ * needs to be either a structural keyword (compare, and, or, …) or a
+ * supported block.
+ */
+export function collectIndicatorBlockTypes(
+  node: unknown,
+  out: Set<string> = new Set<string>(),
+): Set<string> {
+  if (Array.isArray(node)) {
+    for (const item of node) collectIndicatorBlockTypes(item, out);
+    return out;
+  }
+  if (node && typeof node === "object") {
+    const obj = node as Record<string, unknown>;
+    if (typeof obj.blockType === "string") out.add(obj.blockType);
+    if (typeof obj.type === "string") out.add(obj.type);
+    for (const v of Object.values(obj)) collectIndicatorBlockTypes(v, out);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point — registers the four contract describes
+// ---------------------------------------------------------------------------
+
+export interface DescribeGoldenStrategyArgs extends GoldenLoadArgs {
+  /** Preset slug — used as the describe-block prefix. */
+  slug: string;
+}
+
+/**
+ * Register the four shared describe blocks for `slug`.
+ *
+ * Returns the loaded `{ golden, seed }` so the caller can chain
+ * strategy-specific assertions against the exact same JSON without
+ * re-reading from disk.
+ *
+ * Usage:
+ *
+ * ```ts
+ * import { describeGoldenStrategyContract } from "../../_helpers/strategyAcceptance.js";
+ *
+ * const { golden } = describeGoldenStrategyContract({
+ *   slug: "dca-momentum",
+ *   baseDir: dirname(fileURLToPath(import.meta.url)),
+ *   goldenPath: "../../fixtures/strategies/dca-momentum.golden.json",
+ *   seedPath: "../../../prisma/seed/presets/dca-momentum.json",
+ * });
+ *
+ * // Strategy-specific assertions follow:
+ * describe("dca-momentum — DCA exposure inside risk cap", () => { … });
+ * ```
+ */
+export function describeGoldenStrategyContract(
+  args: DescribeGoldenStrategyArgs,
+): LoadedGolden {
+  const loaded = loadGoldenAndSeed(args);
+
+  describe(`${args.slug} — seed/golden pin`, () => {
+    it("seed.dslJson is byte-equal to the golden fixture", () => {
+      expect(loaded.seed.dslJson).toEqual(loaded.golden);
+    });
+  });
+
+  describe(`${args.slug} — DSL validity`, () => {
+    it("validates against the v2 strategy schema", () => {
+      expect(validateDsl(loaded.golden)).toBeNull();
+    });
+
+    it("parseDsl yields a v2-shaped ParsedDsl", () => {
+      const parsed = parseDsl(loaded.golden);
+      expect(parsed.dslVersion).toBe(2);
+      expect(parsed.entry.signal).toBeDefined();
+    });
+  });
+
+  describe(`${args.slug} — uses only supported primitives`, () => {
+    it("every indicator/block referenced is `supported` in BLOCK_SUPPORT_MAP", () => {
+      const types = collectIndicatorBlockTypes(loaded.golden);
+      const offenders: Array<{ name: string; reason: string }> = [];
+
+      for (const raw of types) {
+        if (STRUCTURAL_TYPES.has(raw)) continue;
+        const canonical = SUPPORT_ALIASES[raw] ?? raw;
+        const entry = BLOCK_SUPPORT_MAP[canonical];
+        if (!entry) {
+          offenders.push({
+            name: raw,
+            reason: `not in BLOCK_SUPPORT_MAP (looked up as "${canonical}")`,
+          });
+          continue;
+        }
+        if (entry.status !== "supported") {
+          offenders.push({
+            name: raw,
+            reason: `status is "${entry.status}", expected "supported"`,
+          });
+        }
+      }
+
+      expect(offenders).toEqual([]);
+    });
+  });
+
+  return loaded;
+}

--- a/apps/api/tests/lib/strategies/adaptiveRegime.test.ts
+++ b/apps/api/tests/lib/strategies/adaptiveRegime.test.ts
@@ -1,32 +1,27 @@
 /**
- * Adaptive Regime — golden DSL pin (docs/53-T1 + 53-T6).
+ * Adaptive Regime — golden DSL pin (docs/53-T1 + 53-T6, 54-T5 helper extraction).
  *
  * The golden fixture is the single source of truth for the
- * `adaptive-regime` preset. Tests here lock down four invariants:
+ * `adaptive-regime` preset. The four shared contract checks (seed/golden
+ * pin, DSL validity, parseDsl smoke, supported-primitives) are
+ * registered via `describeGoldenStrategyContract` (54-T5). The two
+ * strategy-specific assertions remain inline:
  *
- *   1. The seed file's `dslJson` and the golden fixture stay byte-equal —
- *      any change to the preset must be a deliberate update of the
- *      golden, not an accidental drift.
- *   2. The golden DSL is structurally valid against the v2 schema
- *      (`validateDsl`) and parses cleanly via `parseDsl`.
- *   3. Every block referenced by the golden is in {@link BLOCK_SUPPORT_MAP}
- *      with status `supported`. No "composite signal types" sneak in —
- *      the strategy must be expressible through primitives, per
- *      docs/50 §Решение 3 / docs/53 §Решение 1.
- *   4. Sanity-evaluator on a synthetic {M5, H1} bundle:
- *      - Trend-up branch fires when EMA50(H1) > EMA200(H1), supertrend(M5) > 0,
- *        ADX(H1) > 20.
- *      - Mean-reversion branch fires when RSI(M5) < 30 and ADX(H1) < 20.
- *      - Neither fires on a calm baseline (RSI ≈ 50, ADX flat).
+ *   - parseDsl returns the expected exit shape (`atr_multiple` SL,
+ *     `fixed_pct` TP) — drift in either type would be a real preset
+ *     change masquerading as a refactor.
+ *   - Sanity-evaluator on a synthetic {M5, H1} bundle:
+ *       * Trend-up branch fires when EMA50(H1) > EMA200(H1), supertrend(M5) > 0,
+ *         ADX(H1) > 20.
+ *       * Mean-reversion branch fires when RSI(M5) < 30 and ADX(H1) < 20.
+ *       * Calm baseline fires neither.
  *
- * The acceptance gate (full walk-forward on real data) lives in
- * docs/53-T2 — that needs market data and is out of scope here.
+ * Acceptance gate (full walk-forward on real data) lives in docs/53-T2.
  */
 
 import { describe, it, expect } from "vitest";
-import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
+import { dirname } from "node:path";
 import {
   evaluateSignal,
   parseDsl,
@@ -34,7 +29,6 @@ import {
   type DslSignal,
   type RuntimeMtfContext,
 } from "../../../src/lib/dslEvaluator.js";
-import { validateDsl } from "../../../src/lib/dslValidator.js";
 import {
   createCandleBundle,
   INTERVAL_MS,
@@ -42,124 +36,33 @@ import {
   type MtfCandle,
 } from "../../../src/lib/mtf/intervalAlignment.js";
 import { createMtfCache } from "../../../src/lib/mtf/mtfIndicatorResolver.js";
-import { BLOCK_SUPPORT_MAP } from "../../../src/lib/compiler/supportMap.ts";
+import { describeGoldenStrategyContract } from "../../_helpers/strategyAcceptance.js";
 
 // ---------------------------------------------------------------------------
-// Fixture / seed loading
+// Shared contract — seed/golden pin, validateDsl, parseDsl, supported blocks
 // ---------------------------------------------------------------------------
 
-const here = dirname(fileURLToPath(import.meta.url));
-
-function loadJson(rel: string): unknown {
-  const abs = join(here, rel);
-  return JSON.parse(readFileSync(abs, "utf8"));
-}
-
-const goldenDsl = loadJson("../../fixtures/strategies/adaptive-regime.golden.json") as Record<string, unknown>;
-const seed = loadJson("../../../prisma/seed/presets/adaptive-regime.json") as { dslJson: unknown };
-
-// ---------------------------------------------------------------------------
-// 1. Seed ⇄ golden pin
-// ---------------------------------------------------------------------------
-
-describe("adaptive-regime — seed/golden pin", () => {
-  it("seed.dslJson is byte-equal to the golden fixture", () => {
-    expect(seed.dslJson).toEqual(goldenDsl);
-  });
+const { golden: goldenDsl } = describeGoldenStrategyContract({
+  slug: "adaptive-regime",
+  baseDir: dirname(fileURLToPath(import.meta.url)),
+  goldenPath: "../../fixtures/strategies/adaptive-regime.golden.json",
+  seedPath: "../../../prisma/seed/presets/adaptive-regime.json",
 });
 
 // ---------------------------------------------------------------------------
-// 2. Schema + parse smoke
+// Strategy-specific: exit shape pin
 // ---------------------------------------------------------------------------
 
-describe("adaptive-regime — DSL validity", () => {
-  it("validates against the v2 strategy schema", () => {
-    const errors = validateDsl(goldenDsl);
-    expect(errors).toBeNull();
-  });
-
-  it("parseDsl yields a v2-shaped ParsedDsl with non-empty signal/exit", () => {
+describe("adaptive-regime — exit shape", () => {
+  it("parseDsl yields atr_multiple stopLoss + fixed_pct takeProfit", () => {
     const parsed = parseDsl(goldenDsl);
-    expect(parsed.dslVersion).toBe(2);
-    expect(parsed.entry.signal).toBeDefined();
     expect(parsed.exit?.stopLoss?.type).toBe("atr_multiple");
     expect(parsed.exit?.takeProfit?.type).toBe("fixed_pct");
   });
 });
 
 // ---------------------------------------------------------------------------
-// 3. No composite types — every block is in BLOCK_SUPPORT_MAP, supported
-// ---------------------------------------------------------------------------
-
-/** Recursively collect every `blockType` and `type: "<indicator>"`-style
- *  reference present in the DSL — anything the evaluator will hit on the
- *  hot path needs to be either a structural keyword (compare, and, or,
- *  …) or a supported block. */
-function collectIndicatorBlockTypes(node: unknown, out = new Set<string>()): Set<string> {
-  if (Array.isArray(node)) {
-    for (const item of node) collectIndicatorBlockTypes(item, out);
-    return out;
-  }
-  if (node && typeof node === "object") {
-    const obj = node as Record<string, unknown>;
-    if (typeof obj.blockType === "string") out.add(obj.blockType);
-    // `type` strings appear both as structural keywords (or/and/compare)
-    // and as indicator names (atr inside exit.stopLoss). Capture them
-    // here and filter the structural ones below.
-    if (typeof obj.type === "string") out.add(obj.type);
-    for (const v of Object.values(obj)) collectIndicatorBlockTypes(v, out);
-  }
-  return out;
-}
-
-const STRUCTURAL_TYPES = new Set([
-  "or", "and", "compare", "crossover", "crossunder", "confirm_n_bars",
-  "fixed_pct", "fixed_price", "atr_multiple",
-]);
-
-/** Map runtime block-name aliases (lowercase / shorthands) back to the
- *  canonical key in `BLOCK_SUPPORT_MAP`. The evaluator's getIndicatorValues
- *  lower-cases its input, so the seed legitimately uses lowercase names —
- *  the support map keys are case-sensitive. */
-const SUPPORT_ALIASES: Record<string, string> = {
-  ema:        "EMA",
-  rsi:        "RSI",
-  sma:        "SMA",
-  // bollinger_lower/upper/middle / bb_* all resolve through the
-  // `bollinger` runtime entry; treat them as the same supported block.
-  bollinger:        "bollinger",
-  bollinger_lower:  "bollinger",
-  bollinger_upper:  "bollinger",
-  bollinger_middle: "bollinger",
-  bb_lower:         "bollinger",
-  bb_upper:         "bollinger",
-  bb_middle:        "bollinger",
-};
-
-describe("adaptive-regime — uses only supported primitives", () => {
-  it("every indicator/block referenced is `supported` in BLOCK_SUPPORT_MAP", () => {
-    const types = collectIndicatorBlockTypes(goldenDsl);
-    const offenders: Array<{ name: string; reason: string }> = [];
-
-    for (const raw of types) {
-      if (STRUCTURAL_TYPES.has(raw)) continue; // structural keyword, not a block
-      const canonical = SUPPORT_ALIASES[raw] ?? raw;
-      const entry = BLOCK_SUPPORT_MAP[canonical];
-      if (!entry) {
-        offenders.push({ name: raw, reason: `not in BLOCK_SUPPORT_MAP (looked up as "${canonical}")` });
-        continue;
-      }
-      if (entry.status !== "supported") {
-        offenders.push({ name: raw, reason: `status is "${entry.status}", expected "supported"` });
-      }
-    }
-
-    expect(offenders).toEqual([]);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// 4. Sanity evaluator on a synthetic {M5, H1} bundle
+// Strategy-specific: sanity evaluator on a synthetic {M5, H1} bundle
 // ---------------------------------------------------------------------------
 
 const t0 = Date.UTC(2026, 0, 1, 0, 0, 0);

--- a/apps/api/tests/lib/strategies/dcaMomentum.test.ts
+++ b/apps/api/tests/lib/strategies/dcaMomentum.test.ts
@@ -1,77 +1,56 @@
 /**
- * DCA Momentum — golden DSL pin (docs/54-T1, partial 54-T5).
+ * DCA Momentum — golden DSL pin (docs/54-T1, helper-extracted under 54-T5).
  *
- * Mirrors tests/lib/strategies/adaptiveRegime.test.ts:
+ * Shared contract checks (seed/golden pin, validateDsl, parseDsl smoke,
+ * supported-primitives) come from `describeGoldenStrategyContract`.
+ * Strategy-specific assertions inline:
  *
- *   1. Seed/golden pin — preset's `dslJson` is byte-equal to the golden.
- *   2. Schema + parse smoke — validateDsl passes, parseDsl yields a
- *      v2-shaped ParsedDsl with the DCA section populated.
- *   3. No composite types — every `blockType` is supported (or a
- *      structural keyword) in BLOCK_SUPPORT_MAP.
- *   4. DCA exposure stays within risk.maxPositionSizeUsd — uses the
- *      production planner so any drift in dcaPlanning is caught here.
- *   5. Sanity evaluator on synthetic single-TF M15 candles:
- *      - Oversold pullback (RSI<40, EMA8<EMA21) → entry fires.
- *      - Strong uptrend (RSI≈70, EMA8>EMA21) → no entry.
+ *   - Deep parseDsl shape — DCA section + indicatorExit + fixed_pct
+ *     stopLoss + takeProfit. Drift in any of these would change the
+ *     preset's behaviour, not just style.
+ *   - DCA exposure stays within `risk.maxPositionSizeUsd` — uses the
+ *     production planner so any drift in dcaPlanning is caught here.
+ *   - Sanity evaluator on synthetic single-TF M15 candles:
+ *       * Oversold pullback (RSI<40, EMA8<EMA21) → entry fires.
+ *       * Strong uptrend (RSI≈70, EMA8>EMA21) → no entry.
  *
  * Walk-forward acceptance and demo smoke (54-T1 §2/§3) need real data
  * and Bybit credentials — not exercised here.
  */
 
 import { describe, it, expect } from "vitest";
-import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
+import { dirname } from "node:path";
 import {
   evaluateSignal,
   parseDsl,
   createIndicatorCache,
   type DslSignal,
 } from "../../../src/lib/dslEvaluator.js";
-import { validateDsl } from "../../../src/lib/dslValidator.js";
 import {
   generateSafetyOrderSchedule,
   type DcaConfig,
 } from "../../../src/lib/dcaPlanning.js";
-import { BLOCK_SUPPORT_MAP } from "../../../src/lib/compiler/supportMap.ts";
+import { describeGoldenStrategyContract } from "../../_helpers/strategyAcceptance.js";
 
 // ---------------------------------------------------------------------------
-// Fixture / seed loading
+// Shared contract — seed/golden pin, validateDsl, parseDsl, supported blocks
 // ---------------------------------------------------------------------------
 
-const here = dirname(fileURLToPath(import.meta.url));
-
-function loadJson(rel: string): unknown {
-  return JSON.parse(readFileSync(join(here, rel), "utf8"));
-}
-
-const goldenDsl = loadJson("../../fixtures/strategies/dca-momentum.golden.json") as Record<string, unknown>;
-const seed = loadJson("../../../prisma/seed/presets/dca-momentum.json") as { dslJson: unknown };
-
-// ---------------------------------------------------------------------------
-// 1. Seed ⇄ golden pin
-// ---------------------------------------------------------------------------
-
-describe("dca-momentum — seed/golden pin", () => {
-  it("seed.dslJson is byte-equal to the golden fixture", () => {
-    expect(seed.dslJson).toEqual(goldenDsl);
-  });
+const { golden: goldenDsl } = describeGoldenStrategyContract({
+  slug: "dca-momentum",
+  baseDir: dirname(fileURLToPath(import.meta.url)),
+  goldenPath: "../../fixtures/strategies/dca-momentum.golden.json",
+  seedPath: "../../../prisma/seed/presets/dca-momentum.json",
 });
 
 // ---------------------------------------------------------------------------
-// 2. Schema + parse smoke
+// Strategy-specific: deep parseDsl shape (DCA + exit configured)
 // ---------------------------------------------------------------------------
 
-describe("dca-momentum — DSL validity", () => {
-  it("validates against the v2 strategy schema", () => {
-    const errors = validateDsl(goldenDsl);
-    expect(errors).toBeNull();
-  });
-
-  it("parseDsl yields a v2-shaped ParsedDsl with DCA + exit configured", () => {
+describe("dca-momentum — DCA + exit shape", () => {
+  it("parseDsl yields fixed_pct exits, indicatorExit, and the DCA section populated", () => {
     const parsed = parseDsl(goldenDsl);
-    expect(parsed.dslVersion).toBe(2);
-    expect(parsed.entry.signal).toBeDefined();
     expect(parsed.exit?.stopLoss?.type).toBe("fixed_pct");
     expect(parsed.exit?.takeProfit?.type).toBe("fixed_pct");
     expect(parsed.exit?.indicatorExit?.condition.op).toBe("gt");
@@ -81,58 +60,7 @@ describe("dca-momentum — DSL validity", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 3. No composite types — every block in BLOCK_SUPPORT_MAP, supported
-// ---------------------------------------------------------------------------
-
-function collectIndicatorBlockTypes(node: unknown, out = new Set<string>()): Set<string> {
-  if (Array.isArray(node)) {
-    for (const item of node) collectIndicatorBlockTypes(item, out);
-    return out;
-  }
-  if (node && typeof node === "object") {
-    const obj = node as Record<string, unknown>;
-    if (typeof obj.blockType === "string") out.add(obj.blockType);
-    if (typeof obj.type === "string") out.add(obj.type);
-    for (const v of Object.values(obj)) collectIndicatorBlockTypes(v, out);
-  }
-  return out;
-}
-
-const STRUCTURAL_TYPES = new Set([
-  "or", "and", "compare", "crossover", "crossunder", "confirm_n_bars",
-  "fixed_pct", "fixed_price", "atr_multiple",
-]);
-
-const SUPPORT_ALIASES: Record<string, string> = {
-  ema: "EMA", rsi: "RSI", sma: "SMA",
-  bollinger: "bollinger",
-  bollinger_lower: "bollinger", bollinger_upper: "bollinger", bollinger_middle: "bollinger",
-  bb_lower: "bollinger", bb_upper: "bollinger", bb_middle: "bollinger",
-};
-
-describe("dca-momentum — uses only supported primitives", () => {
-  it("every indicator/block referenced is `supported` in BLOCK_SUPPORT_MAP", () => {
-    const types = collectIndicatorBlockTypes(goldenDsl);
-    const offenders: Array<{ name: string; reason: string }> = [];
-
-    for (const raw of types) {
-      if (STRUCTURAL_TYPES.has(raw)) continue;
-      const canonical = SUPPORT_ALIASES[raw] ?? raw;
-      const entry = BLOCK_SUPPORT_MAP[canonical];
-      if (!entry) {
-        offenders.push({ name: raw, reason: `not in BLOCK_SUPPORT_MAP (looked up as "${canonical}")` });
-        continue;
-      }
-      if (entry.status !== "supported") {
-        offenders.push({ name: raw, reason: `status is "${entry.status}", expected "supported"` });
-      }
-    }
-    expect(offenders).toEqual([]);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// 4. DCA ladder fits inside risk.maxPositionSizeUsd
+// Strategy-specific: DCA ladder fits inside risk.maxPositionSizeUsd
 // ---------------------------------------------------------------------------
 
 describe("dca-momentum — DCA exposure inside risk cap", () => {
@@ -149,7 +77,7 @@ describe("dca-momentum — DCA exposure inside risk cap", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 5. Sanity evaluator on synthetic M15 candles (single-TF — no bundle)
+// Strategy-specific: sanity evaluator on synthetic M15 candles
 // ---------------------------------------------------------------------------
 
 interface Candle {

--- a/apps/api/tests/lib/strategies/mtfScalper.test.ts
+++ b/apps/api/tests/lib/strategies/mtfScalper.test.ts
@@ -1,28 +1,25 @@
 /**
- * MTF Confluence Scalper — golden DSL pin (docs/54-T2, partial 54-T5).
+ * MTF Confluence Scalper — golden DSL pin (docs/54-T2, helper-extracted under 54-T5).
  *
- * Mirrors tests/lib/strategies/{adaptiveRegime,dcaMomentum}.test.ts:
+ * Shared contract checks (seed/golden pin, validateDsl, parseDsl smoke,
+ * supported-primitives) come from `describeGoldenStrategyContract`.
+ * Strategy-specific assertions inline:
  *
- *   1. Seed/golden pin — preset's `dslJson` is byte-equal to the golden.
- *   2. Schema + parse smoke — validateDsl passes, parseDsl yields a
- *      v2-shaped ParsedDsl with ATR-based stop and indicatorExit.
- *   3. No composite types — every `blockType` is supported (or a
- *      structural keyword) in BLOCK_SUPPORT_MAP. `vwap` block is on
- *      the supported list.
- *   4. Sanity evaluator on a synthetic {M1, M5, M15} bundle:
- *      - Three-way confluence (M15 EMA50>EMA200, M5 close>VWAP, M1
- *        RSI(3)<30 oversold dip) → entry fires.
- *      - M15 downtrend (EMA50<EMA200) → no entry.
- *      - Calm baseline (no trend, RSI ≈ 50) → no entry.
+ *   - parseDsl exit shape — `atr_multiple` SL, `fixed_pct` TP, `gt`
+ *     indicatorExit. Drift in any of these would change behaviour.
+ *   - Sanity evaluator on a synthetic {M1, M5, M15} bundle:
+ *       * Three-way confluence (M15 EMA50>EMA200, M5 close>VWAP, M1
+ *         RSI(3)<30 oversold dip) → entry fires.
+ *       * M15 downtrend (EMA50<EMA200) → no entry even if M1/M5 align.
+ *       * Calm baseline (no trend, RSI ≈ 50) → no entry.
  *
  * Walk-forward acceptance, demo smoke, profile-check (54-T2 §2/§3/§4)
  * need real data and a live runtime — out of scope here.
  */
 
 import { describe, it, expect } from "vitest";
-import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
+import { dirname } from "node:path";
 import {
   evaluateSignal,
   parseDsl,
@@ -30,7 +27,6 @@ import {
   type DslSignal,
   type RuntimeMtfContext,
 } from "../../../src/lib/dslEvaluator.js";
-import { validateDsl } from "../../../src/lib/dslValidator.js";
 import {
   createCandleBundle,
   INTERVAL_MS,
@@ -38,42 +34,26 @@ import {
   type MtfCandle,
 } from "../../../src/lib/mtf/intervalAlignment.js";
 import { createMtfCache } from "../../../src/lib/mtf/mtfIndicatorResolver.js";
-import { BLOCK_SUPPORT_MAP } from "../../../src/lib/compiler/supportMap.ts";
+import { describeGoldenStrategyContract } from "../../_helpers/strategyAcceptance.js";
 
 // ---------------------------------------------------------------------------
-// Fixture / seed loading
+// Shared contract — seed/golden pin, validateDsl, parseDsl, supported blocks
 // ---------------------------------------------------------------------------
 
-const here = dirname(fileURLToPath(import.meta.url));
-const loadJson = (rel: string): unknown => JSON.parse(readFileSync(join(here, rel), "utf8"));
-
-const goldenDsl = loadJson("../../fixtures/strategies/mtf-scalper.golden.json") as Record<string, unknown>;
-const seed = loadJson("../../../prisma/seed/presets/mtf-scalper.json") as { dslJson: unknown };
-
-// ---------------------------------------------------------------------------
-// 1. Seed ⇄ golden pin
-// ---------------------------------------------------------------------------
-
-describe("mtf-scalper — seed/golden pin", () => {
-  it("seed.dslJson is byte-equal to the golden fixture", () => {
-    expect(seed.dslJson).toEqual(goldenDsl);
-  });
+const { golden: goldenDsl } = describeGoldenStrategyContract({
+  slug: "mtf-scalper",
+  baseDir: dirname(fileURLToPath(import.meta.url)),
+  goldenPath: "../../fixtures/strategies/mtf-scalper.golden.json",
+  seedPath: "../../../prisma/seed/presets/mtf-scalper.json",
 });
 
 // ---------------------------------------------------------------------------
-// 2. Schema + parse smoke
+// Strategy-specific: exit shape pin
 // ---------------------------------------------------------------------------
 
-describe("mtf-scalper — DSL validity", () => {
-  it("validates against the v2 strategy schema", () => {
-    const errors = validateDsl(goldenDsl);
-    expect(errors).toBeNull();
-  });
-
-  it("parseDsl yields a v2-shaped ParsedDsl with ATR stop + indicatorExit", () => {
+describe("mtf-scalper — exit shape", () => {
+  it("parseDsl yields atr_multiple SL, fixed_pct TP, gt indicatorExit", () => {
     const parsed = parseDsl(goldenDsl);
-    expect(parsed.dslVersion).toBe(2);
-    expect(parsed.entry.signal).toBeDefined();
     expect(parsed.exit?.stopLoss?.type).toBe("atr_multiple");
     expect(parsed.exit?.takeProfit?.type).toBe("fixed_pct");
     expect(parsed.exit?.indicatorExit?.condition.op).toBe("gt");
@@ -81,58 +61,7 @@ describe("mtf-scalper — DSL validity", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 3. No composite types — every block in BLOCK_SUPPORT_MAP, supported
-// ---------------------------------------------------------------------------
-
-function collectIndicatorBlockTypes(node: unknown, out = new Set<string>()): Set<string> {
-  if (Array.isArray(node)) {
-    for (const item of node) collectIndicatorBlockTypes(item, out);
-    return out;
-  }
-  if (node && typeof node === "object") {
-    const obj = node as Record<string, unknown>;
-    if (typeof obj.blockType === "string") out.add(obj.blockType);
-    if (typeof obj.type === "string") out.add(obj.type);
-    for (const v of Object.values(obj)) collectIndicatorBlockTypes(v, out);
-  }
-  return out;
-}
-
-const STRUCTURAL_TYPES = new Set([
-  "or", "and", "compare", "crossover", "crossunder", "confirm_n_bars",
-  "fixed_pct", "fixed_price", "atr_multiple",
-]);
-
-const SUPPORT_ALIASES: Record<string, string> = {
-  ema: "EMA", rsi: "RSI", sma: "SMA",
-  bollinger: "bollinger",
-  bollinger_lower: "bollinger", bollinger_upper: "bollinger", bollinger_middle: "bollinger",
-  bb_lower: "bollinger", bb_upper: "bollinger", bb_middle: "bollinger",
-};
-
-describe("mtf-scalper — uses only supported primitives", () => {
-  it("every indicator/block referenced is `supported` in BLOCK_SUPPORT_MAP", () => {
-    const types = collectIndicatorBlockTypes(goldenDsl);
-    const offenders: Array<{ name: string; reason: string }> = [];
-
-    for (const raw of types) {
-      if (STRUCTURAL_TYPES.has(raw)) continue;
-      const canonical = SUPPORT_ALIASES[raw] ?? raw;
-      const entry = BLOCK_SUPPORT_MAP[canonical];
-      if (!entry) {
-        offenders.push({ name: raw, reason: `not in BLOCK_SUPPORT_MAP (looked up as "${canonical}")` });
-        continue;
-      }
-      if (entry.status !== "supported") {
-        offenders.push({ name: raw, reason: `status is "${entry.status}", expected "supported"` });
-      }
-    }
-    expect(offenders).toEqual([]);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// 4. Sanity evaluator on a synthetic {M1, M5, M15} bundle
+// Strategy-specific: sanity evaluator on a synthetic {M1, M5, M15} bundle
 // ---------------------------------------------------------------------------
 
 const t0 = Date.UTC(2026, 0, 1, 0, 0, 0);

--- a/apps/api/tests/lib/strategies/smcLiquiditySweep.test.ts
+++ b/apps/api/tests/lib/strategies/smcLiquiditySweep.test.ts
@@ -1,24 +1,23 @@
 /**
- * SMC Liquidity Sweep — golden DSL pin (docs/54-T3, partial 54-T5).
+ * SMC Liquidity Sweep — golden DSL pin (docs/54-T3, helper-extracted under 54-T5).
  *
- * Mirrors tests/lib/strategies/{adaptiveRegime,dcaMomentum,mtfScalper}.test.ts.
+ * Shared contract checks (seed/golden pin, validateDsl, parseDsl smoke,
+ * supported-primitives — including the SMC pattern blocks `liquidity_sweep`,
+ * `market_structure_shift`) come from `describeGoldenStrategyContract`.
+ * Strategy-specific assertions inline:
  *
- *   1. Seed/golden pin — preset's `dslJson` is byte-equal to the golden.
- *   2. Schema + parse smoke — validateDsl passes, parseDsl yields a
- *      v2-shaped ParsedDsl with ATR-based stop and pattern-based signal.
- *   3. No composite types — every `blockType` (including the SMC pattern
- *      blocks `liquidity_sweep`, `market_structure_shift`) is `supported`
- *      in BLOCK_SUPPORT_MAP.
- *   4. Sanity evaluator (negative cases only — pattern-positive fixtures
- *      are deferred to docs/54-T3 §4):
- *      - Calm/flat bundle across all three TFs → no entry; pattern
- *        blocks legitimately produce zeros, AND-gate stays false.
- *      - H4 downtrend (EMA50 < EMA200) → HTF bias filter blocks even
- *        if the lower-TF patterns happened to fire.
- *      - Pattern blocks resolve through the bundle without throwing
- *        — exercises the runtime evaluator's MTF integration end-to-end
- *        for SMC-pattern refs (their first appearance via DslSignalRef
- *        with sourceTimeframe).
+ *   - parseDsl exit shape — `atr_multiple` SL + `fixed_pct` TP, drift here
+ *     would change behaviour.
+ *   - Sanity evaluator (negative cases only — pattern-positive fixtures
+ *     are deferred to docs/54-T3 §4):
+ *       * Calm/flat bundle across all three TFs → no entry; pattern
+ *         blocks legitimately produce zeros, AND-gate stays false.
+ *       * H4 downtrend (EMA50 < EMA200) → HTF bias filter blocks even
+ *         if the lower-TF patterns happened to fire.
+ *       * Pattern blocks resolve through the bundle without throwing
+ *         — exercises the runtime evaluator's MTF integration end-to-end
+ *         for SMC-pattern refs (their first appearance via DslSignalRef
+ *         with sourceTimeframe).
  *
  * Walk-forward acceptance, demo smoke, and the `pattern engine sanity`
  * fixture (54-T3 §4) need real data and known-sweep candle sequences —
@@ -26,9 +25,8 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
+import { dirname } from "node:path";
 import {
   evaluateSignal,
   parseDsl,
@@ -36,7 +34,6 @@ import {
   type DslSignal,
   type RuntimeMtfContext,
 } from "../../../src/lib/dslEvaluator.js";
-import { validateDsl } from "../../../src/lib/dslValidator.js";
 import {
   createCandleBundle,
   INTERVAL_MS,
@@ -44,100 +41,33 @@ import {
   type MtfCandle,
 } from "../../../src/lib/mtf/intervalAlignment.js";
 import { createMtfCache } from "../../../src/lib/mtf/mtfIndicatorResolver.js";
-import { BLOCK_SUPPORT_MAP } from "../../../src/lib/compiler/supportMap.ts";
+import { describeGoldenStrategyContract } from "../../_helpers/strategyAcceptance.js";
 
 // ---------------------------------------------------------------------------
-// Fixture / seed loading
+// Shared contract — seed/golden pin, validateDsl, parseDsl, supported blocks
 // ---------------------------------------------------------------------------
 
-const here = dirname(fileURLToPath(import.meta.url));
-const loadJson = (rel: string): unknown => JSON.parse(readFileSync(join(here, rel), "utf8"));
-
-const goldenDsl = loadJson("../../fixtures/strategies/smc-liquidity-sweep.golden.json") as Record<string, unknown>;
-const seed = loadJson("../../../prisma/seed/presets/smc-liquidity-sweep.json") as { dslJson: unknown };
-
-// ---------------------------------------------------------------------------
-// 1. Seed ⇄ golden pin
-// ---------------------------------------------------------------------------
-
-describe("smc-liquidity-sweep — seed/golden pin", () => {
-  it("seed.dslJson is byte-equal to the golden fixture", () => {
-    expect(seed.dslJson).toEqual(goldenDsl);
-  });
+const { golden: goldenDsl } = describeGoldenStrategyContract({
+  slug: "smc-liquidity-sweep",
+  baseDir: dirname(fileURLToPath(import.meta.url)),
+  goldenPath: "../../fixtures/strategies/smc-liquidity-sweep.golden.json",
+  seedPath: "../../../prisma/seed/presets/smc-liquidity-sweep.json",
 });
 
 // ---------------------------------------------------------------------------
-// 2. Schema + parse smoke
+// Strategy-specific: exit shape pin
 // ---------------------------------------------------------------------------
 
-describe("smc-liquidity-sweep — DSL validity", () => {
-  it("validates against the v2 strategy schema", () => {
-    const errors = validateDsl(goldenDsl);
-    expect(errors).toBeNull();
-  });
-
-  it("parseDsl yields a v2-shaped ParsedDsl with pattern-based signal + ATR exit", () => {
+describe("smc-liquidity-sweep — exit shape", () => {
+  it("parseDsl yields atr_multiple stopLoss + fixed_pct takeProfit", () => {
     const parsed = parseDsl(goldenDsl);
-    expect(parsed.dslVersion).toBe(2);
-    expect(parsed.entry.signal).toBeDefined();
     expect(parsed.exit?.stopLoss?.type).toBe("atr_multiple");
     expect(parsed.exit?.takeProfit?.type).toBe("fixed_pct");
   });
 });
 
 // ---------------------------------------------------------------------------
-// 3. No composite types — every block in BLOCK_SUPPORT_MAP, supported
-// ---------------------------------------------------------------------------
-
-function collectIndicatorBlockTypes(node: unknown, out = new Set<string>()): Set<string> {
-  if (Array.isArray(node)) {
-    for (const item of node) collectIndicatorBlockTypes(item, out);
-    return out;
-  }
-  if (node && typeof node === "object") {
-    const obj = node as Record<string, unknown>;
-    if (typeof obj.blockType === "string") out.add(obj.blockType);
-    if (typeof obj.type === "string") out.add(obj.type);
-    for (const v of Object.values(obj)) collectIndicatorBlockTypes(v, out);
-  }
-  return out;
-}
-
-const STRUCTURAL_TYPES = new Set([
-  "or", "and", "compare", "crossover", "crossunder", "confirm_n_bars",
-  "fixed_pct", "fixed_price", "atr_multiple",
-]);
-
-const SUPPORT_ALIASES: Record<string, string> = {
-  ema: "EMA", rsi: "RSI", sma: "SMA",
-  bollinger: "bollinger",
-  bollinger_lower: "bollinger", bollinger_upper: "bollinger", bollinger_middle: "bollinger",
-  bb_lower: "bollinger", bb_upper: "bollinger", bb_middle: "bollinger",
-};
-
-describe("smc-liquidity-sweep — uses only supported primitives", () => {
-  it("every indicator/block referenced is `supported` in BLOCK_SUPPORT_MAP", () => {
-    const types = collectIndicatorBlockTypes(goldenDsl);
-    const offenders: Array<{ name: string; reason: string }> = [];
-
-    for (const raw of types) {
-      if (STRUCTURAL_TYPES.has(raw)) continue;
-      const canonical = SUPPORT_ALIASES[raw] ?? raw;
-      const entry = BLOCK_SUPPORT_MAP[canonical];
-      if (!entry) {
-        offenders.push({ name: raw, reason: `not in BLOCK_SUPPORT_MAP (looked up as "${canonical}")` });
-        continue;
-      }
-      if (entry.status !== "supported") {
-        offenders.push({ name: raw, reason: `status is "${entry.status}", expected "supported"` });
-      }
-    }
-    expect(offenders).toEqual([]);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// 4. Sanity evaluator on a synthetic {M15, H1, H4} bundle
+// Strategy-specific: sanity evaluator on a synthetic {M15, H1, H4} bundle
 // ---------------------------------------------------------------------------
 
 const t0 = Date.UTC(2026, 0, 1, 0, 0, 0);


### PR DESCRIPTION
## Summary

Pulls the four contract assertions every flagship preset's golden test runs into a shared helper:

- seed/golden byte-equal pin,
- `validateDsl` schema check,
- `parseDsl` v2-shape smoke (`dslVersion=2`, `entry.signal` defined),
- supported-primitives walk over `BLOCK_SUPPORT_MAP` with shared `STRUCTURAL_TYPES` + `SUPPORT_ALIASES` tables.

The four flagship golden tests (`adaptive-regime`, `dca-momentum`, `mtf-scalper`, `smc-liquidity-sweep`) now call `describeGoldenStrategyContract` for the shared block, then keep their strategy-specific assertions inline:

- exit-shape pin (`atr_multiple` SL / `fixed_pct` TP / `indicatorExit` op),
- DCA-exposure planner check (`dca-momentum` only),
- sanity evaluator on synthetic candle bundles.

## Stats

| | Before | After |
|---|---|---|
| Per-strategy test file | ~210 lines × 4 | ~120 lines × 4 |
| Shared helper | — | 200 lines |
| Total | ~870 | ~680 |
| Test count (4 strategy files) | 28 | 32 |

The +4 tests are not new behaviour — every shared describe now has its own `it` block where before they were chained, so the helper splits them cleanly.

## What this PR does NOT do

- **Smoke-replay support** — intentionally absent. Recording a deterministic JSON of a 30-min Bybit-demo run requires the acceptance gates in `docs/53-T3` / `docs/54-T1..T3` / `docs/55-T6` to have actually run, which is blocked on demo creds.
- **Walk-forward CI sub-fixtures** — the second half of `docs/54-T5` is deferred to a follow-up PR; per-strategy mini-datasets are non-trivial to construct and worth their own changeset.

The helper is deliberately structured so `describeSmokeReplay` and `describeWalkForwardCi` can be added next to `describeGoldenStrategyContract` without touching the four flagship test files again.

## Test plan

- [x] `pnpm --filter @botmarketplace/api exec tsc --noEmit` ✓ (EXIT 0)
- [x] `pnpm --filter @botmarketplace/api exec vitest run tests/lib/strategies/` ✓ (32/32)
- [x] `pnpm --filter @botmarketplace/api test` ✓ (2069/2069)
- [ ] CI green


---
_Generated by [Claude Code](https://claude.ai/code/session_012z5NupTCzRjLgFvW7RDVEx)_