### PR TITLE
feat(funding-arb): Bot.mode routing seam — DSL evaluator skips FUNDING_ARB bots (55-T4)

### DIFF
--- a/apps/api/prisma/migrations/20260503100000_bot_mode/migration.sql
+++ b/apps/api/prisma/migrations/20260503100000_bot_mode/migration.sql
@@ -1,0 +1,11 @@
+-- 55-T4: BotMode enum + Bot.mode column.
+--
+-- Additive only. Existing rows backfill to DSL via the column default
+-- so DSL bots remain on the DSL evaluator path with no behavioural
+-- change. FUNDING_ARB is the routing seam for funding-arb bots; the
+-- DSL evaluator (botWorker.evaluateStrategies) early-skips them and
+-- hedgeBotWorker owns intent emission via HedgePosition advancement.
+
+CREATE TYPE "BotMode" AS ENUM ('DSL', 'FUNDING_ARB');
+
+ALTER TABLE "Bot" ADD COLUMN "mode" "BotMode" NOT NULL DEFAULT 'DSL';

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -140,6 +140,21 @@ enum BotStatus {
   DISABLED
 }
 
+/// Runtime dispatch mode for a Bot (docs/55-T4).
+///
+/// - DSL          — default; the regular DSL evaluator (botWorker.evaluateStrategies)
+///                  drives intent emission per tick.
+/// - FUNDING_ARB  — funding-arbitrage bot. Skipped by the DSL evaluator;
+///                  intent emission is delegated to `hedgeBotWorker.ts` once
+///                  the bot-scoped delegation lands. Until then this is a
+///                  routing seam only — FUNDING_ARB bots persist correctly,
+///                  emit no DSL intents, and hedgeBotWorker advances any
+///                  HedgePosition rows linked to them as before.
+enum BotMode {
+  DSL
+  FUNDING_ARB
+}
+
 model Bot {
   id                   String          @id @default(uuid())
   workspaceId          String
@@ -150,6 +165,10 @@ model Bot {
   symbol               String
   timeframe            Timeframe
   status               BotStatus       @default(DRAFT)
+  /// Runtime dispatch mode (docs/55-T4). DSL → regular evaluator path;
+  /// FUNDING_ARB → DSL evaluator skipped, hedge runtime owns intents.
+  /// Existing rows backfill to DSL via column default.
+  mode                 BotMode         @default(DSL)
   /// Optional link to the StrategyPreset this bot was instantiated from.
   /// String reference, no FK — preset can be deleted without cascading.
   templateSlug         String?

--- a/apps/api/prisma/seed/presets/funding-arb.json
+++ b/apps/api/prisma/seed/presets/funding-arb.json
@@ -37,6 +37,8 @@
   "defaultBotConfigJson": {
     "symbol": "BTCUSDT",
     "mode": "FUNDING_ARB",
+    "timeframe": "M15",
+    "maxOpenPositions": 1,
     "minFundingRate": 0.0002,
     "maxSpreadBps": 5,
     "quoteAmount": 1000

--- a/apps/api/src/lib/botWorker.ts
+++ b/apps/api/src/lib/botWorker.ts
@@ -1505,6 +1505,7 @@ async function evaluateStrategies(): Promise<void> {
             id: true,
             symbol: true,
             timeframe: true,
+            mode: true,
             datasetBundleJson: true,
             strategyVersion: { select: { dslJson: true } },
           },
@@ -1514,6 +1515,14 @@ async function evaluateStrategies(): Promise<void> {
     });
 
     for (const run of runningRuns) {
+      // Routing seam (docs/55-T4): FUNDING_ARB bots do not run the DSL
+      // evaluator. Their intents are emitted by hedgeBotWorker.ts as it
+      // advances HedgePosition rows; the DSL evaluator would either no-op
+      // on the placeholder DSL or, worse, fire stray intents on a misseed.
+      // The skip MUST come before the dslJson presence check so a missing
+      // / malformed DSL on a funding-arb preset cannot abort the loop.
+      if (run.bot?.mode === "FUNDING_ARB") continue;
+
       const dslJson = run.bot?.strategyVersion?.dslJson;
       if (!dslJson || typeof dslJson !== "object") continue;
 

--- a/apps/api/src/routes/presets.ts
+++ b/apps/api/src/routes/presets.ts
@@ -17,7 +17,7 @@
 
 import { randomBytes } from "node:crypto";
 import type { FastifyInstance, FastifyRequest } from "fastify";
-import { Prisma, PresetVisibility } from "@prisma/client";
+import { Prisma, PresetVisibility, BotMode } from "@prisma/client";
 import { prisma } from "../lib/prisma.js";
 import { problem } from "../lib/problem.js";
 import { validateDsl } from "../lib/dslValidator.js";
@@ -112,6 +112,12 @@ interface ResolvedConfig {
   quoteAmount: number;
   maxOpenPositions: number;
   baseName: string;
+  /** Runtime dispatch mode (docs/55-T4). Comes from
+   *  `defaultBotConfigJson.mode` when present (e.g. funding-arb preset
+   *  ships `"mode": "FUNDING_ARB"`); otherwise falls back to DSL. The
+   *  override block intentionally cannot set this — it is a preset-level
+   *  property, not a per-instantiation tweak. */
+  mode: BotMode;
 }
 
 function resolveConfig(
@@ -130,6 +136,7 @@ function resolveConfig(
   const quoteAmount = (overrides?.quoteAmount ?? cfg.quoteAmount) as unknown;
   const maxOpenPositions = (overrides?.maxOpenPositions ?? cfg.maxOpenPositions) as unknown;
   const baseName = (overrides?.name ?? preset.name) as unknown;
+  const modeRaw = cfg.mode as unknown;
 
   if (typeof symbol !== "string" || symbol.length === 0) {
     errors.push({ field: "symbol", message: "symbol must be a non-empty string" });
@@ -154,6 +161,19 @@ function resolveConfig(
     errors.push({ field: "name", message: "name must be 1..120 chars" });
   }
 
+  // Mode (docs/55-T4). Absent ⇒ DSL. Present must match the BotMode enum.
+  let mode: BotMode = BotMode.DSL;
+  if (modeRaw !== undefined && modeRaw !== null) {
+    if (typeof modeRaw !== "string" || !(Object.values(BotMode) as string[]).includes(modeRaw)) {
+      errors.push({
+        field: "mode",
+        message: `mode must be one of: ${(Object.values(BotMode) as string[]).join(", ")}`,
+      });
+    } else {
+      mode = modeRaw as BotMode;
+    }
+  }
+
   if (errors.length > 0) return { errors };
 
   return {
@@ -164,6 +184,7 @@ function resolveConfig(
       quoteAmount: quoteAmount as number,
       maxOpenPositions: maxOpenPositions as number,
       baseName: baseName as string,
+      mode,
     },
   };
 }
@@ -431,6 +452,7 @@ export async function presetRoutes(app: FastifyInstance) {
               timeframe: config.timeframe,
               status: "DRAFT",
               templateSlug: preset.slug,
+              mode: config.mode,
             },
           });
 

--- a/apps/api/tests/integration/presetInstantiateFlow.test.ts
+++ b/apps/api/tests/integration/presetInstantiateFlow.test.ts
@@ -70,7 +70,8 @@ vi.mock("@prisma/client", () => {
       InputJsonValue: {} as never,
       PrismaClientKnownRequestError,
     },
-    PresetVisibility: { PRIVATE: "PRIVATE", PUBLIC: "PUBLIC" },
+    PresetVisibility: { PRIVATE: "PRIVATE", BETA: "BETA", PUBLIC: "PUBLIC" },
+    BotMode: { DSL: "DSL", FUNDING_ARB: "FUNDING_ARB" },
   };
 });
 

--- a/apps/api/tests/routes/presets.test.ts
+++ b/apps/api/tests/routes/presets.test.ts
@@ -45,6 +45,7 @@ vi.mock("@prisma/client", () => {
       PrismaClientKnownRequestError,
     },
     PresetVisibility: { PRIVATE: "PRIVATE", BETA: "BETA", PUBLIC: "PUBLIC" },
+    BotMode: { DSL: "DSL", FUNDING_ARB: "FUNDING_ARB" },
   };
 });
 
