### PR TITLE
feat(funding-arb): timestamp-based funding window detector + tick wiring

### DIFF
--- a/apps/api/src/lib/funding/windowDetector.ts
+++ b/apps/api/src/lib/funding/windowDetector.ts
@@ -1,0 +1,75 @@
+/**
+ * Funding-window detector — derives the two upstream signals the
+ * funding-arb runtime needs (`fundingWindowOpen`, `fundingPaymentReceived`)
+ * from the most recent `FundingSnapshot.nextFundingAt` for a symbol.
+ *
+ * This is the timestamp-based approximation. The "real" payment check
+ * (Bybit `/v5/account/transaction-log` query) lands with docs/55-T2
+ * once private API wiring is complete; until then the worker treats
+ * the funding event timestamp itself as the proxy for "payment landed",
+ * with a small lag buffer to absorb settlement latency.
+ *
+ * Bybit perpetual funding settles every 8 hours (00:00, 08:00, 16:00 UTC).
+ * `FundingSnapshot.nextFundingAt` is populated by the ingestion cron
+ * every 8 hours (`apps/api/src/lib/funding/ingestJob.ts`); the value is
+ * read-only here — we never write to it.
+ *
+ * Window definitions:
+ *   - Entry window: `nextFundingAt - now ∈ (0, ENTRY_PRE_BUFFER_MS]`.
+ *     Opens 30 minutes before the funding event by default. Pre-buffer
+ *     keeps the worker from racing the settlement tick.
+ *   - Payment window: `now - nextFundingAt ∈ [PAYMENT_LAG_MS, PAYMENT_WINDOW_MS]`.
+ *     Treats funding as "received" 1 minute after settlement and stays
+ *     open for 30 minutes — long enough for a tick (60s cadence) to
+ *     pick it up at least once but short enough that a stale snapshot
+ *     does not falsely re-trigger an exit on a hedge that already
+ *     closed.
+ */
+
+import { prisma } from "../prisma.js";
+
+export const ENTRY_PRE_BUFFER_MS = 30 * 60_000; // 30 min before funding
+export const PAYMENT_LAG_MS = 60_000;           // 1 min after funding
+export const PAYMENT_WINDOW_MS = 30 * 60_000;   // 30 min payment window
+
+export interface FundingWindow {
+  /** True when `now` is in the entry pre-buffer (before settlement). */
+  open: boolean;
+  /** True when settlement has cleared and the payment window is still open. */
+  paymentReceived: boolean;
+  /** ms epoch of the next funding settlement, or null if no snapshot. */
+  nextFundingAtMs: number | null;
+}
+
+/**
+ * Read the latest `FundingSnapshot.nextFundingAt` for `symbol` and
+ * derive the entry / payment signals at `nowMs`.
+ *
+ * Returns `{ open: false, paymentReceived: false, nextFundingAtMs: null }`
+ * when no snapshot exists for the symbol (the funding ingestion cron
+ * has not seen it yet, or symbol is not on Bybit perpetuals).
+ */
+export async function detectFundingWindow(
+  symbol: string,
+  nowMs: number,
+): Promise<FundingWindow> {
+  const snap = await prisma.fundingSnapshot.findFirst({
+    where: { symbol },
+    orderBy: { timestamp: "desc" },
+    select: { nextFundingAt: true },
+  });
+  if (!snap) {
+    return { open: false, paymentReceived: false, nextFundingAtMs: null };
+  }
+
+  const nextFundingAtMs = snap.nextFundingAt.getTime();
+  const untilFunding = nextFundingAtMs - nowMs;
+  const sinceFunding = nowMs - nextFundingAtMs;
+
+  return {
+    open: untilFunding > 0 && untilFunding <= ENTRY_PRE_BUFFER_MS,
+    paymentReceived:
+      sinceFunding >= PAYMENT_LAG_MS && sinceFunding <= PAYMENT_WINDOW_MS,
+    nextFundingAtMs,
+  };
+}

