### PR TITLE
feat(funding-arb): bot-scoped hedgeBotWorker delegation from botWorker tick (55-T4 follow-up)

### DIFF
--- a/apps/api/src/lib/botWorker.ts
+++ b/apps/api/src/lib/botWorker.ts
@@ -28,6 +28,7 @@
 import { logger } from "./logger.js";
 import { Prisma } from "@prisma/client";
 import { prisma } from "./prisma.js";
+import { tickHedgeBotWorkerForBotRun } from "./hedgeBotWorker.js";
 import { transition, isValidTransition } from "./stateMachine.js";
 import {
   bybitPlaceOrder,
@@ -1516,12 +1517,24 @@ async function evaluateStrategies(): Promise<void> {
 
     for (const run of runningRuns) {
       // Routing seam (docs/55-T4): FUNDING_ARB bots do not run the DSL
-      // evaluator. Their intents are emitted by hedgeBotWorker.ts as it
-      // advances HedgePosition rows; the DSL evaluator would either no-op
-      // on the placeholder DSL or, worse, fire stray intents on a misseed.
-      // The skip MUST come before the dslJson presence check so a missing
-      // / malformed DSL on a funding-arb preset cannot abort the loop.
-      if (run.bot?.mode === "FUNDING_ARB") continue;
+      // evaluator — their intents are emitted by `tickHedgeBotWorkerForBotRun`
+      // as it advances this run's HedgePosition rows. The delegation MUST
+      // come before the dslJson presence check so a missing / malformed DSL
+      // on a funding-arb preset cannot abort the loop. Per-bot errors are
+      // isolated by `advanceCandidates` (logged + swallowed); the outer
+      // try/catch here also guards against a `findMany` failure so one bad
+      // bot can't stall evaluation for the rest.
+      if (run.bot?.mode === "FUNDING_ARB") {
+        try {
+          await tickHedgeBotWorkerForBotRun(run.id);
+        } catch (err) {
+          workerLog.error(
+            { err, runId: run.id, botId: run.bot.id },
+            "hedgeBotWorker delegation failed (isolated)",
+          );
+        }
+        continue;
+      }
 
       const dslJson = run.bot?.strategyVersion?.dslJson;
       if (!dslJson || typeof dslJson !== "object") continue;

--- a/apps/api/src/lib/hedgeBotWorker.ts
+++ b/apps/api/src/lib/hedgeBotWorker.ts
@@ -433,9 +433,37 @@ async function loadHedgeCreds(botRunId: string): Promise<ExchangeConnectionCreds
   return run?.bot?.exchangeConnection ?? null;
 }
 
-/** One pass: advance every non-terminal hedge. Per-hedge errors are
- *  logged + classified but NEVER bubble — funding-arb errors must not
- *  take down the worker.
+type HedgeCandidate = { id: string; symbol: string; botRunId: string };
+
+const NON_TERMINAL_STATUSES = ["PLANNED", "OPENING", "OPEN", "CLOSING"] as const;
+
+/** Shared advance loop. Per-hedge errors are logged + classified but NEVER
+ *  bubble — funding-arb errors must not take down the worker. Used by both
+ *  the global `tickHedgeBotWorker` and the bot-scoped
+ *  `tickHedgeBotWorkerForBotRun` so the inputResolver / default-input
+ *  semantics stay identical regardless of how candidates were sourced. */
+async function advanceCandidates(
+  candidates: HedgeCandidate[],
+  inputResolver?: (hedgeId: string) => HedgeAdvanceInput | Promise<HedgeAdvanceInput>,
+): Promise<HedgeAdvanceResult[]> {
+  const out: HedgeAdvanceResult[] = [];
+  for (const c of candidates) {
+    try {
+      const input = inputResolver
+        ? await inputResolver(c.id)
+        : await buildDefaultInput(c);
+      const res = await advanceHedge(c.id, input);
+      out.push(res);
+    } catch (err) {
+      const classification = classifyExecutionError(err);
+      log.error({ err, hedgeId: c.id, classification }, "hedge advance failed (isolated)");
+      // Swallow — funding-arb tick must keep ticking for other hedges.
+    }
+  }
+  return out;
+}
+
+/** One pass: advance every non-terminal hedge across the whole installation.
  *
  *  Behaviour:
  *   - Default path (no `inputResolver` supplied): for each hedge, load
@@ -452,30 +480,36 @@ async function loadHedgeCreds(botRunId: string): Promise<ExchangeConnectionCreds
  *  whichever upstream owns scanner / payment-ledger lookups (out of
  *  scope for this PR — currently absent, so PENDING / ACTIVE hedges
  *  no-op until that wiring lands).
+ *
+ *  Used by the env-gated `startHedgeBotWorker` daemon. Per-bot delegation
+ *  from the mainline botWorker poll lives in `tickHedgeBotWorkerForBotRun`.
  */
 export async function tickHedgeBotWorker(
   inputResolver?: (hedgeId: string) => HedgeAdvanceInput | Promise<HedgeAdvanceInput>,
 ): Promise<HedgeAdvanceResult[]> {
   const candidates = await prisma.hedgePosition.findMany({
-    where: { status: { in: ["PLANNED", "OPENING", "OPEN", "CLOSING"] } },
+    where: { status: { in: [...NON_TERMINAL_STATUSES] } },
     select: { id: true, symbol: true, botRunId: true },
   });
+  return advanceCandidates(candidates, inputResolver);
+}
 
-  const out: HedgeAdvanceResult[] = [];
-  for (const c of candidates) {
-    try {
-      const input = inputResolver
-        ? await inputResolver(c.id)
-        : await buildDefaultInput(c);
-      const res = await advanceHedge(c.id, input);
-      out.push(res);
-    } catch (err) {
-      const classification = classifyExecutionError(err);
-      log.error({ err, hedgeId: c.id, classification }, "hedge advance failed (isolated)");
-      // Swallow — funding-arb tick must keep ticking for other hedges.
-    }
-  }
-  return out;
+/** Bot-scoped variant: advance only the non-terminal hedges that belong to
+ *  one BotRun. Used by `botWorker.evaluateStrategies` to delegate
+ *  FUNDING_ARB bots — the DSL evaluator already short-circuits on
+ *  `bot.mode === "FUNDING_ARB"`, so this call replaces the no-op skip with
+ *  a real per-bot tick that runs every botWorker poll (4s) instead of the
+ *  60s global daemon cadence. Same advance semantics as the global tick,
+ *  just narrower findMany. */
+export async function tickHedgeBotWorkerForBotRun(
+  botRunId: string,
+  inputResolver?: (hedgeId: string) => HedgeAdvanceInput | Promise<HedgeAdvanceInput>,
+): Promise<HedgeAdvanceResult[]> {
+  const candidates = await prisma.hedgePosition.findMany({
+    where: { botRunId, status: { in: [...NON_TERMINAL_STATUSES] } },
+    select: { id: true, symbol: true, botRunId: true },
+  });
+  return advanceCandidates(candidates, inputResolver);
 }
 
 /**

--- a/apps/api/tests/lib/hedgeBotWorker.test.ts
+++ b/apps/api/tests/lib/hedgeBotWorker.test.ts
@@ -65,10 +65,11 @@ vi.mock("../../src/lib/prisma.js", () => ({
       findUnique: vi.fn(async ({ where }: { where: { id: string } }) => {
         return hedgesById.get(where.id) ?? null;
       }),
-      findMany: vi.fn(async ({ where }: { where: { status: { in: string[] } } }) => {
+      findMany: vi.fn(async ({ where }: { where: { botRunId?: string; status: { in: string[] } } }) => {
         const statuses = new Set(where.status.in);
         return [...hedgesById.values()]
           .filter((h) => statuses.has(h.status))
+          .filter((h) => where.botRunId === undefined || h.botRunId === where.botRunId)
           .map((h) => ({ id: h.id, symbol: h.symbol, botRunId: h.botRunId }));
       }),
       update: vi.fn(async ({ where, data }: { where: { id: string }; data: Record<string, unknown> }) => {
@@ -148,6 +149,7 @@ import {
   advanceHedge,
   startHedgeBotWorker,
   tickHedgeBotWorker,
+  tickHedgeBotWorkerForBotRun,
   type HedgeStage,
 } from "../../src/lib/hedgeBotWorker.js";
 
@@ -481,6 +483,61 @@ describe("tickHedgeBotWorker", () => {
     expect(res[0]).toMatchObject({ hedgeId: "tick-2", toStage: "PENDING", changed: false });
     expect(reconcileBalancesMock).not.toHaveBeenCalled();
     expect(hedgesById.get("tick-2")?.status).toBe("PLANNED");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5b. tickHedgeBotWorkerForBotRun — bot-scoped delegation (docs/55-T4)
+// ---------------------------------------------------------------------------
+
+describe("tickHedgeBotWorkerForBotRun", () => {
+  it("only advances hedges whose botRunId matches the scope", async () => {
+    seedHedge({ id: "scoped-a", status: "PLANNED", botRunId: "run-A" });
+    seedHedge({ id: "scoped-b", status: "PLANNED", botRunId: "run-B" });
+
+    const res = await tickHedgeBotWorkerForBotRun("run-A", () => ({
+      fundingWindowOpen: true,
+      entryQty: 1.0,
+    }));
+
+    expect(res).toHaveLength(1);
+    expect(res[0]).toMatchObject({ hedgeId: "scoped-a", toStage: "ENTRY_PLACED" });
+    expect(hedgesById.get("scoped-a")?.status).toBe("OPENING");
+    // Cross-tenant isolation: the other run's hedge stays untouched.
+    expect(hedgesById.get("scoped-b")?.status).toBe("PLANNED");
+  });
+
+  it("returns empty when the scoped run has no eligible hedges", async () => {
+    seedHedge({ id: "other", status: "PLANNED", botRunId: "run-other" });
+    const res = await tickHedgeBotWorkerForBotRun("run-empty");
+    expect(res).toEqual([]);
+  });
+
+  it("filters by status: terminal hedges in scope are skipped", async () => {
+    seedHedge({ id: "scope-closed", status: "CLOSED", botRunId: "run-X" });
+    seedHedge({ id: "scope-open",   status: "OPENING", botRunId: "run-X" });
+
+    const res = await tickHedgeBotWorkerForBotRun("run-X", () => ({}));
+
+    // Only OPENING gets a tick; the CLOSED hedge is excluded by the
+    // status filter (same as the global tick).
+    expect(res).toHaveLength(1);
+    expect(res[0].hedgeId).toBe("scope-open");
+  });
+
+  it("isolates a per-hedge throw within the scoped run", async () => {
+    seedHedge({ id: "ok",  status: "PLANNED", botRunId: "run-iso" });
+    seedHedge({ id: "bad", status: "PLANNED", botRunId: "run-iso" });
+
+    const res = await tickHedgeBotWorkerForBotRun("run-iso", (hedgeId) => {
+      if (hedgeId === "bad") throw new Error("synthetic");
+      return { fundingWindowOpen: true, entryQty: 1.0 };
+    });
+
+    expect(res).toHaveLength(1);
+    expect(res[0]).toMatchObject({ hedgeId: "ok", toStage: "ENTRY_PLACED" });
+    expect(hedgesById.get("ok")?.status).toBe("OPENING");
+    expect(hedgesById.get("bad")?.status).toBe("PLANNED");
   });
 });
 


### PR DESCRIPTION
## Summary

Replace the no-op `if (bot.mode === FUNDING_ARB) continue;` skip in `evaluateStrategies` (#361) with a real per-BotRun tick that advances only the hedges belonging to that run. The DSL evaluator path is still bypassed for funding-arb bots; what's new is that their `HedgePosition` state machine now ticks every botWorker poll (4s) instead of relying on the env-gated 60s `startHedgeBotWorker` daemon.

This unblocks 55-T2 (spot-leg execution) — once `bybitOrder.ts` gains category dispatch, funding-arb bots will produce executed two-leg trades end-to-end without further worker plumbing.

## Architecture

- **Refactor in `apps/api/src/lib/hedgeBotWorker.ts`** — extract `advanceCandidates(candidates, inputResolver?)` private helper carrying the existing per-hedge try/classify/swallow loop. Both wrappers source candidates from `prisma.hedgePosition.findMany` then defer to `advanceCandidates`, so inputResolver semantics + default `buildDefaultInput` wiring (creds load, `windowDetector`, `reconcileBalances`) stay identical regardless of how the candidate set was scoped.
- **New `tickHedgeBotWorkerForBotRun(botRunId, inputResolver?)`** — adds `botRunId` to the findMany `where` clause; everything downstream is reused.
- **`tickHedgeBotWorker` (global) is unchanged** in behaviour — still used by the env-gated `startHedgeBotWorker` daemon as fallback / dev path.
- **`apps/api/src/lib/botWorker.ts` integration** — single try/await/continue replacing the bare `continue`. Outer try/catch is for a `findMany` failure so one bad bot can't stall evaluation; per-hedge errors are already isolated by `advanceCandidates`.

## Tests

`apps/api/tests/lib/hedgeBotWorker.test.ts` — +4 cases under a new `tickHedgeBotWorkerForBotRun` describe block:
- Cross-tenant isolation (two hedges, different botRunIds, only the scoped one advances).
- Empty scope returns `[]`.
- Status filter still applies inside the scope (CLOSED hedges skipped).
- Per-hedge throw within the scoped run is isolated.

The mock for `prisma.hedgePosition.findMany` is extended to honour an optional `botRunId` filter — additive, existing 20 cases untouched.

## Test plan
- [x] `pnpm --filter @botmarketplace/api exec prisma generate`
- [x] `pnpm --filter @botmarketplace/api exec tsc --noEmit` — clean
- [x] `pnpm --filter @botmarketplace/api exec vitest run tests/lib/hedgeBotWorker.test.ts` — 24/24
- [x] `pnpm --filter @botmarketplace/api test` — 2144/2144 (was 2140 baseline; +4 new)

https://claude.ai/code/session_01XoMMe56sv7QDkoovGn9Lww

---
_Generated by [Claude Code](https://claude.ai/code/session_01XoMMe56sv7QDkoovGn9Lww)_