### PR TITLE
feat(funding-arb): expose nextFundingAt on scanner candidates (55-T3)

### DIFF
--- a/apps/api/src/lib/funding/scanner.ts
+++ b/apps/api/src/lib/funding/scanner.ts
@@ -80,9 +80,8 @@ export function buildCandidate(
   snapshots: FundingSnapshot[],
   spread: SpreadSnapshot | null,
 ): FundingCandidate {
-  const currentRate = snapshots.length > 0
-    ? snapshots[snapshots.length - 1].fundingRate
-    : 0;
+  const last = snapshots.length > 0 ? snapshots[snapshots.length - 1] : null;
+  const currentRate = last?.fundingRate ?? 0;
 
   return {
     symbol,
@@ -91,6 +90,7 @@ export function buildCandidate(
     basisBps: spread?.basisBps ?? 0,
     streak: fundingStreak(snapshots),
     avgRate: averageFundingRate(snapshots),
+    nextFundingAt: last?.nextFundingAt ?? null,
   };
 }
 

--- a/apps/api/src/lib/funding/types.ts
+++ b/apps/api/src/lib/funding/types.ts
@@ -40,6 +40,13 @@ export interface FundingCandidate {
   streak: number;
   /** Average funding rate over the lookback window. */
   avgRate: number;
+  /**
+   * Next funding settlement time (ms epoch) from the most recent snapshot,
+   * or null if the candidate has no snapshots. Same units as
+   * `FundingSnapshot.nextFundingAt`; route layer serialises to ISO before
+   * returning to clients.
+   */
+  nextFundingAt: number | null;
 }
 
 /** Thresholds for the scanner to filter candidates. */

--- a/apps/api/src/routes/funding.ts
+++ b/apps/api/src/routes/funding.ts
@@ -118,7 +118,11 @@ export async function fundingRoutes(app: FastifyInstance) {
       });
 
       return reply.send({
-        candidates,
+        candidates: candidates.map((c) => ({
+          ...c,
+          nextFundingAt:
+            c.nextFundingAt != null ? new Date(c.nextFundingAt).toISOString() : null,
+        })),
         updatedAt: new Date().toISOString(),
       });
     },

--- a/apps/api/tests/funding/scanner.test.ts
+++ b/apps/api/tests/funding/scanner.test.ts
@@ -130,6 +130,9 @@ describe("buildCandidate", () => {
     expect(c.basisBps).toBeCloseTo(1.49, 1);
     expect(c.streak).toBe(3);
     expect(c.avgRate).toBeCloseTo(0.0002, 6);
+    // nextFundingAt mirrors the most recent snapshot — 3rd snapshot's
+    // nextFundingAt = T0 + 3 * H8.
+    expect(c.nextFundingAt).toBe(T0 + 3 * H8);
   });
 
   it("handles null spread", () => {
@@ -143,6 +146,7 @@ describe("buildCandidate", () => {
     expect(c.currentRate).toBe(0);
     expect(c.annualizedYieldPct).toBe(0);
     expect(c.streak).toBe(0);
+    expect(c.nextFundingAt).toBeNull();
   });
 
   it("handles negative funding rates (short-pay)", () => {

--- a/apps/api/tests/routes/funding.test.ts
+++ b/apps/api/tests/routes/funding.test.ts
@@ -104,6 +104,13 @@ describe("GET /api/v1/terminal/funding/scanner", () => {
       expect(typeof c.annualizedYieldPct).toBe("number");
       expect(typeof c.basisBps).toBe("number");
       expect(typeof c.streak).toBe("number");
+      // nextFundingAt is serialised as an ISO string (or null when no
+      // snapshots backed the candidate). Should round-trip through Date.
+      expect(["string", "object"]).toContain(typeof c.nextFundingAt);
+      if (c.nextFundingAt !== null) {
+        expect(typeof c.nextFundingAt).toBe("string");
+        expect(Number.isFinite(Date.parse(c.nextFundingAt))).toBe(true);
+      }
     }
   });
 


### PR DESCRIPTION
## Summary

Scanner candidates now carry the upcoming funding settlement timestamp so the funding scanner UI can render countdown / time-to-payment without a second round-trip.

- `FundingCandidate.nextFundingAt: number | null` — pulled from the most recent `FundingSnapshot` per symbol; null when no snapshots back the candidate.
- Internal type stays in ms epoch to mirror `FundingSnapshot.nextFundingAt`. The `/terminal/funding/scanner` route serialises to ISO at the wire to match the existing `/history` endpoint convention.
- Additive only — existing clients that ignore the field are unaffected.

Part of `docs/55-T3` (funding-arb scanner UI surface). The UI portion in `apps/web` lands separately.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `tests/funding/scanner.test.ts` — `buildCandidate` asserts new field for both populated and empty-snapshot cases
- [x] `tests/routes/funding.test.ts` — route response asserts ISO string round-trips through `Date.parse`
- [x] Full API suite: 2126/2126 passed (no regressions)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EG3E2Gxo2mqhK4PHKL9SBM)_