@@ -237,14 +238,25 @@ const VALID_BODY = {
   },
 };
 
-async function seedPreset(slug: string, visibility: "PRIVATE" | "BETA" | "PUBLIC", category = "trend") {
+async function seedPreset(
+  slug: string,
+  visibility: "PRIVATE" | "BETA" | "PUBLIC",
+  category = "trend",
+  configOverrides: Record<string, unknown> = {},
+) {
   mockPresets[slug] = {
     slug,
     name: `Preset ${slug}`,
     description: `Description ${slug}`,
     category,
     dslJson: VALID_DSL,
-    defaultBotConfigJson: { symbol: "BTCUSDT", timeframe: "M15", quoteAmount: 100, maxOpenPositions: 1 },
+    defaultBotConfigJson: {
+      symbol: "BTCUSDT",
+      timeframe: "M15",
+      quoteAmount: 100,
+      maxOpenPositions: 1,
+      ...configOverrides,
+    },
     datasetBundleHintJson: null,
     visibility,
     createdAt: new Date(),
@@ -627,6 +639,7 @@ describe("POST /api/v1/presets/:slug/instantiate", () => {
     expect(bot.templateSlug).toBe("public-a");
     expect(bot.workspaceId).toBe(WS_ID);
     expect(bot.status).toBe("DRAFT");
+    expect(bot.mode).toBe("DSL"); // 55-T4: defaults to DSL when preset has no mode
     expect(bot.strategyVersionId).toBe(version.id);
     expect(version.strategyId).toBe(strategy.id);
     expect(version.dslJson).toEqual(VALID_DSL);
@@ -691,5 +704,33 @@ describe("POST /api/v1/presets/:slug/instantiate", () => {
     expect(r1.json().botId).not.toBe(r2.json().botId);
     expect(Object.keys(mockBots)).toHaveLength(2);
     expect(Object.keys(mockStrategies)).toHaveLength(2);
+  });
+
+  // ── Bot.mode propagation (docs/55-T4) ─────────────────────────────────────
+
+  it("persists Bot.mode = FUNDING_ARB when preset's defaultBotConfigJson sets it", async () => {
+    await seedPreset("funding-arb-test", "BETA", "arb", { mode: "FUNDING_ARB" });
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/presets/funding-arb-test/instantiate",
+      headers: userHeaders(),
+      payload: {},
+    });
+    expect(res.statusCode).toBe(201);
+    const bot = Object.values(mockBots)[0];
+    expect(bot.mode).toBe("FUNDING_ARB");
+  });
+
+  it("rejects an unknown mode value with 400 + clear error", async () => {
+    await seedPreset("bad-mode", "PUBLIC", "trend", { mode: "TURBO_CRYPTO" });
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/presets/bad-mode/instantiate",
+      headers: userHeaders(),
+      payload: {},
+    });
+    expect(res.statusCode).toBe(400);
+    const body = res.json() as { errors: Array<{ field: string; message: string }> };
+    expect(body.errors.some((e) => e.field === "mode" && /must be one of/.test(e.message))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Introduces the `Bot.mode` column and the matching evaluator-skip required to route funding-arb bots away from the DSL evaluator path.

**Scope is deliberately the routing seam only.** The bot-scoped `hedgeBotWorker.tick(bot)` delegation envisaged by `docs/55-T4 §4` is left for a follow-up because it requires an architectural choice (refactor the existing global `tickHedgeBotWorker` vs add a bot-scoped variant) that's bigger than this PR's surface.

## Schema (additive)

- New `BotMode` enum `{ DSL, FUNDING_ARB }` and `Bot.mode` column with default `DSL`.
- Existing rows backfill via the column default — zero behavioural change for DSL bots.

## Persistence

- `routes/presets.ts resolveConfig` now extracts `mode` from `defaultBotConfigJson`, validates against `BotMode`, and propagates to `bot.create`. Override block intentionally cannot set `mode` — it's a preset-level property, not a per-instantiation tweak.
- `funding-arb.json` seed gets placeholder `timeframe`/`maxOpenPositions` values that `resolveConfig` requires (runtime-irrelevant for FUNDING_ARB but satisfy validation, so the preset is now actually instantiable).

## Routing

- `botWorker.evaluateStrategies` adds an early `continue` when `bot.mode === "FUNDING_ARB"`. The skip is **before** the dslJson presence check so a missing/malformed DSL on a funding-arb preset cannot abort the loop.
- **Crucially `processIntents` is NOT touched** — hedge-leg `BotIntent` rows (category=spot/linear, emitted by `hedgeBotWorker`) still need to flow through the standard execution path. Skipping them there would block hedge execution.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `tests/routes/presets.test.ts` — 33 → 35 (FUNDING_ARB persists, bad mode → 400, DSL is default)
- [x] `tests/integration/presetInstantiateFlow.test.ts` — mock `@prisma/client` now exposes `BotMode`
- [x] Full API suite: 2140/2140 (+2 vs 2138 baseline)
- [x] Migration verified additive — column NOT NULL with default

## Out of scope (follow-ups)

- `hedgeBotWorker.tick(bot)` bot-scoped delegation from `botWorker.ts` (docs/55-T4 §4 — needs architectural decision).
- Scan-and-create logic for funding-arb bots (decides whether the bot or a parallel worker creates `HedgePosition` rows).
- 55-T2 spot-leg execution wiring through `bybitOrder({ category: "spot" })`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EG3E2Gxo2mqhK4PHKL9SBM)_