### PR TITLE
feat(presets): publishPreset.ts CLI for visibility flip (53-T4 + 54-T1..T3 closing)

### DIFF
--- a/apps/api/scripts/publishPreset.ts
+++ b/apps/api/scripts/publishPreset.ts
@@ -1,0 +1,171 @@
+#!/usr/bin/env tsx
+/**
+ * Promote a StrategyPreset to PUBLIC (or roll it back to PRIVATE) —
+ * admin CLI tool for the visibility-flip step shared by docs/53-T4 and
+ * docs/54-T1..T3 closing.
+ *
+ * Why a script and not an HTTP endpoint:
+ *   - Visibility flips are infrequent and audited (commit / chat record).
+ *   - There is no admin UI for `/presets` today — a CLI is the cleanest
+ *     interface that does not require building one.
+ *   - The script writes a one-line audit summary to stdout that
+ *     operators can paste into the gate companion-doc.
+ *
+ * Usage:
+ *   pnpm --filter @botmarketplace/api exec tsx scripts/publishPreset.ts \
+ *     --slug adaptive-regime --visibility PUBLIC
+ *
+ *   pnpm --filter @botmarketplace/api exec tsx scripts/publishPreset.ts \
+ *     --slug adaptive-regime --visibility PRIVATE --dry-run
+ *
+ * Lookup is by slug (unique). Visibility values must match the Prisma
+ * `PresetVisibility` enum — currently `PRIVATE` | `PUBLIC`. The BETA
+ * value lands with docs/55-T6; this script will accept it without
+ * source-edit once the enum is extended (we read the allowed values
+ * from `@prisma/client` at runtime).
+ *
+ * The script is idempotent: setting the visibility a preset already has
+ * is a no-op with a clear "already at <visibility>, no change" message.
+ */
+
+import { PrismaClient, PresetVisibility } from "@prisma/client";
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+
+export interface ParsedArgs {
+  slug?: string;
+  visibility?: string;
+  dryRun: boolean;
+}
+
+export function parseArgs(argv: readonly string[]): ParsedArgs {
+  const out: ParsedArgs = { dryRun: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--slug") out.slug = argv[++i];
+    else if (arg === "--visibility") out.visibility = argv[++i];
+    else if (arg === "--dry-run") out.dryRun = true;
+  }
+  return out;
+}
+
+/** All allowed visibility values, read from the generated enum so the
+ *  script picks up additions (BETA in 55-T6) without an edit here. */
+export function allowedVisibilities(): string[] {
+  return Object.values(PresetVisibility);
+}
+
+// ---------------------------------------------------------------------------
+// Core logic — exported so tests can drive it without spawning a process
+// ---------------------------------------------------------------------------
+
+export type PublishOutcome =
+  | { kind: "noop";       slug: string; visibility: PresetVisibility }
+  | { kind: "changed";    slug: string; from: PresetVisibility; to: PresetVisibility; dryRun: boolean }
+  | { kind: "not_found";  slug: string }
+  | { kind: "bad_input";  reason: string };
+
+export interface PublishArgs {
+  slug?: string;
+  visibility?: string;
+  dryRun?: boolean;
+  /** Inject a Prisma client (mock in tests). */
+  prisma: Pick<PrismaClient, "strategyPreset">;
+  /** Write audit messages somewhere (defaults to console.log). */
+  log?: (line: string) => void;
+}
+
+export async function publishPreset(args: PublishArgs): Promise<PublishOutcome> {
+  const log = args.log ?? ((line: string) => console.log(line));
+
+  if (!args.slug) {
+    return { kind: "bad_input", reason: "--slug <slug> is required" };
+  }
+  if (!args.visibility) {
+    return {
+      kind: "bad_input",
+      reason: `--visibility <${allowedVisibilities().join("|")}> is required`,
+    };
+  }
+  if (!allowedVisibilities().includes(args.visibility)) {
+    return {
+      kind: "bad_input",
+      reason: `invalid visibility "${args.visibility}", expected one of: ${allowedVisibilities().join(", ")}`,
+    };
+  }
+
+  const target = args.visibility as PresetVisibility;
+  const dryRun = args.dryRun ?? false;
+
+  const before = await args.prisma.strategyPreset.findUnique({
+    where: { slug: args.slug },
+    select: { slug: true, name: true, visibility: true, updatedAt: true },
+  });
+  if (!before) {
+    return { kind: "not_found", slug: args.slug };
+  }
+
+  if (before.visibility === target) {
+    log(`[publishPreset] ${before.slug} already at ${target}, no change`);
+    return { kind: "noop", slug: before.slug, visibility: target };
+  }
+
+  log(`[publishPreset] mode=${dryRun ? "dry-run" : "apply"}`);
+  log(`[publishPreset] ${before.slug}: ${before.visibility} → ${target}`);
+  log(`[publishPreset]   name: "${before.name}"`);
+  log(`[publishPreset]   updatedAt(before): ${before.updatedAt.toISOString()}`);
+
+  if (dryRun) {
+    log("[publishPreset] dry-run — no changes written");
+    return { kind: "changed", slug: before.slug, from: before.visibility, to: target, dryRun: true };
+  }
+
+  const updated = await args.prisma.strategyPreset.update({
+    where: { slug: before.slug },
+    data: { visibility: target },
+    select: { slug: true, visibility: true, updatedAt: true },
+  });
+  log(
+    `[publishPreset] OK ${updated.slug} → ${updated.visibility} ` +
+    `(updatedAt=${updated.updatedAt.toISOString()})`,
+  );
+  return { kind: "changed", slug: updated.slug, from: before.visibility, to: target, dryRun: false };
+}
+
+// ---------------------------------------------------------------------------
+// Process entry point — only when invoked directly, not on import.
+// ---------------------------------------------------------------------------
+
+const isDirectInvocation = (() => {
+  // Run when this file is the entry point. Vitest imports the module —
+  // we must not call main() under that scenario.
+  if (typeof process === "undefined" || !process.argv[1]) return false;
+  const entry = process.argv[1];
+  return entry.endsWith("publishPreset.ts") || entry.endsWith("publishPreset.js");
+})();
+
+if (isDirectInvocation) {
+  const cli = parseArgs(process.argv.slice(2));
+  const prisma = new PrismaClient();
+  publishPreset({ ...cli, prisma })
+    .then((out) => {
+      switch (out.kind) {
+        case "bad_input":
+          console.error(`error: ${out.reason}`);
+          process.exit(1);
+        case "not_found":
+          console.error(`error: preset not found: ${out.slug}`);
+          process.exit(2);
+        default:
+          // success — message already logged inside publishPreset.
+          process.exit(0);
+      }
+    })
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    })
+    .finally(() => prisma.$disconnect());
+}

