### PR TITLE
test(walkForward): smoke-grade CI gate for 4 flagship golden DSLs (54-T5 part 2)

### DIFF
--- a/apps/api/tests/_helpers/strategyAcceptance.ts
+++ b/apps/api/tests/_helpers/strategyAcceptance.ts
@@ -28,9 +28,18 @@
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import type { MarketCandle } from "@prisma/client";
 import { parseDsl } from "../../src/lib/dslEvaluator.js";
 import { validateDsl } from "../../src/lib/dslValidator.js";
 import { BLOCK_SUPPORT_MAP } from "../../src/lib/compiler/supportMap.ts";
+import {
+  runWalkForward,
+  runWalkForwardWithBundle,
+} from "../../src/lib/walkForward/run.js";
+import type { FoldConfig } from "../../src/lib/walkForward/types.js";
+import type { CandleInterval } from "../../src/types/datasetBundle.js";
+import { INTERVAL_MS, type Interval } from "../../src/lib/mtf/intervalAlignment.js";
+import type { Candle } from "../../src/lib/bybitCandles.js";
 
 // ---------------------------------------------------------------------------
 // Shared keyword + alias tables
@@ -208,4 +217,196 @@ export function describeGoldenStrategyContract(
   });
 
   return loaded;
+}
+
+// ---------------------------------------------------------------------------
+// Walk-forward smoke (54-T5 — CI sub-fixture)
+// ---------------------------------------------------------------------------
+//
+// `describeGoldenStrategyContract` proves the DSL is structurally valid and
+// uses only supported primitives. What it does NOT prove is that the DSL
+// actually survives the walk-forward pipeline — split → bundle slicing →
+// runBacktest evaluator → aggregate. A regression in any of those layers
+// can break a flagship strategy and ship to main without a single existing
+// test failing.
+//
+// `describeWalkForwardSmoke` plugs that gap with a deterministic synthetic
+// candle generator. It is intentionally *smoke-grade*: candles are a
+// fixed-seed random walk and most strategies will produce zero trades.
+// The assertion is "the pipeline ran end-to-end on this golden DSL and
+// returned a well-shaped report"; PnL / signal-correctness checks belong
+// in the per-strategy synthetic-evaluator tests, not here.
+
+/** Map lowercase DSL-style interval names to the uppercase
+ *  `CandleInterval` enum used by `MarketCandle.interval` and bundle keys. */
+const LOWER_TO_UPPER: Record<Interval, CandleInterval> = {
+  "1m": "M1",
+  "5m": "M5",
+  "15m": "M15",
+  "1h": "H1",
+  "4h": "H4",
+  "1d": "D1",
+};
+
+/** Deterministic LCG — same seed ⇒ same candles across runs / machines.
+ *  We cannot use `Math.random()` here because the smoke run must reproduce
+ *  bit-for-bit on CI; a flaky walk-forward result would be useless. */
+function lcg(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state * 1103515245 + 12345) & 0x7fffffff;
+    return state / 0x7fffffff;
+  };
+}
+
+/** Build a fresh `MarketCandle[]` for one interval. The price series is a
+ *  bounded random walk anchored at `basePrice`; OHLC are derived from the
+ *  walk so high ≥ open/close ≥ low always holds. The output mirrors the
+ *  shape `runBacktestWithBundle` consumes (Decimal columns are passed as
+ *  plain numbers — `toMtfCandle` accepts both via `Number(v.toString())`). */
+function generateCandles(args: {
+  interval: Interval;
+  count: number;
+  basePrice?: number;
+  seed?: number;
+  startMs?: number;
+}): MarketCandle[] {
+  const upper = LOWER_TO_UPPER[args.interval];
+  const ms = INTERVAL_MS[args.interval];
+  const start = args.startMs ?? Date.UTC(2026, 0, 1, 0, 0, 0);
+  const rand = lcg(args.seed ?? 0xC0FFEE);
+  let price = args.basePrice ?? 100;
+  const out: MarketCandle[] = [];
+  for (let i = 0; i < args.count; i++) {
+    // ±0.4% step keeps prices in a sensible band over a few hundred bars
+    // and prevents indicator math (e.g. ATR, BB) from collapsing to zero.
+    const drift = (rand() - 0.5) * 0.008;
+    const open = price;
+    price = Math.max(0.01, price * (1 + drift));
+    const close = price;
+    const high = Math.max(open, close) * (1 + rand() * 0.002);
+    const low = Math.min(open, close) * (1 - rand() * 0.002);
+    out.push({
+      id: `wf-${upper}-${i}`,
+      exchange: "bybit",
+      symbol: "BTCUSDT",
+      interval: upper,
+      openTimeMs: BigInt(start + i * ms),
+      open: open as unknown as MarketCandle["open"],
+      high: high as unknown as MarketCandle["high"],
+      low: low as unknown as MarketCandle["low"],
+      close: close as unknown as MarketCandle["close"],
+      volume: 100 as unknown as MarketCandle["volume"],
+      createdAt: new Date(start + i * ms),
+    });
+  }
+  return out;
+}
+
+function rowToCandle(row: MarketCandle): Candle {
+  return {
+    openTime: Number(row.openTimeMs),
+    open: Number(row.open),
+    high: Number(row.high),
+    low: Number(row.low),
+    close: Number(row.close),
+    volume: Number(row.volume),
+  };
+}
+
+/** Default fold config sized to the synthetic series below. With 400
+ *  primary bars and (200 IS, 60 OOS, 60 step) the splitter produces 3
+ *  folds — enough to exercise the bundle-slicing loop more than once. */
+const DEFAULT_FOLD_CFG: FoldConfig = {
+  isBars: 200,
+  oosBars: 60,
+  step: 60,
+  anchored: false,
+};
+
+/** Default primary count provides ≥ 3 folds with `DEFAULT_FOLD_CFG`. */
+const DEFAULT_PRIMARY_COUNT = 400;
+
+export interface DescribeWalkForwardSmokeArgs {
+  /** Preset slug — used as the describe-block prefix. */
+  slug: string;
+  /** The golden DSL (typically `loaded.golden` from
+   *  `describeGoldenStrategyContract`). */
+  goldenDsl: Record<string, unknown>;
+  /** Primary timeframe in lowercase (e.g. "5m"). Drives split iteration. */
+  primaryInterval: Interval;
+  /** Other timeframes the bundle must include alongside the primary, also
+   *  in lowercase. Empty / omitted ⇒ single-TF path (`runWalkForward`). */
+  contextIntervals?: Interval[];
+  /** Override the fold config when the default 400-bar window is wrong
+   *  for a strategy (e.g. very long lookbacks). */
+  foldCfg?: FoldConfig;
+  /** Override the primary candle count. Must be ≥ isBars + oosBars. */
+  primaryCount?: number;
+}
+
+/**
+ * Register a smoke describe-block proving the golden DSL survives a full
+ * walk-forward run on synthetic candles. The block fails iff the pipeline
+ * throws or produces a malformed report — it is intentionally tolerant of
+ * zero-trade outcomes (most strategies will no-op on a fixed-seed random
+ * walk; that is fine for a smoke check).
+ */
+export function describeWalkForwardSmoke(args: DescribeWalkForwardSmokeArgs): void {
+  const foldCfg = args.foldCfg ?? DEFAULT_FOLD_CFG;
+  const primaryCount = args.primaryCount ?? DEFAULT_PRIMARY_COUNT;
+  const ctx = args.contextIntervals ?? [];
+
+  describe(`${args.slug} — walk-forward smoke (synthetic CI sub-fixture)`, () => {
+    it("runs to completion across all folds with non-null reports", () => {
+      const primaryRows = generateCandles({
+        interval: args.primaryInterval,
+        count: primaryCount,
+        seed: 0xC0FFEE,
+      });
+
+      const isMtf = ctx.length > 0;
+      const report = isMtf
+        ? (() => {
+            const bundle = new Map<CandleInterval, MarketCandle[]>();
+            bundle.set(LOWER_TO_UPPER[args.primaryInterval], primaryRows);
+            const primaryMs = INTERVAL_MS[args.primaryInterval];
+            for (const tf of ctx) {
+              if (tf === args.primaryInterval) continue;
+              const tfMs = INTERVAL_MS[tf];
+              // Cover the primary window plus a small lookback margin so
+              // HTF indicators have at least a handful of closed bars from
+              // the start.
+              const tfCount = Math.max(50, Math.ceil((primaryCount * primaryMs) / tfMs) + 5);
+              bundle.set(
+                LOWER_TO_UPPER[tf],
+                generateCandles({ interval: tf, count: tfCount, seed: 0xC0FFEE ^ tfMs }),
+              );
+            }
+            return runWalkForwardWithBundle({
+              bundle,
+              primaryInterval: LOWER_TO_UPPER[args.primaryInterval],
+              dslJson: args.goldenDsl,
+              opts: {},
+              foldCfg,
+            });
+          })()
+        : runWalkForward(
+            primaryRows.map(rowToCandle),
+            args.goldenDsl,
+            {},
+            foldCfg,
+          );
+
+      expect(report.folds.length).toBeGreaterThan(0);
+      for (const f of report.folds) {
+        expect(f.isReport).not.toBeNull();
+        expect(f.oosReport).not.toBeNull();
+      }
+      // aggregate is computed only after fold reports exist; if it's null
+      // the helper is broken, not the strategy.
+      expect(report.aggregate).toBeDefined();
+      expect(report.aggregate.foldCount).toBe(report.folds.length);
+    });
+  });
 }

