### PR TITLE
feat(funding-arb): seed funding-arb preset (PRIVATE, enabled=false placeholder DSL)

### DIFF
--- a/apps/api/prisma/seed/presets/funding-arb.json
+++ b/apps/api/prisma/seed/presets/funding-arb.json
@@ -1,0 +1,44 @@
+{
+  "name": "Funding Arbitrage (Bybit Perp + Spot)",
+  "description": "Delta-neutral hedge: short perp + long spot when funding rate is positive. Multi-leg execution gated by docs/55-T4 mode routing — runtime path is `hedgeBotWorker.ts`, not the DSL evaluator. The dslJson below is a placeholder with `enabled: false` so the regular bot worker cancels any intents it might emit if the preset is instantiated before mode routing lands. Promotion to BETA visibility happens in docs/55-T6 once the acceptance gate is closed.",
+  "dslJson": {
+    "id": "funding-arb",
+    "name": "Funding Arbitrage",
+    "dslVersion": 2,
+    "enabled": false,
+    "market": {
+      "exchange": "bybit",
+      "env": "demo",
+      "category": "linear",
+      "symbol": "BTCUSDT"
+    },
+    "entry": {
+      "side": "Sell"
+    },
+    "risk": {
+      "maxPositionSizeUsd": 1000,
+      "riskPerTradePct": 1,
+      "cooldownSeconds": 60
+    },
+    "execution": {
+      "orderType": "Market",
+      "clientOrderIdPrefix": "fundarb"
+    },
+    "guards": {
+      "maxOpenPositions": 1,
+      "maxOrdersPerMinute": 10,
+      "pauseOnError": true
+    },
+    "exit": {
+      "stopLoss":   { "type": "fixed_pct", "value": 1 },
+      "takeProfit": { "type": "fixed_pct", "value": 1 }
+    }
+  },
+  "defaultBotConfigJson": {
+    "symbol": "BTCUSDT",
+    "mode": "FUNDING_ARB",
+    "minFundingRate": 0.0002,
+    "maxSpreadBps": 5,
+    "quoteAmount": 1000
+  }
+}

--- a/apps/api/prisma/seed/seedPresets.ts
+++ b/apps/api/prisma/seed/seedPresets.ts
@@ -1,17 +1,24 @@
 /**
- * Strategy Preset seed (docs/51-T6).
+ * Strategy Preset seed (docs/51-T6 + docs/55-T4 funding-arb registration).
  *
  * Loads the 4 non-Funding flagship presets (Adaptive Regime, DCA Momentum,
- * MTF Scalper, SMC Liquidity Sweep) from JSON fixtures next to this file
- * and upserts them into the StrategyPreset table.
+ * MTF Scalper, SMC Liquidity Sweep) plus the funding-arb preset from JSON
+ * fixtures next to this file and upserts them into the StrategyPreset table.
  *
  * - Inserts always start as `PRIVATE` so a partially-finished preset is
- *   never visible to end users. Promotion to `PUBLIC` is a separate admin
- *   step (docs/51 §Решение 3) — the `update` branch below is intentionally
- *   careful not to roll back a `PUBLIC` flip.
- * - The DSL inside each fixture is a placeholder. Final flagship-grade DSL
- *   lands in docs/53 (Adaptive Regime golden fixture) and docs/54 (DCA /
- *   MTF / SMC). The placeholders are real enough to pass `validateDsl`.
+ *   never visible to end users. Promotion to `PUBLIC` (or `BETA` for
+ *   funding-arb, once docs/55-T6 extends the visibility enum) is a
+ *   separate admin step (docs/51 §Решение 3) — the `update` branch below
+ *   is intentionally careful not to roll back a manual flip.
+ * - The DSL inside each flagship fixture is a placeholder. Final
+ *   flagship-grade DSL lands in docs/53 (Adaptive Regime golden fixture)
+ *   and docs/54 (DCA / MTF / SMC). The placeholders are real enough to
+ *   pass `validateDsl`.
+ * - The funding-arb fixture's DSL is a placeholder too, but with
+ *   `enabled: false` — funding-arb's real runtime path is
+ *   `hedgeBotWorker.ts` (docs/55-T4), not the DSL evaluator, and the
+ *   `enabled` flag keeps the standard bot worker from emitting intents
+ *   on this preset before mode routing lands.
  */
 
 import { promises as fs } from "node:fs";
