### PR TITLE
feat(presets): three-tier BETA visibility for funding-arb gating (55-T6 §A4)

### DIFF
--- a/apps/api/prisma/migrations/20260503000000_preset_beta_visibility/migration.sql
+++ b/apps/api/prisma/migrations/20260503000000_preset_beta_visibility/migration.sql
@@ -1,0 +1,10 @@
+-- 55-T6: extend PresetVisibility with BETA between PRIVATE and PUBLIC.
+--
+-- Additive only — existing rows keep their PRIVATE / PUBLIC values; the
+-- column default ('PRIVATE') is unchanged. No backfill required.
+--
+-- Note: PostgreSQL <12 cannot run "ALTER TYPE ... ADD VALUE" inside a
+-- transaction block. Prisma 4+ wraps each migration in an implicit
+-- transaction, but ships PostgreSQL ≥13 in the supported matrix
+-- (`docs/14-deployment.md`), so the wrapping is safe in this project.
+ALTER TYPE "PresetVisibility" ADD VALUE 'BETA' BEFORE 'PUBLIC';

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -893,6 +893,7 @@ model LabJournalEntry {
 
 enum PresetVisibility {
   PRIVATE
+  BETA
   PUBLIC
 }
 

--- a/apps/api/scripts/publishPreset.ts
+++ b/apps/api/scripts/publishPreset.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env tsx
 /**
- * Promote a StrategyPreset to PUBLIC (or roll it back to PRIVATE) —
- * admin CLI tool for the visibility-flip step shared by docs/53-T4 and
- * docs/54-T1..T3 closing.
+ * Promote a StrategyPreset between visibility tiers — admin CLI tool for
+ * the visibility-flip step shared by docs/53-T4, docs/54-T1..T3, and
+ * docs/55-T6.
  *
  * Why a script and not an HTTP endpoint:
  *   - Visibility flips are infrequent and audited (commit / chat record).
@@ -16,13 +16,12 @@
  *     --slug adaptive-regime --visibility PUBLIC
  *
  *   pnpm --filter @botmarketplace/api exec tsx scripts/publishPreset.ts \
- *     --slug adaptive-regime --visibility PRIVATE --dry-run
+ *     --slug funding-arb --visibility BETA --dry-run
  *
  * Lookup is by slug (unique). Visibility values must match the Prisma
- * `PresetVisibility` enum — currently `PRIVATE` | `PUBLIC`. The BETA
- * value lands with docs/55-T6; this script will accept it without
- * source-edit once the enum is extended (we read the allowed values
- * from `@prisma/client` at runtime).
+ * `PresetVisibility` enum (`PRIVATE` | `BETA` | `PUBLIC` as of 55-T6).
+ * `allowedVisibilities()` reads the enum dynamically, so future
+ * additions land without a source edit here.
  *
  * The script is idempotent: setting the visibility a preset already has
  * is a no-op with a clear "already at <visibility>, no change" message.

--- a/apps/api/src/routes/presets.ts
+++ b/apps/api/src/routes/presets.ts
@@ -16,13 +16,51 @@
  */
 
 import { randomBytes } from "node:crypto";
-import type { FastifyInstance } from "fastify";
+import type { FastifyInstance, FastifyRequest } from "fastify";
 import { Prisma, PresetVisibility } from "@prisma/client";
 import { prisma } from "../lib/prisma.js";
 import { problem } from "../lib/problem.js";
 import { validateDsl } from "../lib/dslValidator.js";
 import { isAdminRequest } from "../lib/adminGuard.js";
 import { resolveWorkspace } from "../lib/workspace.js";
+
+// ---------------------------------------------------------------------------
+// Visibility helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Soft authentication for endpoints that have public + authenticated tiers
+ * (docs/55-T6 §A4). Unlike `app.authenticate`, this never sends a 401: it
+ * simply reports whether a valid Bearer token was supplied so the handler
+ * can scope its visibility filter accordingly.
+ */
+async function tryAuthenticate(request: FastifyRequest): Promise<boolean> {
+  try {
+    await request.jwtVerify();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+interface ViewerScope {
+  admin: boolean;
+  authed: boolean;
+}
+
+/**
+ * Three-tier visibility check: PRIVATE → admin only, BETA → authed users
+ * (admin always passes), PUBLIC → everyone. The funding-arb preset lives
+ * at BETA per docs/55-T6 — visible to authenticated users with an explicit
+ * "experimental, multi-leg" badge in the UI, but kept off the anonymous
+ * landing page until promoted to PUBLIC.
+ */
+function canViewPreset(visibility: PresetVisibility, scope: ViewerScope): boolean {
+  if (scope.admin) return true;
+  if (visibility === PresetVisibility.PUBLIC) return true;
+  if (visibility === PresetVisibility.BETA) return scope.authed;
+  return false; // PRIVATE — admin-only, already short-circuited above
+}
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -55,7 +93,7 @@ interface CreatePresetBody {
   dslJson: unknown;
   defaultBotConfigJson: DefaultBotConfig;
   datasetBundleHintJson?: Record<string, unknown> | null;
-  visibility?: "PRIVATE" | "PUBLIC";
+  visibility?: "PRIVATE" | "BETA" | "PUBLIC";
 }
 
 interface InstantiateBody {
@@ -192,8 +230,13 @@ function validateCreateBody(
     }
   }
 
-  if (b.visibility !== undefined && b.visibility !== "PRIVATE" && b.visibility !== "PUBLIC") {
-    errors.push({ field: "visibility", message: "visibility must be PRIVATE or PUBLIC" });
+  if (
+    b.visibility !== undefined &&
+    b.visibility !== "PRIVATE" &&
+    b.visibility !== "BETA" &&
+    b.visibility !== "PUBLIC"
+  ) {
+    errors.push({ field: "visibility", message: "visibility must be PRIVATE, BETA, or PUBLIC" });
   }
 
   if (errors.length > 0) return { errors };
@@ -246,18 +289,32 @@ export async function presetRoutes(app: FastifyInstance) {
     }
   });
 
-  // GET /presets — public (PUBLIC only) or admin (all)
+  // GET /presets — three-tier visibility scoping (docs/55-T6 §A4):
+  //   • anon         → PUBLIC only
+  //   • authed user  → PUBLIC + BETA (BETA gates experimental presets like funding-arb
+  //                    behind login while still keeping them off the anonymous landing)
+  //   • admin        → all (or filtered by ?visibility=…)
   app.get<{ Querystring: { category?: string; visibility?: string } }>(
     "/presets",
     async (request, reply) => {
       const admin = isAdminRequest(request);
+      const authed = await tryAuthenticate(request);
       const where: Prisma.StrategyPresetWhereInput = {};
 
       // Visibility scoping
-      if (!admin) {
+      if (admin) {
+        if (
+          request.query?.visibility === "PRIVATE" ||
+          request.query?.visibility === "BETA" ||
+          request.query?.visibility === "PUBLIC"
+        ) {
+          where.visibility = request.query.visibility as PresetVisibility;
+        }
+        // else: admin sees everything regardless of visibility
+      } else if (authed) {
+        where.visibility = { in: [PresetVisibility.PUBLIC, PresetVisibility.BETA] };
+      } else {
         where.visibility = PresetVisibility.PUBLIC;
-      } else if (request.query?.visibility === "PRIVATE" || request.query?.visibility === "PUBLIC") {
-        where.visibility = request.query.visibility as PresetVisibility;
       }
 
       // Category filter
@@ -285,15 +342,17 @@ export async function presetRoutes(app: FastifyInstance) {
     },
   );
 
-  // GET /presets/:slug — full record
+  // GET /presets/:slug — full record. Visibility rules mirror the list endpoint
+  // (docs/55-T6 §A4): PRIVATE is admin-only; BETA requires authentication; PUBLIC
+  // is open. 404 (not 403) on hidden so existence is not revealed.
   app.get<{ Params: { slug: string } }>("/presets/:slug", async (request, reply) => {
     const admin = isAdminRequest(request);
+    const authed = admin ? true : await tryAuthenticate(request);
     const preset = await prisma.strategyPreset.findUnique({
       where: { slug: request.params.slug },
     });
 
-    // 404 (not 403) on PRIVATE without admin so existence is not revealed.
-    if (!preset || (preset.visibility === PresetVisibility.PRIVATE && !admin)) {
+    if (!preset || !canViewPreset(preset.visibility, { admin, authed })) {
       return problem(reply, 404, "Not Found", "Preset not found");
     }
 
@@ -317,8 +376,9 @@ export async function presetRoutes(app: FastifyInstance) {
       const preset = await prisma.strategyPreset.findUnique({
         where: { slug: request.params.slug },
       });
-      // PRIVATE presets are invisible to non-admins (matches GET semantics).
-      if (!preset || (preset.visibility === PresetVisibility.PRIVATE && !admin)) {
+      // Endpoint runs under app.authenticate, so authed=true by construction.
+      // Mirror GET semantics so PRIVATE is admin-only and BETA visible to authed.
+      if (!preset || !canViewPreset(preset.visibility, { admin, authed: true })) {
         return problem(reply, 404, "Not Found", "Preset not found");
       }
 

--- a/apps/api/tests/routes/presets.test.ts
+++ b/apps/api/tests/routes/presets.test.ts
@@ -44,7 +44,7 @@ vi.mock("@prisma/client", () => {
       InputJsonValue: {} as never,
       PrismaClientKnownRequestError,
     },
-    PresetVisibility: { PRIVATE: "PRIVATE", PUBLIC: "PUBLIC" },
+    PresetVisibility: { PRIVATE: "PRIVATE", BETA: "BETA", PUBLIC: "PUBLIC" },
   };
 });
 
@@ -105,8 +105,18 @@ vi.mock("../../src/lib/prisma.js", () => {
       findMany: vi.fn().mockImplementation(({ where, select }: { where: Record<string, unknown>; select?: Record<string, boolean> }) => {
         const visibility = where?.visibility;
         const category = where?.category;
+        // Visibility filter supports `value` (eq) and `{ in: [...] }` (Prisma's
+        // OR-set), the two shapes the route uses for three-tier scoping.
+        const visibilityIn =
+          visibility && typeof visibility === "object" && "in" in (visibility as object)
+            ? ((visibility as { in: unknown[] }).in)
+            : null;
         const matched = Object.values(mockPresets).filter((p) => {
-          if (visibility !== undefined && p.visibility !== visibility) return false;
+          if (visibilityIn != null) {
+            if (!visibilityIn.includes(p.visibility)) return false;
+          } else if (visibility !== undefined && p.visibility !== visibility) {
+            return false;
+          }
           if (category !== undefined && p.category !== category) return false;
           return true;
         });
@@ -227,7 +237,7 @@ const VALID_BODY = {
   },
 };
 
-async function seedPreset(slug: string, visibility: "PRIVATE" | "PUBLIC", category = "trend") {
+async function seedPreset(slug: string, visibility: "PRIVATE" | "BETA" | "PUBLIC", category = "trend") {
   mockPresets[slug] = {
     slug,
     name: `Preset ${slug}`,
@@ -391,6 +401,46 @@ describe("GET /api/v1/presets", () => {
     expect(rows[0]).not.toHaveProperty("dslJson");
     expect(rows[0]).toHaveProperty("defaultBotConfigJson");
   });
+
+  // ── BETA visibility tier (docs/55-T6 §A4) ─────────────────────────────────
+
+  it("anonymous list excludes BETA presets", async () => {
+    await seedPreset("public-a", "PUBLIC");
+    await seedPreset("beta-a", "BETA", "arb");
+
+    const res = await app.inject({ method: "GET", url: "/api/v1/presets" });
+    const slugs = (res.json() as Array<{ slug: string }>).map((p) => p.slug);
+    expect(slugs).toEqual(["public-a"]);
+  });
+
+  it("authenticated list includes both PUBLIC and BETA presets", async () => {
+    await seedPreset("public-a", "PUBLIC");
+    await seedPreset("beta-a", "BETA", "arb");
+    await seedPreset("private-a", "PRIVATE");
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/presets",
+      headers: { authorization: `Bearer ${userToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const slugs = (res.json() as Array<{ slug: string }>).map((p) => p.slug).sort();
+    expect(slugs).toEqual(["beta-a", "public-a"]);
+  });
+
+  it("admin can filter by ?visibility=BETA", async () => {
+    await seedPreset("public-a", "PUBLIC");
+    await seedPreset("beta-a", "BETA", "arb");
+    await seedPreset("private-a", "PRIVATE");
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/presets?visibility=BETA",
+      headers: { "x-admin-token": ADMIN_TOKEN },
+    });
+    const slugs = (res.json() as Array<{ slug: string }>).map((p) => p.slug);
+    expect(slugs).toEqual(["beta-a"]);
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -428,6 +478,25 @@ describe("GET /api/v1/presets/:slug", () => {
     });
     expect(res.statusCode).toBe(200);
     expect(res.json().slug).toBe("secret");
+  });
+
+  // ── BETA visibility tier (docs/55-T6 §A4) ─────────────────────────────────
+
+  it("returns 404 for BETA preset without authentication", async () => {
+    await seedPreset("beta-arb", "BETA", "arb");
+    const res = await app.inject({ method: "GET", url: "/api/v1/presets/beta-arb" });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 200 for BETA preset with a valid Bearer token", async () => {
+    await seedPreset("beta-arb", "BETA", "arb");
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/presets/beta-arb",
+      headers: { authorization: `Bearer ${userToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().visibility).toBe("BETA");
   });
 });
 
@@ -522,6 +591,18 @@ describe("POST /api/v1/presets/:slug/instantiate", () => {
     expect(body.botId).toBeDefined();
     expect(body.strategyId).toBeDefined();
     expect(body.strategyVersionId).toBeDefined();
+  });
+
+  it("instantiates BETA preset for an authenticated non-admin user (docs/55-T6)", async () => {
+    await seedPreset("beta-arb", "BETA", "arb");
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/presets/beta-arb/instantiate",
+      headers: userHeaders(),
+      payload: {},
+    });
+    expect(res.statusCode).toBe(201);
+    expect(res.json().botId).toBeDefined();
   });
 
   it("creates exactly one Strategy + Version + Bot, all tagged with templateSlug", async () => {


### PR DESCRIPTION
## Summary

Extends `PresetVisibility` enum with `BETA` between `PRIVATE` and `PUBLIC`, and splits `/presets` visibility scoping into three tiers per `docs/55-T6 §A4`:

| Viewer | Visible |
|---|---|
| anon | `PUBLIC` only |
| authed user | `PUBLIC` + `BETA` |
| admin | all (or filtered by `?visibility=…`) |

`BETA` gates experimental presets (e.g. `funding-arb`) behind login while keeping them off the anonymous landing — exactly the visibility tier the funding-arb track has been waiting on.

**No UI badge in this PR.** `PresetCard.tsx` rendering of a yellow "BETA" badge is a frontend change carrying browser-verification risk and is intentionally deferred to a follow-up.

## Changes

- **Prisma migration** (`20260503000000_preset_beta_visibility`): `ALTER TYPE "PresetVisibility" ADD VALUE 'BETA' BEFORE 'PUBLIC'`. Additive — existing rows untouched, column default unchanged.
- **`routes/presets.ts`**:
  - New helpers: `tryAuthenticate` (soft jwtVerify, never 401s) + `canViewPreset` (three-tier check).
  - Applied uniformly to `GET /presets`, `GET /presets/:slug`, `POST /presets/:slug/instantiate`.
  - `validateCreateBody` now accepts `BETA` as a valid POST payload value.
- **`publishPreset.ts`**: zero logic change — `allowedVisibilities()` already reads `Object.values(PresetVisibility)` dynamically, so it picks up `BETA` after `prisma generate`. JSDoc updated.
- **`presets.test.ts`**: 6 new tests covering the three tiers (3× list endpoint, 2× single-slug endpoint, 1× instantiate). Mocks updated to handle `where.visibility = { in: [...] }`.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `tests/routes/presets.test.ts` — 27 → 33 (+6 BETA tests)
- [x] Full API suite: 2138/2138 (+6 vs 2132 baseline)
- [x] `prisma generate` regenerates client with `PresetVisibility.BETA`
- [ ] Migration verified locally — relies on PostgreSQL ≥12 (project ships PG13+); migration file documents the constraint


---
_Generated by [Claude Code](https://claude.ai/code/session_01EG3E2Gxo2mqhK4PHKL9SBM)_