### PR TITLE
feat(funding-arb): tickHedgeBotWorker loads creds + wires reconcileBalances by default

### DIFF
--- a/apps/api/src/lib/hedgeBotWorker.ts
+++ b/apps/api/src/lib/hedgeBotWorker.ts
@@ -44,6 +44,10 @@ import { randomUUID } from "node:crypto";
 import { prisma } from "./prisma.js";
 import { logger } from "./logger.js";
 import { classifyExecutionError } from "./errorClassifier.js";
+import {
+  reconcileBalances,
+  type ExchangeConnectionCreds,
+} from "./exchange/balanceReconciler.js";
 
 const log = logger.child({ module: "hedgeBotWorker" });
 
@@ -397,21 +401,71 @@ export async function advanceHedge(
 // Tick loop
 // ---------------------------------------------------------------------------
 
+/**
+ * Load the exchange credentials linked to a hedge via its BotRun → Bot →
+ * ExchangeConnection chain. Returns null if any link is missing — the
+ * caller treats null as "skip the balance check" (safer than blocking
+ * forever on a misconfigured bot).
+ *
+ * The select intentionally pulls only the four credential columns the
+ * reconciler needs; nothing else from ExchangeConnection leaks to the
+ * worker context.
+ */
+async function loadHedgeCreds(botRunId: string): Promise<ExchangeConnectionCreds | null> {
+  const run = await prisma.botRun.findUnique({
+    where: { id: botRunId },
+    select: {
+      bot: {
+        select: {
+          exchangeConnection: {
+            select: {
+              apiKey: true,
+              encryptedSecret: true,
+              spotApiKey: true,
+              spotEncryptedSecret: true,
+            },
+          },
+        },
+      },
+    },
+  });
+  return run?.bot?.exchangeConnection ?? null;
+}
+
 /** One pass: advance every non-terminal hedge. Per-hedge errors are
  *  logged + classified but NEVER bubble — funding-arb errors must not
- *  take down the worker. */
+ *  take down the worker.
+ *
+ *  Behaviour:
+ *   - Default path (no `inputResolver` supplied): for each hedge, load
+ *     creds via `loadHedgeCreds` and wire a `reconcileBeforeEntry`
+ *     callback so the PENDING → ENTRY_PLACED gate consults the live
+ *     Bybit wallet (docs/55-T5 §3). Hedges whose Bot has no linked
+ *     ExchangeConnection skip the check (callback omitted) — no
+ *     blocking, just a warning in the log.
+ *   - Caller-supplied path (`inputResolver` provided): tests + advanced
+ *     callers fully own the input shape. The default credential loader
+ *     is NOT layered underneath — explicit beats implicit.
+ *
+ *  Funding-window / funding-payment signals must still be supplied by
+ *  whichever upstream owns scanner / payment-ledger lookups (out of
+ *  scope for this PR — currently absent, so PENDING / ACTIVE hedges
+ *  no-op until that wiring lands).
+ */
 export async function tickHedgeBotWorker(
   inputResolver?: (hedgeId: string) => HedgeAdvanceInput | Promise<HedgeAdvanceInput>,
 ): Promise<HedgeAdvanceResult[]> {
   const candidates = await prisma.hedgePosition.findMany({
     where: { status: { in: ["PLANNED", "OPENING", "OPEN", "CLOSING"] } },
-    select: { id: true },
+    select: { id: true, symbol: true, botRunId: true },
   });
 
   const out: HedgeAdvanceResult[] = [];
   for (const c of candidates) {
     try {
-      const input = inputResolver ? await inputResolver(c.id) : {};
+      const input = inputResolver
+        ? await inputResolver(c.id)
+        : await buildDefaultInput(c);
       const res = await advanceHedge(c.id, input);
       out.push(res);
     } catch (err) {
@@ -421,6 +475,26 @@ export async function tickHedgeBotWorker(
     }
   }
   return out;
+}
+
+/**
+ * Default `HedgeAdvanceInput` builder used when no `inputResolver` is
+ * supplied. Wires the reconciler callback so production ticks consult
+ * the live Bybit wallet at the entry gate. Funding-window / payment
+ * signals stay undefined here — they are upstream signals out of scope
+ * for this orchestration step.
+ */
+async function buildDefaultInput(
+  hedge: { id: string; symbol: string; botRunId: string },
+): Promise<HedgeAdvanceInput> {
+  const creds = await loadHedgeCreds(hedge.botRunId);
+  if (!creds) {
+    log.warn({ hedgeId: hedge.id }, "no ExchangeConnection linked — balance check skipped");
+    return {};
+  }
+  return {
+    reconcileBeforeEntry: () => reconcileBalances(creds, [hedge.symbol]),
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/tests/lib/hedgeBotWorker.test.ts
+++ b/apps/api/tests/lib/hedgeBotWorker.test.ts
@@ -42,12 +42,19 @@ interface FakeIntent {
 
 const hedgesById = new Map<string, FakeHedge>();
 const intents: FakeIntent[] = [];
+const connectionsByBotRunId = new Map<string, {
+  apiKey: string;
+  encryptedSecret: string;
+  spotApiKey: string | null;
+  spotEncryptedSecret: string | null;
+} | null>();
 const created: Array<Partial<FakeIntent> & { qty?: number; orderLinkId?: string; side?: string }> = [];
 const updates: Array<{ id: string; data: Record<string, unknown> }> = [];
 
 function resetState() {
   hedgesById.clear();
   intents.length = 0;
+  connectionsByBotRunId.clear();
   created.length = 0;
   updates.length = 0;
 }
@@ -62,7 +69,7 @@ vi.mock("../../src/lib/prisma.js", () => ({
         const statuses = new Set(where.status.in);
         return [...hedgesById.values()]
           .filter((h) => statuses.has(h.status))
-          .map((h) => ({ id: h.id }));
+          .map((h) => ({ id: h.id, symbol: h.symbol, botRunId: h.botRunId }));
       }),
       update: vi.fn(async ({ where, data }: { where: { id: string }; data: Record<string, unknown> }) => {
         const h = hedgesById.get(where.id);
@@ -71,6 +78,16 @@ vi.mock("../../src/lib/prisma.js", () => ({
         }
         updates.push({ id: where.id, data });
         return h;
+      }),
+    },
+    botRun: {
+      findUnique: vi.fn(async ({ where }: { where: { id: string } }) => {
+        // The real query goes BotRun → Bot → ExchangeConnection. We
+        // collapse it to a single map keyed by botRunId for tests; the
+        // hedgeBotWorker only reads `run?.bot?.exchangeConnection`.
+        const conn = connectionsByBotRunId.get(where.id);
+        if (conn === undefined) return null;
+        return { bot: { exchangeConnection: conn } };
       }),
     },
     botIntent: {
@@ -98,6 +115,11 @@ vi.mock("../../src/lib/prisma.js", () => ({
       return Promise.all(ops as Promise<unknown>[]);
     }),
   },
+}));
+
+const reconcileBalancesMock = vi.fn();
+vi.mock("../../src/lib/exchange/balanceReconciler.js", () => ({
+  reconcileBalances: (...args: unknown[]) => reconcileBalancesMock(...args),
 }));
 
 vi.mock("../../src/lib/logger.js", () => ({
@@ -405,6 +427,53 @@ describe("tickHedgeBotWorker", () => {
     seedHedge({ id: "terminal", status: "CLOSED" });
     const res = await tickHedgeBotWorker();
     expect(res).toEqual([]);
+  });
+
+  // -------------------------------------------------------------------------
+  // Default-path orchestration: load creds → wire reconcileBalances callback
+  //
+  // The default path produces input { reconcileBeforeEntry: <wired> } only —
+  // it does NOT set fundingWindowOpen, because that signal is owned by the
+  // upstream funding scanner (out of scope here). So in these tests the
+  // PENDING gate short-circuits on the closed-window check before the
+  // reconciler is ever consulted. We instead pin:
+  //   * loadHedgeCreds runs (BotRun.findUnique called with the right id),
+  //   * advance returns no-change at the closed-window branch,
+  //   * the reconciler is NEVER called when the window is closed even
+  //     though the wiring is in place.
+  //
+  // Once the funding-scanner layer lands, a fresh test here will cover
+  // the open-window path end-to-end.
+  // -------------------------------------------------------------------------
+
+  it("default path: loads ExchangeConnection via BotRun.findUnique", async () => {
+    seedHedge({ id: "tick-1", status: "PLANNED", symbol: "BTCUSDT", botRunId: "run-tick-1" });
+    connectionsByBotRunId.set("run-tick-1", {
+      apiKey: "k", encryptedSecret: "enc:s",
+      spotApiKey: "sk", spotEncryptedSecret: "enc:ss",
+    });
+
+    const { prisma } = await import("../../src/lib/prisma.js");
+
+    await tickHedgeBotWorker();
+
+    expect((prisma.botRun.findUnique as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "run-tick-1" } }),
+    );
+    // Closed window ⇒ no reconciler call, but wiring was prepared.
+    expect(reconcileBalancesMock).not.toHaveBeenCalled();
+    expect(hedgesById.get("tick-1")?.status).toBe("PLANNED");
+  });
+
+  it("default path: hedge without linked ExchangeConnection — reconciler not wired, no error", async () => {
+    seedHedge({ id: "tick-2", status: "PLANNED", symbol: "BTCUSDT", botRunId: "run-tick-2" });
+    // No connectionsByBotRunId entry for run-tick-2 → loadHedgeCreds returns null.
+
+    const res = await tickHedgeBotWorker();
+
+    expect(res[0]).toMatchObject({ hedgeId: "tick-2", toStage: "PENDING", changed: false });
+    expect(reconcileBalancesMock).not.toHaveBeenCalled();
+    expect(hedgesById.get("tick-2")?.status).toBe("PLANNED");
   });
 });
 


### PR DESCRIPTION
## Summary

Closes the production-path gap left after PR #353 (callback was supplied only by tests). The default `tickHedgeBotWorker` path now loads `ExchangeConnection` through `BotRun → Bot → ExchangeConnection` and wires `reconcileBeforeEntry` to call `reconcileBalances([symbol])` at the `PENDING` gate. funding-arb integration is now end-to-end wired: balanceReconciler (#345) → hedgeBotWorker entry gate (#353) → orchestration (this PR).

## Behaviour

| Path | Behaviour |
|---|---|
| **Default** (no `inputResolver`) | Loads creds, wires reconciler callback. `fundingWindowOpen` stays undefined here — upstream funding scanner still owns that signal, so PENDING / ACTIVE hedges no-op until that wiring lands. The reconciler wiring is in place and ready. |
| **Caller-supplied** (`inputResolver`) | Tests + advanced callers fully own input. The default credential loader is NOT layered underneath: explicit beats implicit. |
| **No ExchangeConnection linked** | Helper logs a warning and returns an empty input — callback omitted ⇒ balance check skipped rather than blocking on a misconfigured bot. |

## Implementation notes

- `loadHedgeCreds(botRunId)` selects only the four credential columns the reconciler needs; nothing else from `ExchangeConnection` leaks to the worker context.
- `hedgePosition.findMany` now selects `{ id, symbol, botRunId }` — the extra two fields let `buildDefaultInput` build the per-hedge callback without a second `findUnique` round-trip.

## Tests (2 new)

- Default path with linked `ExchangeConnection` → `BotRun.findUnique` is called with the right id; reconciler is NOT invoked while the funding window is closed (correct skip).
- Default path without linked `ExchangeConnection` → reconciler not wired (warn logged); hedge stays `PLANNED`.

The 18 pre-existing `hedgeBotWorker` tests still pass.

## Test plan

- [x] `pnpm --filter @botmarketplace/api exec tsc --noEmit` ✓ (EXIT 0)
- [x] `pnpm --filter @botmarketplace/api exec vitest run tests/lib/hedgeBotWorker.test.ts` ✓ (20/20 — 18 baseline + 2 new)
- [x] `pnpm --filter @botmarketplace/api test` ✓ (2115/2115 — baseline 2113 + 2 new)
- [ ] CI green


---
_Generated by [Claude Code](https://claude.ai/code/session_012z5NupTCzRjLgFvW7RDVEx)_