--- a/apps/api/tests/lib/strategies/adaptiveRegime.test.ts
+++ b/apps/api/tests/lib/strategies/adaptiveRegime.test.ts
@@ -36,7 +36,10 @@ import {
   type MtfCandle,
 } from "../../../src/lib/mtf/intervalAlignment.js";
 import { createMtfCache } from "../../../src/lib/mtf/mtfIndicatorResolver.js";
-import { describeGoldenStrategyContract } from "../../_helpers/strategyAcceptance.js";
+import {
+  describeGoldenStrategyContract,
+  describeWalkForwardSmoke,
+} from "../../_helpers/strategyAcceptance.js";
 
 // ---------------------------------------------------------------------------
 // Shared contract — seed/golden pin, validateDsl, parseDsl, supported blocks
@@ -47,6 +50,17 @@ const { golden: goldenDsl } = describeGoldenStrategyContract({
   baseDir: dirname(fileURLToPath(import.meta.url)),
   goldenPath: "../../fixtures/strategies/adaptive-regime.golden.json",
   seedPath: "../../../prisma/seed/presets/adaptive-regime.json",
+});
+
+// ---------------------------------------------------------------------------
+// Walk-forward smoke — bundle {M5, H1}, primary M5
+// ---------------------------------------------------------------------------
+
+describeWalkForwardSmoke({
+  slug: "adaptive-regime",
+  goldenDsl,
+  primaryInterval: "5m",
+  contextIntervals: ["1h"],
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/api/tests/lib/strategies/dcaMomentum.test.ts
+++ b/apps/api/tests/lib/strategies/dcaMomentum.test.ts
@@ -31,7 +31,10 @@ import {
   generateSafetyOrderSchedule,
   type DcaConfig,
 } from "../../../src/lib/dcaPlanning.js";
-import { describeGoldenStrategyContract } from "../../_helpers/strategyAcceptance.js";
+import {
+  describeGoldenStrategyContract,
+  describeWalkForwardSmoke,
+} from "../../_helpers/strategyAcceptance.js";
 
 // ---------------------------------------------------------------------------
 // Shared contract — seed/golden pin, validateDsl, parseDsl, supported blocks
@@ -42,6 +45,16 @@ const { golden: goldenDsl } = describeGoldenStrategyContract({
   baseDir: dirname(fileURLToPath(import.meta.url)),
   goldenPath: "../../fixtures/strategies/dca-momentum.golden.json",
   seedPath: "../../../prisma/seed/presets/dca-momentum.json",
+});
+
+// ---------------------------------------------------------------------------
+// Walk-forward smoke — single-TF M15
+// ---------------------------------------------------------------------------
+
+describeWalkForwardSmoke({
+  slug: "dca-momentum",
+  goldenDsl,
+  primaryInterval: "15m",
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/api/tests/lib/strategies/mtfScalper.test.ts
+++ b/apps/api/tests/lib/strategies/mtfScalper.test.ts
@@ -34,7 +34,10 @@ import {
   type MtfCandle,
 } from "../../../src/lib/mtf/intervalAlignment.js";
 import { createMtfCache } from "../../../src/lib/mtf/mtfIndicatorResolver.js";
-import { describeGoldenStrategyContract } from "../../_helpers/strategyAcceptance.js";
+import {
+  describeGoldenStrategyContract,
+  describeWalkForwardSmoke,
+} from "../../_helpers/strategyAcceptance.js";
 
 // ---------------------------------------------------------------------------
 // Shared contract — seed/golden pin, validateDsl, parseDsl, supported blocks
@@ -45,6 +48,17 @@ const { golden: goldenDsl } = describeGoldenStrategyContract({
   baseDir: dirname(fileURLToPath(import.meta.url)),
   goldenPath: "../../fixtures/strategies/mtf-scalper.golden.json",
   seedPath: "../../../prisma/seed/presets/mtf-scalper.json",
+});
+
+// ---------------------------------------------------------------------------
+// Walk-forward smoke — bundle {M1, M5, M15}, primary M1
+// ---------------------------------------------------------------------------
+
+describeWalkForwardSmoke({
+  slug: "mtf-scalper",
+  goldenDsl,
+  primaryInterval: "1m",
+  contextIntervals: ["5m", "15m"],
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/api/tests/lib/strategies/smcLiquiditySweep.test.ts
+++ b/apps/api/tests/lib/strategies/smcLiquiditySweep.test.ts
@@ -41,7 +41,10 @@ import {
   type MtfCandle,
 } from "../../../src/lib/mtf/intervalAlignment.js";
 import { createMtfCache } from "../../../src/lib/mtf/mtfIndicatorResolver.js";
-import { describeGoldenStrategyContract } from "../../_helpers/strategyAcceptance.js";
+import {
+  describeGoldenStrategyContract,
+  describeWalkForwardSmoke,
+} from "../../_helpers/strategyAcceptance.js";
 
 // ---------------------------------------------------------------------------
 // Shared contract — seed/golden pin, validateDsl, parseDsl, supported blocks
@@ -52,6 +55,17 @@ const { golden: goldenDsl } = describeGoldenStrategyContract({
   baseDir: dirname(fileURLToPath(import.meta.url)),
   goldenPath: "../../fixtures/strategies/smc-liquidity-sweep.golden.json",
   seedPath: "../../../prisma/seed/presets/smc-liquidity-sweep.json",
+});
+
+// ---------------------------------------------------------------------------
+// Walk-forward smoke — bundle {M15, H1, H4}, primary M15
+// ---------------------------------------------------------------------------
+
+describeWalkForwardSmoke({
+  slug: "smc-liquidity-sweep",
+  goldenDsl,
+  primaryInterval: "15m",
+  contextIntervals: ["1h", "4h"],
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds `describeWalkForwardSmoke` to the strategyAcceptance helper plus a deterministic synthetic-candle generator. Each flagship test (`adaptive-regime`, `dca-momentum`, `mtf-scalper`, `smc-liquidity-sweep`) now registers one extra describe-block that runs its golden DSL through `runWalkForward` / `runWalkForwardWithBundle` on a fixed-seed random walk and asserts the pipeline returned a well-shaped report.

**Why smoke-grade.** Real per-fold acceptance (`pnl > 0`, `sharpe > 0.3`) needs real market data, which lives in `docs/53-T2` / `docs/54-T1..T3` alongside Bybit credentials. What CI uniquely catches *here*: walk-forward orchestration, bundle slicing, evaluator + indicator caches, and pattern-engine integration end-to-end against the actual flagship DSLs — gaps `describeGoldenStrategyContract` (structure-only) cannot cover. Each smoke run executes ≥ 3 folds in single digits of milliseconds, so the full CI cost is negligible.

**Determinism.** Candle generator uses a seeded LCG, never `Math.random()`; identical inputs reproduce bit-for-bit across machines.

## Coverage matrix

| Slug | Path | Bundle | Primary |
|---|---|---|---|
| adaptive-regime | bundle | M5 + H1 | M5 |
| dca-momentum | single-TF | — | M15 |
| mtf-scalper | bundle | M1 + M5 + M15 | M1 |
| smc-liquidity-sweep | bundle | M15 + H1 + H4 | M15 |

`funding-arb` is intentionally excluded — its runtime path is `hedgeBotWorker.ts`, not the DSL evaluator (see `docs/55-T4`).

## Test plan

- [x] `tsc --noEmit` clean
- [x] `tests/lib/strategies/*.test.ts` — 8 → 9 tests each (+1 walk-forward smoke per file)
- [x] Full API suite: 2132/2132 passed (+4 vs 2128 baseline)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EG3E2Gxo2mqhK4PHKL9SBM)_