@@ -40,6 +47,7 @@ const PRESETS: PresetSpec[] = [
   { slug: "dca-momentum",        category: "dca",      file: "presets/dca-momentum.json" },
   { slug: "mtf-scalper",         category: "scalping", file: "presets/mtf-scalper.json" },
   { slug: "smc-liquidity-sweep", category: "smc",      file: "presets/smc-liquidity-sweep.json" },
+  { slug: "funding-arb",         category: "arb",      file: "presets/funding-arb.json" },
 ];
 
 async function loadFixture(file: string): Promise<PresetFixture> {

--- a/apps/api/tests/integration/presetInstantiateFlow.test.ts
+++ b/apps/api/tests/integration/presetInstantiateFlow.test.ts
@@ -252,12 +252,12 @@ function userHeaders() {
 // ═══════════════════════════════════════════════════════════════════════════
 
 describe("preset instantiate flow (e2e, mocked Prisma)", () => {
-  it("seed populates 4 presets in PRIVATE state", async () => {
+  it("seed populates all flagship presets in PRIVATE state", async () => {
     const results = await seedPresets(
       mockedPrisma as unknown as import("@prisma/client").PrismaClient,
     );
     expect(results.map((r) => r.slug).sort()).toEqual(
-      ["adaptive-regime", "dca-momentum", "mtf-scalper", "smc-liquidity-sweep"],
+      ["adaptive-regime", "dca-momentum", "funding-arb", "mtf-scalper", "smc-liquidity-sweep"],
     );
     for (const slug of Object.keys(mockPresets)) {
       expect(mockPresets[slug].visibility).toBe("PRIVATE");

--- a/apps/api/tests/prisma/seedPresets.test.ts
+++ b/apps/api/tests/prisma/seedPresets.test.ts
@@ -19,7 +19,13 @@ import { validateDsl } from "../../src/lib/dslValidator.js";
 const HERE = dirname(fileURLToPath(import.meta.url));
 const SEED_DIR = resolve(HERE, "../../prisma/seed/presets");
 
-const SLUGS = ["adaptive-regime", "dca-momentum", "mtf-scalper", "smc-liquidity-sweep"] as const;
+const SLUGS = [
+  "adaptive-regime",
+  "dca-momentum",
+  "mtf-scalper",
+  "smc-liquidity-sweep",
+  "funding-arb",
+] as const;
 
 // ---------------------------------------------------------------------------
 // Fixture-level DSL validation (no Prisma involved)
@@ -115,5 +121,17 @@ describe("seedPresets()", () => {
     expect(mockPresets["dca-momentum"].category).toBe("dca");
     expect(mockPresets["mtf-scalper"].category).toBe("scalping");
     expect(mockPresets["smc-liquidity-sweep"].category).toBe("smc");
+    expect(mockPresets["funding-arb"].category).toBe("arb");
+  });
+
+  it("funding-arb seeds with enabled=false so the DSL evaluator emits no intents", async () => {
+    // Mode-based routing (docs/55-T4) is not yet wired; until it is,
+    // instantiating this preset would put the bot on the regular DSL
+    // path. The placeholder DSL must short-circuit at the
+    // `enabled: false` gate (botWorker.ts stage 12) so we never emit
+    // accidental orders on a preset whose real runtime is hedgeBotWorker.
+    await seedPresets(mockPrisma as unknown as import("@prisma/client").PrismaClient);
+    const dsl = mockPresets["funding-arb"].dslJson as Record<string, unknown>;
+    expect(dsl.enabled).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Registers the `funding-arb` `StrategyPreset` row so the Lab Library has a discoverable card once `docs/55-T6` promotes it to BETA. The dslJson is intentionally a placeholder with `enabled: false`:

- funding-arb's real runtime path is `hedgeBotWorker.ts` (`docs/55-T4`), not the DSL evaluator.
- The `enabled: false` flag short-circuits at `botWorker.ts` stage 12 — even if the preset is instantiated through the regular flow before mode routing lands, the bot worker **cancels** intents instead of acting on the placeholder strategy.
- Default visibility stays `PRIVATE`; promotion is admin-gated via `publishPreset.ts`.

The fixture is structured to satisfy `validateDsl` (v2 shape with required `market` / `entry` / `risk` / `execution` / `guards` / `exit` sections) so the existing `seed/presets/*.json passes validateDsl` test loop covers it without special-casing.

Closes the seed-registration prerequisite for `docs/55-T4`. Mode-based routing (the `Bot.mode` enum and `hedgeBotWorker` dispatch from `botWorker.ts`) is **not** in this PR.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `tests/prisma/seedPresets.test.ts` — funding-arb passes `validateDsl`, seeds with category=`"arb"` and `enabled: false`
- [x] `tests/integration/presetInstantiateFlow.test.ts` — slug list updated to include funding-arb; all flagship presets seed PRIVATE
- [x] Full API suite: 2128/2128 passed (+2 new assertions vs 2126 baseline)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EG3E2Gxo2mqhK4PHKL9SBM)_