--- a/apps/api/tests/scripts/publishPreset.test.ts
+++ b/apps/api/tests/scripts/publishPreset.test.ts
@@ -1,0 +1,212 @@
+/**
+ * publishPreset CLI — unit coverage (docs/53-T4 / 54-T1..T3 closing).
+ *
+ * Drives `publishPreset()` directly with an in-memory mock prisma so
+ * the visibility-flip logic is exercised without a database.
+ *
+ * Coverage:
+ *   1. argv parsing: --slug / --visibility / --dry-run.
+ *   2. Bad input: missing slug, missing visibility, invalid visibility.
+ *   3. Not-found preset → kind "not_found", no update.
+ *   4. Already-at-target → kind "noop", no update.
+ *   5. PRIVATE → PUBLIC apply → kind "changed", update called.
+ *   6. PRIVATE → PUBLIC dry-run → kind "changed" with dryRun=true, NO update.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  parseArgs,
+  publishPreset,
+  allowedVisibilities,
+} from "../../scripts/publishPreset.js";
+
+// ---------------------------------------------------------------------------
+// Mock prisma — minimum surface required by publishPreset
+// ---------------------------------------------------------------------------
+
+interface FakePreset {
+  slug: string;
+  name: string;
+  visibility: "PRIVATE" | "PUBLIC";
+  updatedAt: Date;
+}
+
+function buildPrisma(seed: FakePreset[]) {
+  const store = new Map<string, FakePreset>();
+  for (const p of seed) store.set(p.slug, { ...p });
+
+  const findUnique = vi.fn(async ({ where }: { where: { slug: string } }) => {
+    // Return a copy — real prisma never hands back a live reference.
+    const row = store.get(where.slug);
+    return row ? { ...row } : null;
+  });
+  const update = vi.fn(async ({ where, data }: { where: { slug: string }; data: { visibility: "PRIVATE" | "PUBLIC" } }) => {
+    const row = store.get(where.slug);
+    if (!row) throw new Error("test fixture: preset not present");
+    row.visibility = data.visibility;
+    row.updatedAt = new Date();
+    return row;
+  });
+
+  return {
+    prisma: { strategyPreset: { findUnique, update } } as never,
+    findUnique,
+    update,
+    store,
+  };
+}
+
+function silentLog() {
+  const lines: string[] = [];
+  return { log: (l: string) => lines.push(l), lines };
+}
+
+// ---------------------------------------------------------------------------
+// 1. argv parsing
+// ---------------------------------------------------------------------------
+
+describe("parseArgs", () => {
+  it("reads --slug, --visibility, --dry-run", () => {
+    const out = parseArgs(["--slug", "adaptive-regime", "--visibility", "PUBLIC", "--dry-run"]);
+    expect(out).toEqual({ slug: "adaptive-regime", visibility: "PUBLIC", dryRun: true });
+  });
+
+  it("dryRun defaults to false", () => {
+    const out = parseArgs(["--slug", "x", "--visibility", "PRIVATE"]);
+    expect(out.dryRun).toBe(false);
+  });
+
+  it("missing fields stay undefined", () => {
+    expect(parseArgs([])).toEqual({ dryRun: false });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. allowedVisibilities — sanity
+// ---------------------------------------------------------------------------
+
+describe("allowedVisibilities", () => {
+  it("contains PRIVATE and PUBLIC at minimum", () => {
+    const list = allowedVisibilities();
+    expect(list).toContain("PRIVATE");
+    expect(list).toContain("PUBLIC");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Bad input
+// ---------------------------------------------------------------------------
+
+describe("publishPreset — bad input", () => {
+  it("rejects missing slug", async () => {
+    const { prisma } = buildPrisma([]);
+    const out = await publishPreset({ visibility: "PUBLIC", prisma, log: () => {} });
+    expect(out).toMatchObject({ kind: "bad_input" });
+  });
+
+  it("rejects missing visibility", async () => {
+    const { prisma } = buildPrisma([]);
+    const out = await publishPreset({ slug: "x", prisma, log: () => {} });
+    expect(out).toMatchObject({ kind: "bad_input" });
+  });
+
+  it("rejects unknown visibility value", async () => {
+    const { prisma } = buildPrisma([]);
+    const out = await publishPreset({ slug: "x", visibility: "EXPERIMENTAL", prisma, log: () => {} });
+    expect(out).toMatchObject({ kind: "bad_input" });
+    if (out.kind === "bad_input") {
+      expect(out.reason).toMatch(/invalid visibility/);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Not-found preset
+// ---------------------------------------------------------------------------
+
+describe("publishPreset — not found", () => {
+  it("returns { kind: 'not_found' } when slug doesn't match", async () => {
+    const { prisma, update } = buildPrisma([]);
+    const out = await publishPreset({ slug: "ghost", visibility: "PUBLIC", prisma, log: () => {} });
+    expect(out).toEqual({ kind: "not_found", slug: "ghost" });
+    expect(update).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Already-at-target — noop
+// ---------------------------------------------------------------------------
+
+describe("publishPreset — noop", () => {
+  it("returns { kind: 'noop' } and skips update when visibility already matches", async () => {
+    const { prisma, update } = buildPrisma([{
+      slug: "adaptive-regime",
+      name: "Adaptive Regime",
+      visibility: "PUBLIC",
+      updatedAt: new Date("2026-04-01T00:00:00Z"),
+    }]);
+    const sink = silentLog();
+
+    const out = await publishPreset({ slug: "adaptive-regime", visibility: "PUBLIC", prisma, log: sink.log });
+
+    expect(out).toEqual({ kind: "noop", slug: "adaptive-regime", visibility: "PUBLIC" });
+    expect(update).not.toHaveBeenCalled();
+    expect(sink.lines.join(" ")).toMatch(/already at PUBLIC/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Apply path
+// ---------------------------------------------------------------------------
+
+describe("publishPreset — apply", () => {
+  it("PRIVATE → PUBLIC writes the update and returns { kind: 'changed', dryRun: false }", async () => {
+    const { prisma, update, store } = buildPrisma([{
+      slug: "dca-momentum",
+      name: "DCA Momentum",
+      visibility: "PRIVATE",
+      updatedAt: new Date("2026-04-01T00:00:00Z"),
+    }]);
+    const sink = silentLog();
+
+    const out = await publishPreset({
+      slug: "dca-momentum", visibility: "PUBLIC", dryRun: false, prisma, log: sink.log,
+    });
+
+    expect(out).toMatchObject({
+      kind: "changed",
+      slug: "dca-momentum",
+      from: "PRIVATE",
+      to: "PUBLIC",
+      dryRun: false,
+    });
+    expect(update).toHaveBeenCalledOnce();
+    expect(store.get("dca-momentum")?.visibility).toBe("PUBLIC");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Dry-run path
+// ---------------------------------------------------------------------------
+
+describe("publishPreset — dry-run", () => {
+  it("PRIVATE → PUBLIC with --dry-run does NOT call update; returns dryRun: true", async () => {
+    const { prisma, update, store } = buildPrisma([{
+      slug: "smc-liquidity-sweep",
+      name: "SMC Liquidity Sweep",
+      visibility: "PRIVATE",
+      updatedAt: new Date("2026-04-01T00:00:00Z"),
+    }]);
+    const sink = silentLog();
+
+    const out = await publishPreset({
+      slug: "smc-liquidity-sweep", visibility: "PUBLIC", dryRun: true, prisma, log: sink.log,
+    });
+
+    expect(out).toMatchObject({ kind: "changed", dryRun: true });
+    expect(update).not.toHaveBeenCalled();
+    // Store unchanged — dry-run.
+    expect(store.get("smc-liquidity-sweep")?.visibility).toBe("PRIVATE");
+    expect(sink.lines.join(" ")).toMatch(/dry-run/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `apps/api/scripts/publishPreset.ts` — admin CLI that flips a `StrategyPreset`'s visibility between `PRIVATE` and `PUBLIC`. Closes the publish step shared by `docs/53-T4` and the `docs/54-T1/T2/T3` acceptance gates.

## Why this script

The `seedPresets` path creates flagship presets as `PRIVATE` and the seed's update branch deliberately preserves whatever visibility an admin already set (`apps/api/prisma/seed/seedPresets.ts:62`). Until now the only way to perform the flip was a direct SQL `UPDATE` — this script makes the action visible, idempotent, and auditable via stdout.

## Usage

```bash
# Promote
pnpm --filter @botmarketplace/api exec tsx scripts/publishPreset.ts \
  --slug adaptive-regime --visibility PUBLIC

# Roll back
pnpm --filter @botmarketplace/api exec tsx scripts/publishPreset.ts \
  --slug adaptive-regime --visibility PRIVATE

# Preview
pnpm --filter @botmarketplace/api exec tsx scripts/publishPreset.ts \
  --slug adaptive-regime --visibility PUBLIC --dry-run
```

## Behaviour

- `--dry-run` prints the planned diff without writing.
- Already-at-target → `"no change"` message, returns `kind: 'noop'`.
- Allowed visibilities are read from the generated `PresetVisibility` enum, so once `docs/55-T6` extends it with `BETA` the script accepts it without an edit here.
- Direct prisma update — no HTTP route added, since visibility flips are infrequent and audited via the commit log / chat record.

## Architecture

`publishPreset()` is the testable core, exported from the same file. The script's process entry point only runs when the file is invoked as a script (the `isDirectInvocation` guard checks `process.argv[1]`), so importing it from a test file does NOT trigger any DB connection.

## Test plan

- [x] `pnpm --filter @botmarketplace/api exec tsc --noEmit` ✓ (EXIT 0)
- [x] `pnpm --filter @botmarketplace/api exec vitest run tests/scripts/publishPreset.test.ts` ✓ (11/11)
- [x] `pnpm --filter @botmarketplace/api test` ✓ (2080/2080)
- [ ] CI green


---
_Generated by [Claude Code](https://claude.ai/code/session_012z5NupTCzRjLgFvW7RDVEx)_