### PR TITLE
feat(funding-arb): sync sequential spot-leg execution in /hedges/:id/execute &amp; /exit (55-T2)

### DIFF
--- a/apps/api/src/lib/exchange/hedgeExecutor.ts
+++ b/apps/api/src/lib/exchange/hedgeExecutor.ts
@@ -1,0 +1,357 @@
+/**
+ * Funding-arb hedge execution (docs/55-T2).
+ *
+ * Places real Bybit orders for the spot + perp legs of a hedge, sequentially,
+ * with compensating unwind on partial failure. Used synchronously by the
+ * `/hedges/:id/execute` and `/hedges/:id/exit` REST routes.
+ *
+ * Sequencing:
+ *   - Entry: spot Buy first, then perp Sell. Spot leads because spot market
+ *     orders historically take longer to fill on Bybit; if spot fails, the
+ *     perp side is never opened so no orphan position can result. If spot
+ *     ok but perp fails, a compensating market sell is attempted on the
+ *     spot leg (best-effort, swallowed errors → manual unwind alert).
+ *   - Exit: spot Sell first, then perp Buy-to-close. Spot leads for the
+ *     same reason. If perp close fails AFTER spot sell, no compensating
+ *     reverse is attempted (re-buying spot would contradict the operator's
+ *     intent to exit) — outcome is PARTIAL_ERROR with structured reason.
+ *
+ * Each leg uses bybitPlaceOrder (Market + IOC) and then polls
+ * bybitGetOrderStatus a small fixed number of times to obtain avgPrice +
+ * cumExecQty for the LegExecution row. Non-terminal status after the poll
+ * budget is treated as a leg failure.
+ *
+ * Scope boundary: this module imports `bybitOrder.ts` but does NOT modify
+ * it. The processIntents pipeline that the async hedgeBotWorker emits to
+ * is unchanged — that path is still scoped to linear and will be wired up
+ * separately.
+ */
+
+import {
+  bybitPlaceOrder,
+  bybitGetOrderStatus,
+  sanitizeBybitError,
+} from "../bybitOrder.js";
+import { logger } from "../logger.js";
+
+const log = logger.child({ module: "hedgeExecutor" });
+
+// ---------------------------------------------------------------------------
+// Polling config — env-overridable so tests can disable real timers.
+// ---------------------------------------------------------------------------
+
+function getPollAttempts(): number {
+  const raw = parseInt(process.env.HEDGE_LEG_POLL_ATTEMPTS ?? "", 10);
+  return Number.isFinite(raw) && raw > 0 ? raw : 5;
+}
+
+function getPollDelayMs(): number {
+  const raw = parseInt(process.env.HEDGE_LEG_POLL_DELAY_MS ?? "", 10);
+  return Number.isFinite(raw) && raw >= 0 ? raw : 200;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface LegCreds {
+  apiKey: string;
+  /** Plaintext secret — caller is responsible for decrypting. */
+  secret: string;
+}
+
+export interface PlaceLegInput {
+  category: "linear" | "spot";
+  symbol: string;
+  side: "Buy" | "Sell";
+  qty: string;
+}
+
+export interface PlacedLegResult {
+  orderId: string;
+  /** Average fill price as number (parsed from Bybit string response). */
+  avgPrice: number;
+  /** Cumulative executed quantity as number. */
+  cumExecQty: number;
+}
+
+export type HedgeLegSide = "SPOT_BUY" | "PERP_SHORT" | "SPOT_SELL" | "PERP_CLOSE";
+
+export interface HedgeLegRow {
+  side: HedgeLegSide;
+  price: number;
+  quantity: number;
+  /** Bybit order response does not include exec fee on this path; populated
+   *  from the order-status reconciler in a later pass. Default 0 keeps the
+   *  LegExecution row writable today. */
+  fee: number;
+  orderId: string;
+}
+
+export type HedgeExecutionOutcome = "FILLED" | "FAILED" | "PARTIAL_ERROR";
+
+export interface HedgeExecutionResult {
+  outcome: HedgeExecutionOutcome;
+  /** Successfully placed legs (one or two depending on outcome). */
+  legs: HedgeLegRow[];
+  /** Set when outcome is FAILED or PARTIAL_ERROR. */
+  reason?: string;
+  /** True iff a compensating action was attempted (PARTIAL_ERROR entry path). */
+  compensatingUnwindAttempted?: boolean;
+  /** True iff that compensating action itself succeeded. */
+  compensatingUnwindSucceeded?: boolean;
+}
+
+export interface HedgeExecutionInput {
+  spotCreds: LegCreds;
+  perpCreds: LegCreds;
+  symbol: string;
+  /** Quantity as string (Bybit requires string representation). */
+  qty: string;
+  /** For structured logging only. */
+  hedgeId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Single-leg placement + status poll
+// ---------------------------------------------------------------------------
+
+/** Place a Market+IOC order and poll bybitGetOrderStatus until terminal.
+ *  Throws on Cancelled / Rejected / Deactivated terminal state, or on
+ *  polling timeout (treated as a leg failure by the orchestrator above).
+ *  Filled with cumExecQty=0 is reported as failure for safety — Bybit
+ *  occasionally reports zero-fill Filled responses on rate-limited paths,
+ *  and treating that as success would create a phantom LegExecution. */
+export async function placeMarketLeg(
+  creds: LegCreds,
+  input: PlaceLegInput,
+): Promise<PlacedLegResult> {
+  const placed = await bybitPlaceOrder(creds.apiKey, creds.secret, {
+    category: input.category,
+    symbol: input.symbol,
+    side: input.side,
+    orderType: "Market",
+    qty: input.qty,
+  });
+
+  const attempts = getPollAttempts();
+  const delayMs = getPollDelayMs();
+
+  for (let i = 0; i < attempts; i++) {
+    const status = await bybitGetOrderStatus(
+      creds.apiKey,
+      creds.secret,
+      placed.orderId,
+      input.symbol,
+      input.category,
+    );
+
+    if (status.orderStatus === "Filled") {
+      const cumExecQty = parseFloat(status.cumExecQty);
+      const avgPrice = parseFloat(status.avgPrice);
+      if (!Number.isFinite(cumExecQty) || cumExecQty <= 0) {
+        throw new Error(
+          `Bybit reported Filled with non-positive cumExecQty (${status.cumExecQty}) for ${placed.orderId}`,
+        );
+      }
+      if (!Number.isFinite(avgPrice) || avgPrice <= 0) {
+        throw new Error(
+          `Bybit reported Filled with non-positive avgPrice (${status.avgPrice}) for ${placed.orderId}`,
+        );
+      }
+      return { orderId: placed.orderId, avgPrice, cumExecQty };
+    }
+
+    if (
+      status.orderStatus === "Cancelled" ||
+      status.orderStatus === "Rejected" ||
+      status.orderStatus === "Deactivated"
+    ) {
+      throw new Error(
+        `Order ${placed.orderId} reached terminal non-Filled state: ${status.orderStatus}`,
+      );
+    }
+
+    if (i < attempts - 1 && delayMs > 0) {
+      await sleep(delayMs);
+    }
+  }
+
+  throw new Error(
+    `Order ${placed.orderId} did not reach Filled within ${attempts} polls`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Two-leg orchestration: entry + exit
+// ---------------------------------------------------------------------------
+
+/** Sequential entry: spot Buy first, then perp Sell. On spot failure the
+ *  perp side is never opened; on perp failure after spot ok a compensating
+ *  spot sell is attempted (best-effort). */
+export async function executeHedgeEntry(
+  input: HedgeExecutionInput,
+): Promise<HedgeExecutionResult> {
+  let spotLeg: PlacedLegResult;
+  try {
+    spotLeg = await placeMarketLeg(input.spotCreds, {
+      category: "spot",
+      symbol: input.symbol,
+      side: "Buy",
+      qty: input.qty,
+    });
+  } catch (err) {
+    const reason = sanitizeBybitError(err);
+    log.error(
+      { hedgeId: input.hedgeId, leg: "SPOT_BUY", reason },
+      "spot entry leg failed — abort before perp call",
+    );
+    return { outcome: "FAILED", legs: [], reason: `spot leg failed: ${reason}` };
+  }
+
+  let perpLeg: PlacedLegResult;
+  try {
+    perpLeg = await placeMarketLeg(input.perpCreds, {
+      category: "linear",
+      symbol: input.symbol,
+      side: "Sell",
+      qty: input.qty,
+    });
+  } catch (perpErr) {
+    const perpReason = sanitizeBybitError(perpErr);
+    log.error(
+      { hedgeId: input.hedgeId, leg: "PERP_SHORT", reason: perpReason },
+      "perp entry leg failed after spot fill — attempting compensating spot sell",
+    );
+
+    let compensatingSucceeded = false;
+    try {
+      await placeMarketLeg(input.spotCreds, {
+        category: "spot",
+        symbol: input.symbol,
+        side: "Sell",
+        qty: input.qty,
+      });
+      compensatingSucceeded = true;
+      log.warn({ hedgeId: input.hedgeId }, "compensating spot sell succeeded");
+    } catch (sellErr) {
+      log.error(
+        { hedgeId: input.hedgeId, reason: sanitizeBybitError(sellErr) },
+        "compensating spot sell FAILED — manual unwind required",
+      );
+    }
+
+    return {
+      outcome: "PARTIAL_ERROR",
+      legs: [
+        {
+          side: "SPOT_BUY",
+          price: spotLeg.avgPrice,
+          quantity: spotLeg.cumExecQty,
+          fee: 0,
+          orderId: spotLeg.orderId,
+        },
+      ],
+      reason: `perp leg failed: ${perpReason}`,
+      compensatingUnwindAttempted: true,
+      compensatingUnwindSucceeded: compensatingSucceeded,
+    };
+  }
+
+  return {
+    outcome: "FILLED",
+    legs: [
+      {
+        side: "SPOT_BUY",
+        price: spotLeg.avgPrice,
+        quantity: spotLeg.cumExecQty,
+        fee: 0,
+        orderId: spotLeg.orderId,
+      },
+      {
+        side: "PERP_SHORT",
+        price: perpLeg.avgPrice,
+        quantity: perpLeg.cumExecQty,
+        fee: 0,
+        orderId: perpLeg.orderId,
+      },
+    ],
+  };
+}
+
+/** Sequential exit: spot Sell first, then perp Buy-to-close. No compensating
+ *  reverse on partial failure — re-buying spot would contradict the operator's
+ *  intent to exit. PARTIAL_ERROR signals manual unwind required. */
+export async function executeHedgeExit(
+  input: HedgeExecutionInput,
+): Promise<HedgeExecutionResult> {
+  let spotLeg: PlacedLegResult;
+  try {
+    spotLeg = await placeMarketLeg(input.spotCreds, {
+      category: "spot",
+      symbol: input.symbol,
+      side: "Sell",
+      qty: input.qty,
+    });
+  } catch (err) {
+    const reason = sanitizeBybitError(err);
+    log.error(
+      { hedgeId: input.hedgeId, leg: "SPOT_SELL", reason },
+      "spot exit leg failed — abort before perp close",
+    );
+    return { outcome: "FAILED", legs: [], reason: `spot exit leg failed: ${reason}` };
+  }
+
+  let perpLeg: PlacedLegResult;
+  try {
+    perpLeg = await placeMarketLeg(input.perpCreds, {
+      category: "linear",
+      symbol: input.symbol,
+      side: "Buy",
+      qty: input.qty,
+    });
+  } catch (perpErr) {
+    const perpReason = sanitizeBybitError(perpErr);
+    log.error(
+      { hedgeId: input.hedgeId, leg: "PERP_CLOSE", reason: perpReason },
+      "perp close leg failed after spot sell — manual unwind alert",
+    );
+    return {
+      outcome: "PARTIAL_ERROR",
+      legs: [
+        {
+          side: "SPOT_SELL",
+          price: spotLeg.avgPrice,
+          quantity: spotLeg.cumExecQty,
+          fee: 0,
+          orderId: spotLeg.orderId,
+        },
+      ],
+      reason: `perp close leg failed: ${perpReason}`,
+    };
+  }
+
+  return {
+    outcome: "FILLED",
+    legs: [
+      {
+        side: "SPOT_SELL",
+        price: spotLeg.avgPrice,
+        quantity: spotLeg.cumExecQty,
+        fee: 0,
+        orderId: spotLeg.orderId,
+      },
+      {
+        side: "PERP_CLOSE",
+        price: perpLeg.avgPrice,
+        quantity: perpLeg.cumExecQty,
+        fee: 0,
+        orderId: perpLeg.orderId,
+      },
+    ],
+  };
+}

--- a/apps/api/src/routes/hedges.ts
+++ b/apps/api/src/routes/hedges.ts
@@ -8,13 +8,19 @@
  * GET  /hedges/:id            — position details + legs + computed P&L
  */
 
-import { randomUUID } from "node:crypto";
-import type { FastifyInstance } from "fastify";
+import type { FastifyInstance, FastifyReply } from "fastify";
 import { prisma } from "../lib/prisma.js";
 import { problem } from "../lib/problem.js";
 import { resolveWorkspace } from "../lib/workspace.js";
 import { computeHedgePnl } from "../lib/funding/hedgePlanner.js";
 import type { HedgePosition as HedgePlannerPos, LegExecution } from "../lib/funding/hedgeTypes.js";
+import { decryptWithFallback } from "../lib/crypto.js";
+import {
+  executeHedgeEntry,
+  executeHedgeExit,
+  type HedgeExecutionResult,
+  type LegCreds,
+} from "../lib/exchange/hedgeExecutor.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -64,6 +70,116 @@ function toHedgePlannerPos(
   };
 }
 
+/** Pull the BotRun with the credentials needed to execute hedge legs. The
+ *  shape returned is consumed by both `resolveLegCreds` (decrypt) and the
+ *  ownership check (workspaceId match). */
+async function loadRunWithCreds(botRunId: string) {
+  return prisma.botRun.findUnique({
+    where: { id: botRunId },
+    select: {
+      id: true,
+      workspaceId: true,
+      bot: {
+        select: {
+          exchangeConnection: {
+            select: {
+              apiKey: true,
+              encryptedSecret: true,
+              spotApiKey: true,
+              spotEncryptedSecret: true,
+            },
+          },
+        },
+      },
+    },
+  });
+}
+
+type RunWithCreds = NonNullable<Awaited<ReturnType<typeof loadRunWithCreds>>>;
+
+/** Build per-leg credentials. Spot uses dedicated `spotApiKey/spotEncryptedSecret`
+ *  when present, falling back to the linear key — the single-key fallback
+ *  documented in docs/55-T5 §4. Returns null when no ExchangeConnection is
+ *  linked at all (caller responds 422). Secrets are decrypted here so the
+ *  hedgeExecutor receives plaintext and never touches crypto. */
+function resolveLegCreds(run: RunWithCreds): { spotCreds: LegCreds; perpCreds: LegCreds } | null {
+  const conn = run.bot?.exchangeConnection;
+  if (!conn) return null;
+
+  const perpSecret = decryptWithFallback(conn.encryptedSecret);
+  const spotSecret = conn.spotEncryptedSecret
+    ? decryptWithFallback(conn.spotEncryptedSecret)
+    : perpSecret;
+  return {
+    perpCreds: { apiKey: conn.apiKey, secret: perpSecret },
+    spotCreds: { apiKey: conn.spotApiKey ?? conn.apiKey, secret: spotSecret },
+  };
+}
+
+/** Persist execution result + advance HedgePosition status, then send the
+ *  HTTP response. Single-transaction write of LegExecution rows + status
+ *  bump so an interrupted process can't leave a hedge with legs but stale
+ *  status, or vice versa. */
+async function persistAndRespond(
+  reply: FastifyReply,
+  hedgeId: string,
+  exec: HedgeExecutionResult,
+  type: "ENTRY" | "EXIT",
+) {
+  const isEntry = type === "ENTRY";
+
+  // Status mapping — outcome × type:
+  //   FILLED entry → OPEN
+  //   FILLED exit  → CLOSED (with closedAt)
+  //   FAILED any   → FAILED
+  //   PARTIAL_ERROR any → FAILED (operator alert lives in the response body
+  //                        + structured logs from hedgeExecutor)
+  let nextStatus: "OPEN" | "CLOSED" | "FAILED";
+  if (exec.outcome === "FILLED") {
+    nextStatus = isEntry ? "OPEN" : "CLOSED";
+  } else {
+    nextStatus = "FAILED";
+  }
+
+  const updateData: { status: typeof nextStatus; closedAt?: Date } = { status: nextStatus };
+  if (nextStatus === "CLOSED") updateData.closedAt = new Date();
+
+  await prisma.$transaction([
+    ...exec.legs.map((leg) =>
+      prisma.legExecution.create({
+        data: {
+          hedgeId,
+          side: leg.side,
+          price: leg.price,
+          quantity: leg.quantity,
+          fee: leg.fee,
+        },
+      }),
+    ),
+    prisma.hedgePosition.update({
+      where: { id: hedgeId },
+      data: updateData,
+    }),
+  ]);
+
+  const httpStatus = exec.outcome === "FILLED" ? 200 : 422;
+  return reply.status(httpStatus).send({
+    hedgeId,
+    status: nextStatus,
+    outcome: exec.outcome,
+    legs: exec.legs,
+    ...(exec.reason ? { reason: exec.reason } : {}),
+    ...(exec.compensatingUnwindAttempted !== undefined
+      ? {
+          compensatingUnwind: {
+            attempted: exec.compensatingUnwindAttempted,
+            succeeded: exec.compensatingUnwindSucceeded ?? false,
+          },
+        }
+      : {}),
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Route plugin
 // ---------------------------------------------------------------------------
@@ -106,12 +222,10 @@ export async function hedgeRoutes(app: FastifyInstance) {
     return reply.status(201).send(hedge);
   });
 
-  // ── POST /hedges/:id/execute ── place entry legs → OPENING ──────────────
+  // ── POST /hedges/:id/execute ── sync sequential entry → OPEN | FAILED ───
   app.post<{
     Params: { id: string };
     Body: {
-      spotPrice?: number;
-      perpPrice?: number;
       quantity?: number;
     };
   }>("/hedges/:id/execute", { onRequest: [app.authenticate] }, async (request, reply) => {
@@ -125,59 +239,40 @@ export async function hedgeRoutes(app: FastifyInstance) {
 
     if (!hedge) return problem(reply, 404, "Not Found", "Hedge position not found");
 
-    // Verify ownership via botRun → workspace
-    const run = await prisma.botRun.findUnique({ where: { id: hedge.botRunId } });
+    const run = await loadRunWithCreds(hedge.botRunId);
     if (!run || run.workspaceId !== workspace.id) {
       return problem(reply, 404, "Not Found", "Hedge position not found");
     }
 
+    // Idempotency: only PLANNED hedges may be executed. Any other status
+    // (OPENING, OPEN, CLOSING, CLOSED, FAILED) returns 409 — covers both
+    // a repeated execute after success (status=OPEN) and a repeated execute
+    // after a partial-error path (status=FAILED).
     if (hedge.status !== "PLANNED") {
       return problem(reply, 409, "Conflict", `Cannot execute hedge in status: ${hedge.status}`);
     }
 
-    // Create two BotIntents — spot buy + perp short
-    const spotIntentId = `hedge-${hedge.id}-spot-entry`;
-    const perpIntentId = `hedge-${hedge.id}-perp-entry`;
+    const qty = request.body?.quantity;
+    if (typeof qty !== "number" || qty <= 0) {
+      return problem(reply, 400, "Bad Request", "'quantity' must be a positive number");
+    }
 
-    const [spotIntent, perpIntent] = await prisma.$transaction([
-      prisma.botIntent.create({
-        data: {
-          botRunId: hedge.botRunId,
-          intentId: spotIntentId,
-          orderLinkId: randomUUID(),
-          type: "ENTRY",
-          state: "PENDING",
-          side: "BUY",
-          qty: request.body?.quantity ?? 0,
-          metaJson: { hedgeId: hedge.id, legSide: "SPOT_BUY", category: "spot" },
-        },
-      }),
-      prisma.botIntent.create({
-        data: {
-          botRunId: hedge.botRunId,
-          intentId: perpIntentId,
-          orderLinkId: randomUUID(),
-          type: "ENTRY",
-          state: "PENDING",
-          side: "SELL",
-          qty: request.body?.quantity ?? 0,
-          metaJson: { hedgeId: hedge.id, legSide: "PERP_SHORT", category: "linear" },
-        },
-      }),
-      prisma.hedgePosition.update({
-        where: { id: hedge.id },
-        data: { status: "OPENING" },
-      }),
-    ]);
+    const creds = resolveLegCreds(run);
+    if (!creds) {
+      return problem(reply, 422, "Unprocessable Content", "Bot has no linked ExchangeConnection");
+    }
 
-    return reply.send({
+    const exec = await executeHedgeEntry({
+      ...creds,
+      symbol: hedge.symbol,
+      qty: qty.toString(),
       hedgeId: hedge.id,
-      status: "OPENING",
-      intents: { spot: spotIntent, perp: perpIntent },
     });
+
+    return persistAndRespond(reply, hedge.id, exec, "ENTRY");
   });
 
-  // ── POST /hedges/:id/exit ── place exit legs → CLOSING ──────────────────
+  // ── POST /hedges/:id/exit ── sync sequential exit → CLOSED | FAILED ─────
   app.post<{
     Params: { id: string };
     Body: {
@@ -194,7 +289,7 @@ export async function hedgeRoutes(app: FastifyInstance) {
 
     if (!hedge) return problem(reply, 404, "Not Found", "Hedge position not found");
 
-    const run = await prisma.botRun.findUnique({ where: { id: hedge.botRunId } });
+    const run = await loadRunWithCreds(hedge.botRunId);
     if (!run || run.workspaceId !== workspace.id) {
       return problem(reply, 404, "Not Found", "Hedge position not found");
     }
@@ -203,53 +298,27 @@ export async function hedgeRoutes(app: FastifyInstance) {
       return problem(reply, 409, "Conflict", `Cannot exit hedge in status: ${hedge.status}`);
     }
 
-    // Determine quantity from entry legs
-    const spotLeg = hedge.legs.find((l) => l.side === "SPOT_BUY");
-    const exitQty = request.body?.quantity ?? spotLeg?.quantity ?? 0;
-
+    // Quantity defaults to the SPOT_BUY leg quantity from entry — exit
+    // matches entry size unless caller explicitly overrides.
+    const spotEntryLeg = hedge.legs.find((l) => l.side === "SPOT_BUY");
+    const exitQty = request.body?.quantity ?? spotEntryLeg?.quantity ?? 0;
     if (exitQty <= 0) {
       return problem(reply, 400, "Bad Request", "Cannot determine exit quantity — no filled entry legs");
     }
 
-    const spotExitIntentId = `hedge-${hedge.id}-spot-exit`;
-    const perpExitIntentId = `hedge-${hedge.id}-perp-exit`;
+    const creds = resolveLegCreds(run);
+    if (!creds) {
+      return problem(reply, 422, "Unprocessable Content", "Bot has no linked ExchangeConnection");
+    }
 
-    const [spotIntent, perpIntent] = await prisma.$transaction([
-      prisma.botIntent.create({
-        data: {
-          botRunId: hedge.botRunId,
-          intentId: spotExitIntentId,
-          orderLinkId: randomUUID(),
-          type: "EXIT",
-          state: "PENDING",
-          side: "SELL",
-          qty: exitQty,
-          metaJson: { hedgeId: hedge.id, legSide: "SPOT_SELL", category: "spot" },
-        },
-      }),
-      prisma.botIntent.create({
-        data: {
-          botRunId: hedge.botRunId,
-          intentId: perpExitIntentId,
-          orderLinkId: randomUUID(),
-          type: "EXIT",
-          state: "PENDING",
-          side: "BUY",
-          qty: exitQty,
-          metaJson: { hedgeId: hedge.id, legSide: "PERP_CLOSE", category: "linear" },
-        },
-      }),
-      prisma.hedgePosition.update({
-        where: { id: hedge.id },
-        data: { status: "CLOSING" },
-      }),
-    ]);
-
-    return reply.send({
+    const exec = await executeHedgeExit({
+      ...creds,
+      symbol: hedge.symbol,
+      qty: exitQty.toString(),
       hedgeId: hedge.id,
-      status: "CLOSING",
-      intents: { spot: spotIntent, perp: perpIntent },
     });
+
+    return persistAndRespond(reply, hedge.id, exec, "EXIT");
   });
 
   // ── GET /hedges?botRunId=... ── list positions for a run ────────────────

--- a/apps/api/tests/routes/hedges.test.ts
+++ b/apps/api/tests/routes/hedges.test.ts
@@ -5,7 +5,12 @@ import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from "vites
 const mockHedgePositions: Record<string, unknown> = {};
 const mockBotRuns: Record<string, unknown> = {};
 const mockBotIntents: unknown[] = [];
+const mockLegExecutions: unknown[] = [];
 const mockWorkspaceMemberships: unknown[] = [];
+
+// Bybit mocks — terminal.test.ts pattern. Reset between tests.
+const mockBybitPlaceOrder = vi.fn();
+const mockBybitGetOrderStatus = vi.fn();
 
 vi.mock("@prisma/client", () => ({
   PrismaClient: vi.fn().mockImplementation(() => ({})),
@@ -48,14 +53,30 @@ vi.mock("../../src/lib/prisma.js", () => ({
       }),
     },
     botRun: {
-      findUnique: vi.fn().mockImplementation(({ where }: { where: { id: string } }) => {
-        return Promise.resolve(mockBotRuns[where.id] ?? null);
+      findUnique: vi.fn().mockImplementation(({ where, select }: { where: { id: string }; select?: Record<string, unknown> }) => {
+        const row = mockBotRuns[where.id];
+        if (!row) return Promise.resolve(null);
+        // The /execute and /exit handlers project bot.exchangeConnection via
+        // a `select` clause; the legacy /entry and ownership-check paths do
+        // not. The mock returns the full row regardless — Prisma's runtime
+        // semantics where unselected fields are dropped don't matter here
+        // because the consumer reads only what it asked for, and excess
+        // fields are harmless.
+        void select;
+        return Promise.resolve(row);
       }),
     },
     botIntent: {
       create: vi.fn().mockImplementation(({ data }: { data: Record<string, unknown> }) => {
         const record = { id: `intent-${Date.now()}-${Math.random()}`, ...data, createdAt: new Date(), updatedAt: new Date() };
         mockBotIntents.push(record);
+        return Promise.resolve(record);
+      }),
+    },
+    legExecution: {
+      create: vi.fn().mockImplementation(({ data }: { data: Record<string, unknown> }) => {
+        const record = { id: `leg-${Date.now()}-${Math.random()}`, ...data, timestamp: new Date() };
+        mockLegExecutions.push(record);
         return Promise.resolve(record);
       }),
     },
@@ -80,6 +101,21 @@ vi.mock("../../src/lib/prisma.js", () => ({
     $connect: vi.fn(),
     $disconnect: vi.fn(),
   },
+}));
+
+vi.mock("../../src/lib/crypto.js", () => ({
+  decryptWithFallback: vi.fn().mockReturnValue("plaintext-secret"),
+}));
+
+vi.mock("../../src/lib/bybitOrder.js", () => ({
+  bybitPlaceOrder: (...args: unknown[]) => mockBybitPlaceOrder(...args),
+  bybitGetOrderStatus: (...args: unknown[]) => mockBybitGetOrderStatus(...args),
+  sanitizeBybitError: (err: unknown) => (err instanceof Error ? err.message : String(err)),
+  // Unused by hedge routes, but other importers of this module may pull them
+  // via the same mock factory if Vitest hoists shared modules. Provide stubs.
+  mapBybitStatus: vi.fn(),
+  getBybitBaseUrl: () => "https://api-demo.bybit.com",
+  isBybitLive: () => false,
 }));
 
 import { buildApp } from "../../src/app.js";
@@ -107,9 +143,17 @@ beforeEach(() => {
   Object.keys(mockHedgePositions).forEach((k) => delete mockHedgePositions[k]);
   Object.keys(mockBotRuns).forEach((k) => delete mockBotRuns[k]);
   mockBotIntents.length = 0;
+  mockLegExecutions.length = 0;
   mockWorkspaceMemberships.length = 0;
+  mockBybitPlaceOrder.mockReset();
+  mockBybitGetOrderStatus.mockReset();
+  // Disable real timers in the leg poll loop — tests rely on the mock
+  // returning Filled on the first call, but defence-in-depth.
+  process.env.HEDGE_LEG_POLL_DELAY_MS = "0";
 
-  // Set up default workspace membership + run
+  // Set up default workspace membership + run with linked exchange creds
+  // (the /execute and /exit routes need bot.exchangeConnection populated;
+  // tests for /entry / GET endpoints simply ignore the extra fields).
   mockWorkspaceMemberships.push({
     userId: "test-user-id",
     workspaceId: TEST_WORKSPACE_ID,
@@ -119,6 +163,14 @@ beforeEach(() => {
     id: TEST_RUN_ID,
     workspaceId: TEST_WORKSPACE_ID,
     status: "RUNNING",
+    bot: {
+      exchangeConnection: {
+        apiKey: "linear-key",
+        encryptedSecret: "iv:tag:cipher",
+        spotApiKey: "spot-key",
+        spotEncryptedSecret: "iv:tag:cipher2",
+      },
+    },
   };
 });
 
@@ -200,6 +252,40 @@ describe("POST /api/v1/hedges/entry", () => {
 
 // ── POST /hedges/:id/execute ─────────────────────────────────────────────────
 
+function seedPlannedHedge(id: string, runId = TEST_RUN_ID, symbol = "BTCUSDT") {
+  mockHedgePositions[id] = {
+    id,
+    botRunId: runId,
+    symbol,
+    status: "PLANNED",
+    entryBasisBps: 5,
+    fundingCollected: 0,
+    createdAt: new Date(),
+    closedAt: null,
+    legs: [],
+  };
+}
+
+function placedOk(orderId: string) {
+  return Promise.resolve({ orderId, orderLinkId: `link-${orderId}` });
+}
+
+function statusFilled(orderId: string, qty: string, price: string) {
+  return Promise.resolve({
+    orderId,
+    symbol: "BTCUSDT",
+    side: "Buy",
+    orderType: "Market",
+    qty,
+    price: "0",
+    avgPrice: price,
+    cumExecQty: qty,
+    orderStatus: "Filled",
+    createdTime: "0",
+    updatedTime: "0",
+  });
+}
+
 describe("POST /api/v1/hedges/:id/execute", () => {
   it("returns 404 for nonexistent hedge", async () => {
     const res = await app.inject({
@@ -212,9 +298,8 @@ describe("POST /api/v1/hedges/:id/execute", () => {
   });
 
   it("returns 409 if hedge is not PLANNED", async () => {
-    const hedgeId = "hedge-already-open";
-    mockHedgePositions[hedgeId] = {
-      id: hedgeId,
+    mockHedgePositions["hedge-already-open"] = {
+      id: "hedge-already-open",
       botRunId: TEST_RUN_ID,
       symbol: "BTCUSDT",
       status: "OPEN",
@@ -227,95 +312,258 @@ describe("POST /api/v1/hedges/:id/execute", () => {
 
     const res = await app.inject({
       method: "POST",
-      url: `/api/v1/hedges/${hedgeId}/execute`,
+      url: `/api/v1/hedges/hedge-already-open/execute`,
       headers: authHeaders(),
       payload: { quantity: 0.01 },
     });
     expect(res.statusCode).toBe(409);
   });
 
-  it("creates intents and transitions to OPENING", async () => {
-    const hedgeId = "hedge-planned";
-    mockHedgePositions[hedgeId] = {
-      id: hedgeId,
-      botRunId: TEST_RUN_ID,
-      symbol: "BTCUSDT",
-      status: "PLANNED",
-      entryBasisBps: 5,
-      fundingCollected: 0,
-      createdAt: new Date(),
-      closedAt: null,
-      legs: [],
-    };
+  it("returns 400 when quantity is missing or non-positive", async () => {
+    seedPlannedHedge("h-bad-qty");
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/hedges/h-bad-qty/execute`,
+      headers: authHeaders(),
+      payload: {},
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("places spot Buy + perp Sell sequentially → status OPEN with 2 LegExecutions", async () => {
+    seedPlannedHedge("h-ok");
+    // Spot first, then perp — sequencing assertion below pins this.
+    mockBybitPlaceOrder
+      .mockImplementationOnce(() => placedOk("spot-1"))
+      .mockImplementationOnce(() => placedOk("perp-1"));
+    mockBybitGetOrderStatus
+      .mockImplementationOnce(() => statusFilled("spot-1", "0.01", "67000"))
+      .mockImplementationOnce(() => statusFilled("perp-1", "0.01", "67005"));
 
     const res = await app.inject({
       method: "POST",
-      url: `/api/v1/hedges/${hedgeId}/execute`,
+      url: `/api/v1/hedges/h-ok/execute`,
       headers: authHeaders(),
       payload: { quantity: 0.01 },
     });
+
     expect(res.statusCode).toBe(200);
     const body = res.json();
-    expect(body.status).toBe("OPENING");
-    expect(body.intents.spot).toBeDefined();
-    expect(body.intents.perp).toBeDefined();
+    expect(body.status).toBe("OPEN");
+    expect(body.outcome).toBe("FILLED");
+    expect(body.legs).toHaveLength(2);
+
+    // Spot leg recorded with the spot category fill, perp leg with the perp fill.
+    const spotLeg = body.legs.find((l: { side: string }) => l.side === "SPOT_BUY");
+    const perpLeg = body.legs.find((l: { side: string }) => l.side === "PERP_SHORT");
+    expect(spotLeg).toMatchObject({ price: 67000, quantity: 0.01, orderId: "spot-1" });
+    expect(perpLeg).toMatchObject({ price: 67005, quantity: 0.01, orderId: "perp-1" });
+
+    // Sequencing: first call MUST be category=spot (spot leads).
+    expect(mockBybitPlaceOrder).toHaveBeenCalledTimes(2);
+    const firstCallArgs = mockBybitPlaceOrder.mock.calls[0];
+    expect((firstCallArgs?.[2] as { category: string }).category).toBe("spot");
+    expect((firstCallArgs?.[2] as { side: string }).side).toBe("Buy");
+    const secondCallArgs = mockBybitPlaceOrder.mock.calls[1];
+    expect((secondCallArgs?.[2] as { category: string }).category).toBe("linear");
+    expect((secondCallArgs?.[2] as { side: string }).side).toBe("Sell");
+
+    // Persisted state: status OPEN, 2 LegExecution rows.
+    expect((mockHedgePositions["h-ok"] as { status: string }).status).toBe("OPEN");
+    expect(mockLegExecutions.filter(
+      (l) => (l as { hedgeId: string }).hedgeId === "h-ok",
+    )).toHaveLength(2);
+  });
+
+  it("spot leg failure → no perp call, status FAILED, no LegExecution rows", async () => {
+    seedPlannedHedge("h-spot-fail");
+    mockBybitPlaceOrder.mockRejectedValueOnce(new Error("spot rejected"));
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/hedges/h-spot-fail/execute`,
+      headers: authHeaders(),
+      payload: { quantity: 0.01 },
+    });
+
+    expect(res.statusCode).toBe(422);
+    const body = res.json();
+    expect(body.status).toBe("FAILED");
+    expect(body.outcome).toBe("FAILED");
+    expect(body.legs).toEqual([]);
+    expect(body.reason).toMatch(/spot leg failed/);
+
+    // Perp leg was never attempted.
+    expect(mockBybitPlaceOrder).toHaveBeenCalledTimes(1);
+    expect((mockHedgePositions["h-spot-fail"] as { status: string }).status).toBe("FAILED");
+    expect(mockLegExecutions.filter(
+      (l) => (l as { hedgeId: string }).hedgeId === "h-spot-fail",
+    )).toHaveLength(0);
+  });
+
+  it("spot ok + perp fail → compensating spot Sell attempted, status FAILED", async () => {
+    seedPlannedHedge("h-perp-fail");
+    // Call 1: spot Buy (placed)        ; status poll Filled.
+    // Call 2: perp Sell (rejected)     ; no status poll.
+    // Call 3: compensating spot Sell   ; status poll Filled (succeeds).
+    mockBybitPlaceOrder
+      .mockImplementationOnce(() => placedOk("spot-buy-1"))
+      .mockImplementationOnce(() => Promise.reject(new Error("perp rejected")))
+      .mockImplementationOnce(() => placedOk("spot-sell-comp"));
+    mockBybitGetOrderStatus
+      .mockImplementationOnce(() => statusFilled("spot-buy-1", "0.01", "67000"))
+      .mockImplementationOnce(() => statusFilled("spot-sell-comp", "0.01", "66990"));
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/hedges/h-perp-fail/execute`,
+      headers: authHeaders(),
+      payload: { quantity: 0.01 },
+    });
+
+    expect(res.statusCode).toBe(422);
+    const body = res.json();
+    expect(body.status).toBe("FAILED");
+    expect(body.outcome).toBe("PARTIAL_ERROR");
+    expect(body.compensatingUnwind).toEqual({ attempted: true, succeeded: true });
+    expect(body.reason).toMatch(/perp leg failed/);
+
+    // The route reports only the original spot fill on the partial-error
+    // path — the compensating sell is best-effort and not recorded in the
+    // LegExecution audit (status=FAILED is the operator alert).
+    expect(body.legs).toHaveLength(1);
+    expect(body.legs[0].side).toBe("SPOT_BUY");
+
+    expect(mockBybitPlaceOrder).toHaveBeenCalledTimes(3);
+    const thirdCallArgs = mockBybitPlaceOrder.mock.calls[2];
+    expect((thirdCallArgs?.[2] as { category: string; side: string }).category).toBe("spot");
+    expect((thirdCallArgs?.[2] as { category: string; side: string }).side).toBe("Sell");
+  });
+
+  it("idempotency — repeated execute on already-OPEN hedge returns 409", async () => {
+    seedPlannedHedge("h-idem");
+    mockBybitPlaceOrder
+      .mockImplementationOnce(() => placedOk("s-1"))
+      .mockImplementationOnce(() => placedOk("p-1"));
+    mockBybitGetOrderStatus
+      .mockImplementationOnce(() => statusFilled("s-1", "0.01", "67000"))
+      .mockImplementationOnce(() => statusFilled("p-1", "0.01", "67005"));
+
+    const first = await app.inject({
+      method: "POST",
+      url: `/api/v1/hedges/h-idem/execute`,
+      headers: authHeaders(),
+      payload: { quantity: 0.01 },
+    });
+    expect(first.statusCode).toBe(200);
+
+    // Second attempt on the now-OPEN hedge.
+    const second = await app.inject({
+      method: "POST",
+      url: `/api/v1/hedges/h-idem/execute`,
+      headers: authHeaders(),
+      payload: { quantity: 0.01 },
+    });
+    expect(second.statusCode).toBe(409);
+    // No additional Bybit calls — guard kicks in before executor is invoked.
+    expect(mockBybitPlaceOrder).toHaveBeenCalledTimes(2);
   });
 });
 
 // ── POST /hedges/:id/exit ────────────────────────────────────────────────────
 
+function seedOpenHedge(id: string, qty = 0.015) {
+  mockHedgePositions[id] = {
+    id,
+    botRunId: TEST_RUN_ID,
+    symbol: "BTCUSDT",
+    status: "OPEN",
+    entryBasisBps: 5,
+    fundingCollected: 10,
+    createdAt: new Date(),
+    closedAt: null,
+    legs: [
+      { side: "SPOT_BUY", price: 67000, quantity: qty, fee: 0.5, timestamp: new Date() },
+      { side: "PERP_SHORT", price: 67005, quantity: qty, fee: 0.5, timestamp: new Date() },
+    ],
+  };
+}
+
 describe("POST /api/v1/hedges/:id/exit", () => {
   it("returns 409 if hedge is not OPEN", async () => {
-    const hedgeId = "hedge-planned-exit";
-    mockHedgePositions[hedgeId] = {
-      id: hedgeId,
-      botRunId: TEST_RUN_ID,
-      symbol: "BTCUSDT",
-      status: "PLANNED",
-      entryBasisBps: 5,
-      fundingCollected: 0,
-      createdAt: new Date(),
-      closedAt: null,
-      legs: [],
-    };
-
+    seedPlannedHedge("hedge-planned-exit");
     const res = await app.inject({
       method: "POST",
-      url: `/api/v1/hedges/${hedgeId}/exit`,
+      url: `/api/v1/hedges/hedge-planned-exit/exit`,
       headers: authHeaders(),
       payload: {},
     });
     expect(res.statusCode).toBe(409);
   });
 
-  it("creates exit intents and transitions to CLOSING", async () => {
-    const hedgeId = "hedge-open-exit";
-    mockHedgePositions[hedgeId] = {
-      id: hedgeId,
-      botRunId: TEST_RUN_ID,
-      symbol: "BTCUSDT",
-      status: "OPEN",
-      entryBasisBps: 5,
-      fundingCollected: 10,
-      createdAt: new Date(),
-      closedAt: null,
-      legs: [
-        { side: "SPOT_BUY", price: 67000, quantity: 0.015, fee: 0.5, timestamp: new Date() },
-        { side: "PERP_SHORT", price: 67005, quantity: 0.015, fee: 0.5, timestamp: new Date() },
-      ],
-    };
+  it("places spot Sell + perp Buy sequentially → status CLOSED with 2 LegExecutions", async () => {
+    seedOpenHedge("h-exit-ok", 0.015);
+    mockBybitPlaceOrder
+      .mockImplementationOnce(() => placedOk("spot-sell-1"))
+      .mockImplementationOnce(() => placedOk("perp-buy-1"));
+    mockBybitGetOrderStatus
+      .mockImplementationOnce(() => statusFilled("spot-sell-1", "0.015", "67100"))
+      .mockImplementationOnce(() => statusFilled("perp-buy-1", "0.015", "67095"));
 
     const res = await app.inject({
       method: "POST",
-      url: `/api/v1/hedges/${hedgeId}/exit`,
+      url: `/api/v1/hedges/h-exit-ok/exit`,
       headers: authHeaders(),
       payload: {},
     });
+
     expect(res.statusCode).toBe(200);
     const body = res.json();
-    expect(body.status).toBe("CLOSING");
-    expect(body.intents.spot).toBeDefined();
-    expect(body.intents.perp).toBeDefined();
+    expect(body.status).toBe("CLOSED");
+    expect(body.outcome).toBe("FILLED");
+    expect(body.legs).toHaveLength(2);
+    expect(body.legs.find((l: { side: string }) => l.side === "SPOT_SELL"))
+      .toMatchObject({ price: 67100, quantity: 0.015, orderId: "spot-sell-1" });
+    expect(body.legs.find((l: { side: string }) => l.side === "PERP_CLOSE"))
+      .toMatchObject({ price: 67095, quantity: 0.015, orderId: "perp-buy-1" });
+
+    // Sequencing — spot Sell first.
+    const firstCall = mockBybitPlaceOrder.mock.calls[0]?.[2] as { category: string; side: string };
+    expect(firstCall.category).toBe("spot");
+    expect(firstCall.side).toBe("Sell");
+
+    expect((mockHedgePositions["h-exit-ok"] as { status: string }).status).toBe("CLOSED");
+    expect((mockHedgePositions["h-exit-ok"] as { closedAt: Date | null }).closedAt).toBeInstanceOf(Date);
+  });
+
+  it("perp close fail after spot sell → PARTIAL_ERROR (manual unwind, no auto-rebuy)", async () => {
+    seedOpenHedge("h-exit-perp-fail", 0.015);
+    mockBybitPlaceOrder
+      .mockImplementationOnce(() => placedOk("spot-sell-2"))
+      .mockImplementationOnce(() => Promise.reject(new Error("perp close rejected")));
+    mockBybitGetOrderStatus.mockImplementationOnce(() =>
+      statusFilled("spot-sell-2", "0.015", "67100"),
+    );
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/hedges/h-exit-perp-fail/exit`,
+      headers: authHeaders(),
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(422);
+    const body = res.json();
+    expect(body.status).toBe("FAILED");
+    expect(body.outcome).toBe("PARTIAL_ERROR");
+    expect(body.legs).toHaveLength(1);
+    expect(body.legs[0].side).toBe("SPOT_SELL");
+    expect(body.reason).toMatch(/perp close leg failed/);
+    // No compensatingUnwind block on exit path — re-buying spot would
+    // contradict the operator's intent to exit.
+    expect(body.compensatingUnwind).toBeUndefined();
+    // Exactly 2 place calls: spot sell + failed perp close. No auto-rebuy.
+    expect(mockBybitPlaceOrder).toHaveBeenCalledTimes(2);
   });
 });
 


### PR DESCRIPTION
## Summary

Convert `/hedges/:id/execute` and `/hedges/:id/exit` from BotIntent emission (legacy, linear-only via processIntents) to **direct synchronous Bybit calls with spot category dispatch**. This closes the production-blocker that prevented funding-arb's spot leg from ever being placed end-to-end.

The async `hedgeBotWorker` BotIntent path is **unchanged** — wiring spot category through `processIntents` is a separate, narrower change tracked for a follow-up PR.

## Architecture

**New `apps/api/src/lib/exchange/hedgeExecutor.ts`** (296 lines):
- `placeMarketLeg(creds, input)` — `bybitPlaceOrder` (Market + IOC) followed by `bybitGetOrderStatus` poll (configurable via `HEDGE_LEG_POLL_ATTEMPTS` / `HEDGE_LEG_POLL_DELAY_MS` env vars). Filled with non-positive cumExecQty/avgPrice is treated as a leg failure — Bybit occasionally reports zero-fill Filled responses on rate-limited paths and phantom LegExecution rows must not result.
- `executeHedgeEntry({spotCreds, perpCreds, symbol, qty, hedgeId})` — sequential: **spot Buy first**, then perp Sell. If spot fails the perp side is never opened. If spot ok + perp fail, a compensating market spot Sell is attempted (best-effort, swallowed errors → manual unwind alert in logs).
- `executeHedgeExit(...)` — symmetric: spot Sell first, then perp Buy-to-close. **No compensating reverse** — re-buying spot would contradict operator intent; `PARTIAL_ERROR` signals manual unwind required.

**`apps/api/src/routes/hedges.ts` rewrites for `/execute` & `/exit`:**
- Load `Bot.exchangeConnection` via `BotRun` projection. Build per-leg creds with the docs/55-T5 §4 single-key fallback (`spotApiKey ?? apiKey`). Decrypt via `decryptWithFallback`.
- On `FILLED` → `HedgePosition.status = OPEN` (entry) / `CLOSED` + `closedAt` (exit), 2 `LegExecution` rows in single tx.
- On `FAILED` / `PARTIAL_ERROR` → `status = FAILED` with structured response body (`reason`, `compensatingUnwind` block on entry only).
- Idempotency: existing `409` guard on `status !== PLANNED` (entry) / `status !== OPEN` (exit) covers retry after success and retry after failure.
- BotIntent creation dropped on these paths — `LegExecution` rows are the audit trail.

## Scope boundary

- `bybitOrder.ts`: imported, not modified.
- `botWorker.processIntents` / `intentExecutor.ts`: untouched.
- The autonomous `hedgeBotWorker` tick path (BotIntent-mediated) is unchanged — the `processIntents` spot dispatch will land in a follow-up PR.

## Tests

`tests/routes/hedges.test.ts`:
- Rewrote the 2 legacy `OPENING`/`CLOSING`-status assertions to `OPEN`/`CLOSED`.
- Added 5 new scenarios:
  - **Spot leg failure** → no perp call, status `FAILED`, no LegExecutions.
  - **Spot ok + perp fail** → compensating spot Sell attempted, status `FAILED` with `compensatingUnwind: { attempted: true, succeeded: true }`.
  - **Exit happy path** → spot Sell + perp Buy sequencing pinned via mock call order, status `CLOSED` with `closedAt` populated.
  - **Exit perp close fail** → `PARTIAL_ERROR`, no auto-rebuy (`compensatingUnwind` absent on exit path).
  - **Idempotency** — repeated execute on already-`OPEN` hedge returns `409` with no additional Bybit calls.
- New mocks for `bybitOrder.ts` and `crypto.ts` following the `terminal.test.ts` pattern. `HEDGE_LEG_POLL_DELAY_MS=0` in `beforeEach` as defence-in-depth (mocks return `Filled` on first poll anyway).

## Test plan

- [x] `pnpm --filter @botmarketplace/api exec tsc --noEmit` — clean
- [x] `pnpm --filter @botmarketplace/api exec vitest run tests/routes/hedges.test.ts` — 22/22
- [x] `pnpm --filter @botmarketplace/api test` — **2149/2149** (was 2144 baseline; +5 new)

https://claude.ai/code/session_01XoMMe56sv7QDkoovGn9Lww

---
_Generated by [Claude Code](https://claude.ai/code/session_01XoMMe56sv7QDkoovGn9Lww)_