--- a/apps/api/src/lib/hedgeBotWorker.ts
+++ b/apps/api/src/lib/hedgeBotWorker.ts
@@ -48,6 +48,7 @@ import {
   reconcileBalances,
   type ExchangeConnectionCreds,
 } from "./exchange/balanceReconciler.js";
+import { detectFundingWindow } from "./funding/windowDetector.js";
 
 const log = logger.child({ module: "hedgeBotWorker" });
 
@@ -480,19 +481,30 @@ export async function tickHedgeBotWorker(
 /**
  * Default `HedgeAdvanceInput` builder used when no `inputResolver` is
  * supplied. Wires the reconciler callback so production ticks consult
- * the live Bybit wallet at the entry gate. Funding-window / payment
- * signals stay undefined here — they are upstream signals out of scope
- * for this orchestration step.
+ * the live Bybit wallet at the entry gate, and derives funding-window
+ * signals from the latest `FundingSnapshot.nextFundingAt` via
+ * `detectFundingWindow`. Read-only; safe to call concurrently across
+ * hedges within one tick.
  */
 async function buildDefaultInput(
   hedge: { id: string; symbol: string; botRunId: string },
 ): Promise<HedgeAdvanceInput> {
+  const window = await detectFundingWindow(hedge.symbol, Date.now());
   const creds = await loadHedgeCreds(hedge.botRunId);
+
   if (!creds) {
-    log.warn({ hedgeId: hedge.id }, "no ExchangeConnection linked — balance check skipped");
-    return {};
+    log.warn(
+      { hedgeId: hedge.id, symbol: hedge.symbol },
+      "no ExchangeConnection linked — balance check skipped",
+    );
+    return {
+      fundingWindowOpen: window.open,
+      fundingPaymentReceived: window.paymentReceived,
+    };
   }
   return {
+    fundingWindowOpen: window.open,
+    fundingPaymentReceived: window.paymentReceived,
     reconcileBeforeEntry: () => reconcileBalances(creds, [hedge.symbol]),
   };
 }

--- a/apps/api/tests/lib/funding/windowDetector.test.ts
+++ b/apps/api/tests/lib/funding/windowDetector.test.ts
@@ -1,0 +1,122 @@
+/**
+ * windowDetector — unit coverage (docs/55-T4 follow-up).
+ *
+ * Mocks prisma.fundingSnapshot.findFirst to feed canned `nextFundingAt`
+ * values, then pins the entry / payment signals at carefully-chosen
+ * `now` offsets. Confirms:
+ *
+ *   1. No snapshot present → both signals false, nextFundingAtMs null.
+ *   2. now >> nextFundingAt → both signals false (stale snapshot,
+ *      payment window has long since closed).
+ *   3. now ∈ (next - 30min, next) → entry window OPEN, payment false.
+ *   4. now ∈ (next - 31min, next - 30min) → both false (one minute
+ *      before the entry window opens — pin the boundary).
+ *   5. now ∈ (next + 1min, next + 30min) → payment received, entry false.
+ *   6. now > next + 30min → both false (payment window closed).
+ *   7. Exact boundaries — `now == next` → both false (atomic settlement
+ *      window; need at least the lag buffer to claim "received").
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let canned: { nextFundingAt: Date } | null = null;
+
+vi.mock("../../../src/lib/prisma.js", () => ({
+  prisma: {
+    fundingSnapshot: {
+      findFirst: vi.fn(async () => canned),
+    },
+  },
+}));
+
+import {
+  detectFundingWindow,
+  ENTRY_PRE_BUFFER_MS,
+  PAYMENT_LAG_MS,
+  PAYMENT_WINDOW_MS,
+} from "../../../src/lib/funding/windowDetector.js";
+
+const NEXT_FUNDING_MS = Date.UTC(2026, 4, 2, 16, 0, 0); // 2026-05-02T16:00:00Z
+const NEXT_FUNDING_DATE = new Date(NEXT_FUNDING_MS);
+
+beforeEach(() => {
+  canned = { nextFundingAt: NEXT_FUNDING_DATE };
+});
+
+afterEach(() => {
+  canned = null;
+});
+
+describe("detectFundingWindow — no snapshot", () => {
+  it("returns all-false / null when fundingSnapshot.findFirst yields nothing", async () => {
+    canned = null;
+    const out = await detectFundingWindow("BTCUSDT", NEXT_FUNDING_MS - 60_000);
+    expect(out).toEqual({ open: false, paymentReceived: false, nextFundingAtMs: null });
+  });
+});
+
+describe("detectFundingWindow — entry window", () => {
+  it("OPEN when now is 1 minute before funding", async () => {
+    const out = await detectFundingWindow("BTCUSDT", NEXT_FUNDING_MS - 60_000);
+    expect(out.open).toBe(true);
+    expect(out.paymentReceived).toBe(false);
+    expect(out.nextFundingAtMs).toBe(NEXT_FUNDING_MS);
+  });
+
+  it("OPEN at the exact pre-buffer boundary (now = next - 30min)", async () => {
+    const out = await detectFundingWindow("BTCUSDT", NEXT_FUNDING_MS - ENTRY_PRE_BUFFER_MS);
+    expect(out.open).toBe(true);
+  });
+
+  it("CLOSED 1ms before the entry window opens", async () => {
+    const out = await detectFundingWindow("BTCUSDT", NEXT_FUNDING_MS - ENTRY_PRE_BUFFER_MS - 1);
+    expect(out.open).toBe(false);
+    expect(out.paymentReceived).toBe(false);
+  });
+});
+
+describe("detectFundingWindow — payment window", () => {
+  it("OPEN at PAYMENT_LAG_MS after funding", async () => {
+    const out = await detectFundingWindow("BTCUSDT", NEXT_FUNDING_MS + PAYMENT_LAG_MS);
+    expect(out.open).toBe(false);
+    expect(out.paymentReceived).toBe(true);
+  });
+
+  it("OPEN at the far edge (next + PAYMENT_WINDOW_MS)", async () => {
+    const out = await detectFundingWindow("BTCUSDT", NEXT_FUNDING_MS + PAYMENT_WINDOW_MS);
+    expect(out.paymentReceived).toBe(true);
+  });
+
+  it("CLOSED 1ms beyond the payment window", async () => {
+    const out = await detectFundingWindow("BTCUSDT", NEXT_FUNDING_MS + PAYMENT_WINDOW_MS + 1);
+    expect(out.paymentReceived).toBe(false);
+    expect(out.open).toBe(false);
+  });
+
+  it("CLOSED in the gap between funding and the lag (now < next + LAG)", async () => {
+    const out = await detectFundingWindow("BTCUSDT", NEXT_FUNDING_MS + 30_000);
+    expect(out.paymentReceived).toBe(false);
+    expect(out.open).toBe(false);
+  });
+});
+
+describe("detectFundingWindow — exact funding moment", () => {
+  it("now == nextFundingAt → both false (atomic settlement)", async () => {
+    const out = await detectFundingWindow("BTCUSDT", NEXT_FUNDING_MS);
+    expect(out).toMatchObject({ open: false, paymentReceived: false });
+  });
+});
+
+describe("detectFundingWindow — far future / past", () => {
+  it("hours after the payment window → both false", async () => {
+    const out = await detectFundingWindow("BTCUSDT", NEXT_FUNDING_MS + 4 * 60 * 60_000);
+    expect(out.open).toBe(false);
+    expect(out.paymentReceived).toBe(false);
+  });
+
+  it("days before the funding event → both false", async () => {
+    const out = await detectFundingWindow("BTCUSDT", NEXT_FUNDING_MS - 2 * 24 * 60 * 60_000);
+    expect(out.open).toBe(false);
+    expect(out.paymentReceived).toBe(false);
+  });
+});

--- a/apps/api/tests/lib/hedgeBotWorker.test.ts
+++ b/apps/api/tests/lib/hedgeBotWorker.test.ts
@@ -90,6 +90,13 @@ vi.mock("../../src/lib/prisma.js", () => ({
         return { bot: { exchangeConnection: conn } };
       }),
     },
+    fundingSnapshot: {
+      // Default: no snapshot → windowDetector returns { open: false,
+      // paymentReceived: false }, which keeps existing tests' "closed
+      // window" assumption intact. Tests that need to open the window
+      // can override this mock per-case.
+      findFirst: vi.fn(async () => null),
+    },
     botIntent: {
       create: vi.fn(async ({ data }: { data: Record<string, unknown> }) => {
         created.push(data as never);


### PR DESCRIPTION
## Summary

Closes the last upstream-signal gap in the funding-arb runtime: `buildDefaultInput` now derives `fundingWindowOpen` / `fundingPaymentReceived` from the most recent `FundingSnapshot.nextFundingAt` for the hedge's symbol, via the new `apps/api/src/lib/funding/windowDetector.ts`.

After this PR, the funding-arb default tick path is end-to-end wired:

```
fundingSnapshot.nextFundingAt
       ↓ (windowDetector — this PR)
fundingWindowOpen / fundingPaymentReceived
       ↓ (advanceHedge — #353)
PENDING → ENTRY_PLACED gate (with reconcileBalances check)
       ↓ (tickHedgeBotWorker — #354)
loadHedgeCreds → reconcileBalances([symbol])
```

The only remaining production-side work is the real funding-payment ledger query — currently approximated by the timestamp window — which lands with `docs/55-T2`.

## Window definitions

Configurable via the exported constants:

| Signal | Definition | Default |
|---|---|---|
| `open` | `nextFundingAt - now ∈ (0, ENTRY_PRE_BUFFER_MS]` | 30 min pre-buffer |
| `paymentReceived` | `now - nextFundingAt ∈ [PAYMENT_LAG_MS, PAYMENT_WINDOW_MS]` | 1 min lag, 30 min window |

The pre-buffer keeps the worker from racing the settlement tick; the payment window is long enough for at least one 60-second tick to pick it up but short enough that a stale snapshot does not falsely re-trigger an exit.

## Why timestamp-based, not Bybit account API

Real `/v5/account/transaction-log` query requires private API wiring tied to `docs/55-T2` (real spot-leg execution). The detector module shape stays stable; 55-T2 only swaps the implementation behind `detectFundingWindow` if it wants per-symbol payment confirmation.

## Tests (11 new)

- No snapshot → both signals false, `nextFundingAtMs` null.
- Entry window: 1 minute before, exact `-30 min` boundary, 1 ms before the boundary opens.
- Payment window: at lag boundary, at far edge, 1 ms past, in the gap before lag.
- Exact settlement moment (`now == next`) → both false.
- Far-future / far-past sanity.

Pre-existing 20 `hedgeBotWorker` tests still pass — `fundingSnapshot.findFirst` defaults to `null` in the hedge worker mock, which preserves the closed-window assumption every prior test relied on.

## Test plan

- [x] `pnpm --filter @botmarketplace/api exec tsc --noEmit` ✓ (EXIT 0)
- [x] `pnpm --filter @botmarketplace/api exec vitest run tests/lib/funding/windowDetector.test.ts tests/lib/hedgeBotWorker.test.ts` ✓ (31/31 — 20 hedge + 11 new detector)
- [x] `pnpm --filter @botmarketplace/api test` ✓ (2126/2126 — baseline 2115 + 11 new)
- [ ] CI green


---
_Generated by [Claude Code](https://claude.ai/code/session_012z5NupTCzRjLgFvW7RDVEx)_