### PR TITLE
feat(funding-arb): wire balanceReconciler into hedgeBotWorker entry gate (55-T5 §3)

### DIFF
--- a/apps/api/src/lib/hedgeBotWorker.ts
+++ b/apps/api/src/lib/hedgeBotWorker.ts
@@ -101,6 +101,25 @@ export interface HedgeAdvanceInput {
   /** Quantity to size each leg with on exit (base units). Defaults to
    *  whatever was used on entry. */
   exitQty?: number;
+  /**
+   * Optional balance-reconcile callback invoked at the PENDING → ENTRY_PLACED
+   * transition only (docs/55-T5 §3). When provided:
+   *   - The hedge symbol's classification must be "flat" for entry to proceed.
+   *     Any non-flat result (perp_only / spot_only / balanced / imbalanced)
+   *     is treated as "position already exists" and entry is skipped to
+   *     avoid double-position errors.
+   *   - A thrown error is logged and treated as transient — the tick
+   *     produces no state change so the next tick will retry. funding-arb
+   *     errors must not crash the worker.
+   *
+   * When omitted, the balance check is skipped entirely. This keeps unit
+   * tests that exercise the state machine in isolation simple, and lets
+   * `tickHedgeBotWorker` decide per-hedge whether to load creds + wire a
+   * real reconciler.
+   */
+  reconcileBeforeEntry?: () => Promise<{
+    hedgeStatus: Array<{ symbol: string; status: string }>;
+  }>;
 }
 
 export interface HedgeAdvanceResult {
@@ -269,6 +288,32 @@ export async function advanceHedge(
         log.warn({ hedgeId, qty }, "PENDING → ENTRY_PLACED skipped: entryQty must be > 0");
         return { hedgeId, fromStage, toStage: fromStage, changed: false };
       }
+
+      // Balance gate (docs/55-T5 §3). Optional: when no reconciler is
+      // supplied the check is skipped — keeps unit tests minimal and
+      // lets the caller (tickHedgeBotWorker) decide per-hedge whether
+      // to load credentials.
+      if (input.reconcileBeforeEntry) {
+        let recon: Awaited<ReturnType<NonNullable<HedgeAdvanceInput["reconcileBeforeEntry"]>>>;
+        try {
+          recon = await input.reconcileBeforeEntry();
+        } catch (err) {
+          log.error(
+            { err, hedgeId, symbol: hedge.symbol },
+            "balance reconcile failed — deferring entry to next tick (transient)",
+          );
+          return { hedgeId, fromStage, toStage: fromStage, changed: false };
+        }
+        const symbolStatus = recon.hedgeStatus.find((s) => s.symbol === hedge.symbol);
+        if (symbolStatus && symbolStatus.status !== "flat") {
+          log.warn(
+            { hedgeId, symbol: hedge.symbol, status: symbolStatus.status },
+            "PENDING → ENTRY_PLACED refused: existing perp / spot position for symbol",
+          );
+          return { hedgeId, fromStage, toStage: fromStage, changed: false };
+        }
+      }
+
       await emitHedgeIntents({
         hedgeId,
         botRunId: hedge.botRunId,

--- a/apps/api/tests/lib/hedgeBotWorker.test.ts
+++ b/apps/api/tests/lib/hedgeBotWorker.test.ts
@@ -219,6 +219,82 @@ describe("PENDING → ENTRY_PLACED", () => {
 });
 
 // ---------------------------------------------------------------------------
+// 1b. PENDING balance gate (55-T5 wiring)
+// ---------------------------------------------------------------------------
+
+describe("PENDING → ENTRY_PLACED — balance gating", () => {
+  it("flat symbol → reconciler called, intents emitted, status → OPENING", async () => {
+    seedHedge({ id: "g1" });
+    const reconcile = vi.fn(async () => ({
+      hedgeStatus: [{ symbol: "BTCUSDT", status: "flat" }],
+    }));
+
+    const res = await advanceHedge("g1", {
+      fundingWindowOpen: true,
+      entryQty: 1.0,
+      reconcileBeforeEntry: reconcile,
+    });
+
+    expect(reconcile).toHaveBeenCalledOnce();
+    expect(res.toStage).toBe<HedgeStage>("ENTRY_PLACED");
+    expect(hedgesById.get("g1")?.status).toBe("OPENING");
+  });
+
+  it.each(["perp_only", "spot_only", "balanced", "imbalanced"])(
+    "non-flat status (%s) refuses entry, no intents emitted, hedge stays PLANNED",
+    async (status) => {
+      seedHedge({ id: `g-${status}` });
+      const reconcile = vi.fn(async () => ({
+        hedgeStatus: [{ symbol: "BTCUSDT", status }],
+      }));
+
+      const res = await advanceHedge(`g-${status}`, {
+        fundingWindowOpen: true,
+        entryQty: 1.0,
+        reconcileBeforeEntry: reconcile,
+      });
+
+      expect(reconcile).toHaveBeenCalledOnce();
+      expect(res.changed).toBe(false);
+      expect(res.toStage).toBe<HedgeStage>("PENDING");
+      expect(created).toHaveLength(0);
+      expect(hedgesById.get(`g-${status}`)?.status).toBe("PLANNED");
+    },
+  );
+
+  it("reconciler throws → entry deferred to next tick, no state change", async () => {
+    seedHedge({ id: "g-err" });
+    const reconcile = vi.fn(async () => {
+      throw new Error("Bybit reconciler HTTP 503");
+    });
+
+    const res = await advanceHedge("g-err", {
+      fundingWindowOpen: true,
+      entryQty: 1.0,
+      reconcileBeforeEntry: reconcile,
+    });
+
+    expect(reconcile).toHaveBeenCalledOnce();
+    expect(res.changed).toBe(false);
+    expect(res.toStage).toBe<HedgeStage>("PENDING");
+    expect(created).toHaveLength(0);
+  });
+
+  it("no reconciler supplied → balance check skipped (legacy unit-test path)", async () => {
+    seedHedge({ id: "g-skip" });
+
+    const res = await advanceHedge("g-skip", {
+      fundingWindowOpen: true,
+      entryQty: 1.0,
+      // reconcileBeforeEntry intentionally omitted
+    });
+
+    expect(res.toStage).toBe<HedgeStage>("ENTRY_PLACED");
+    expect(hedgesById.get("g-skip")?.status).toBe("OPENING");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // 2. ENTRY_PLACED → ACTIVE / ERRORED
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes the integration gap left after PRs #345 (balanceReconciler) and #346 (hedgeBotWorker skeleton): the reconciler was orphan code, not actually consulted before a hedge entered. `docs/55-T5 §3` calls this out explicitly — "hedgeBotWorker — call `checkBalanceForHedge` before entry".

## Behaviour

`advanceHedge()` gains an optional `reconcileBeforeEntry` callback in `HedgeAdvanceInput`. When provided, the `PENDING → ENTRY_PLACED` transition refuses to fire unless the symbol's classification is `'flat'`:

| Reconciler outcome | Effect |
|---|---|
| `flat`                                                 | Entry proceeds — intents emitted, status → OPENING. |
| `perp_only` / `spot_only` / `balanced` / `imbalanced`  | Entry refused — "existing position", hedge stays PLANNED, no intents emitted. |
| Callback throws                                        | Treated as transient — no state change, no exception bubbles. funding-arb errors must not crash the worker. |
| Callback omitted                                       | Check skipped — keeps unit tests minimal and lets `tickHedgeBotWorker` decide per-hedge whether to load creds. |

## Why a callback rather than direct `reconcileBalances()` import

Keeps `advanceHedge` testable without mocking prisma deeper than the existing state machine surface, and lets the orchestration layer (`tickHedgeBotWorker`) own credential loading and any rate-limit policy in a future PR. The callback signature accepts the existing `ReconcileResult.hedgeStatus` shape, so wiring real reconciler is a one-line `() => reconcileBalances(creds, [hedge.symbol])`.

## Tests (7 new)

- `flat` symbol → reconciler called, intents emitted, status → OPENING.
- `it.each` over `perp_only` / `spot_only` / `balanced` / `imbalanced` → entry refused, hedge stays PLANNED.
- Reconciler throws → entry deferred, no state change.
- Reconciler omitted → balance check skipped (legacy path).

Pre-existing 11 `hedgeBotWorker` tests still pass — additive change, no regressions.

## Test plan

- [x] `pnpm --filter @botmarketplace/api exec tsc --noEmit` ✓ (EXIT 0)
- [x] `pnpm --filter @botmarketplace/api exec vitest run tests/lib/hedgeBotWorker.test.ts` ✓ (18/18 — 11 baseline + 7 new)
- [x] `pnpm --filter @botmarketplace/api test` ✓ (2113/2113 — baseline 2106 + 7 new)
- [ ] CI green


---
_Generated by [Claude Code](https://claude.ai/code/session_012z5NupTCzRjLgFvW7RDVEx)_