### PR TITLE
feat(funding-arb): thread metaJson.category through processIntents → bybitPlaceOrder (T2 follow-up)

### DIFF
--- a/apps/api/src/lib/botWorker.ts
+++ b/apps/api/src/lib/botWorker.ts
@@ -571,7 +571,12 @@ async function executeIntent(intent: {
       id: string;
       symbol: string;
       exchangeConnectionId: string | null;
-      exchangeConnection: { apiKey: string; encryptedSecret: string } | null;
+      exchangeConnection: {
+        apiKey: string;
+        encryptedSecret: string;
+        spotApiKey: string | null;
+        spotEncryptedSecret: string | null;
+      } | null;
       strategyVersion: { dslJson: Prisma.JsonValue } | null;
     };
   };

--- a/apps/api/src/lib/worker/intentExecutor.ts
+++ b/apps/api/src/lib/worker/intentExecutor.ts
@@ -44,10 +44,33 @@ export interface IntentRecord {
       id: string;
       symbol: string;
       exchangeConnectionId: string | null;
-      exchangeConnection: { apiKey: string; encryptedSecret: string } | null;
+      /** Spot fields are nullable (docs/55-T5). When `metaJson.category === "spot"`
+       *  on an intent, the executor uses the spot key/secret pair if present,
+       *  falling back to the linear pair when not — single-key Bybit accounts
+       *  with both scopes work without configuring a dedicated spot key. */
+      exchangeConnection: {
+        apiKey: string;
+        encryptedSecret: string;
+        spotApiKey: string | null;
+        spotEncryptedSecret: string | null;
+      } | null;
       strategyVersion: { dslJson: Prisma.JsonValue } | null;
     };
   };
+}
+
+/** Read `metaJson.category` and coerce to a Bybit category. Defaults to
+ *  "linear" so legacy DSL intents (no category in metaJson) keep their
+ *  pre-#364 behaviour. funding-arb hedge intents emitted by
+ *  `hedgeBotWorker.emitHedgeIntents` carry `category: "spot" | "linear"`
+ *  per leg and rely on this dispatch to reach the correct Bybit instrument
+ *  scope. */
+function readIntentCategory(metaJson: Prisma.JsonValue): "linear" | "spot" {
+  if (metaJson && typeof metaJson === "object" && !Array.isArray(metaJson)) {
+    const v = (metaJson as Record<string, unknown>)["category"];
+    if (v === "spot") return "spot";
+  }
+  return "linear";
 }
 
 // ---------------------------------------------------------------------------
@@ -96,7 +119,20 @@ export async function executeIntent(intent: IntentRecord, parentLog: Logger): Pr
       intentLog.info("intent simulated (demo mode)");
     } else {
       // ── Live mode: place order on Bybit ──────────────────────────────────
-      const plainSecret = decryptWithFallback(bot.exchangeConnection.encryptedSecret);
+      const category = readIntentCategory(intent.metaJson);
+
+      // Per-category credential selection (docs/55-T5 §4 single-key fallback):
+      // spot intents prefer the dedicated spot key/secret pair; when either
+      // half is missing the linear pair is reused. Linear intents always use
+      // the linear pair — unchanged behaviour.
+      const conn = bot.exchangeConnection;
+      const apiKey =
+        category === "spot" && conn.spotApiKey ? conn.spotApiKey : conn.apiKey;
+      const secretCipher =
+        category === "spot" && conn.spotEncryptedSecret
+          ? conn.spotEncryptedSecret
+          : conn.encryptedSecret;
+      const plainSecret = decryptWithFallback(secretCipher);
 
       const dsl = bot.strategyVersion?.dslJson as { execution?: { orderType?: string } } | null;
       const orderType =
@@ -107,50 +143,63 @@ export async function executeIntent(intent: IntentRecord, parentLog: Logger): Pr
       let qtyStr = intent.qty.toString();
       let priceStr = intent.price && orderType === "Limit" ? intent.price.toString() : undefined;
 
-      try {
-        const instrument = await getInstrument(bot.symbol);
-        const normalized = normalizeOrder(
-          {
-            symbol: bot.symbol,
-            side,
-            orderType,
-            qty: Number(intent.qty.toString()),
-            price: intent.price ? Number(intent.price.toString()) : undefined,
-          },
-          instrument,
-        );
+      // Order-rule normalization is linear-only — the cached instrument
+      // metadata comes from Bybit's `category=linear` instruments-info
+      // endpoint and the lot/tick rules differ from spot (different decimal
+      // precision, different minOrderQty, base-vs-quote sizing on Market).
+      // For spot intents we trust the upstream sizing (REST /hedges path
+      // computes qty from instrument-info via getSpotInstrumentInfo when
+      // 55-T1 lands; hedgeBotWorker.emitHedgeIntents currently passes the
+      // operator-provided qty as-is). Skip the linear normalizer to avoid
+      // a wrong-rules rejection.
+      if (category === "linear") {
+        try {
+          const instrument = await getInstrument(bot.symbol);
+          const normalized = normalizeOrder(
+            {
+              symbol: bot.symbol,
+              side,
+              orderType,
+              qty: Number(intent.qty.toString()),
+              price: intent.price ? Number(intent.price.toString()) : undefined,
+            },
+            instrument,
+          );
 
-        if (!normalized.valid) {
-          throw new Error(`Order normalization failed: ${normalized.reason}`);
+          if (!normalized.valid) {
+            throw new Error(`Order normalization failed: ${normalized.reason}`);
+          }
+
+          qtyStr = normalized.order.qty;
+          priceStr = normalized.order.price;
+
+          intentLog.info(
+            {
+              diagnostics: normalized.order.diagnostics,
+              env: isBybitLive() ? "live" : "demo",
+              baseUrl: getBybitBaseUrl(),
+            },
+            "order normalized",
+          );
+        } catch (normErr) {
+          intentLog.warn({ err: normErr }, "order normalization error");
+          throw normErr;
         }
-
-        qtyStr = normalized.order.qty;
-        priceStr = normalized.order.price;
-
+      } else {
         intentLog.info(
-          {
-            diagnostics: normalized.order.diagnostics,
-            env: isBybitLive() ? "live" : "demo",
-            baseUrl: getBybitBaseUrl(),
-          },
-          "order normalized",
+          { category, env: isBybitLive() ? "live" : "demo", baseUrl: getBybitBaseUrl() },
+          "spot intent — linear normalizer skipped",
         );
-      } catch (normErr) {
-        intentLog.warn({ err: normErr }, "order normalization error");
-        throw normErr;
       }
 
-      const result = await bybitPlaceOrder(
-        bot.exchangeConnection.apiKey,
-        plainSecret,
-        {
-          symbol: bot.symbol,
-          side,
-          orderType,
-          qty: qtyStr,
-          ...(priceStr ? { price: priceStr } : {}),
-        },
-      );
+      const result = await bybitPlaceOrder(apiKey, plainSecret, {
+        category,
+        symbol: bot.symbol,
+        side,
+        orderType,
+        qty: qtyStr,
+        ...(priceStr ? { price: priceStr } : {}),
+      });
 
       const meta = {
         ...(intent.metaJson && typeof intent.metaJson === "object" ? intent.metaJson as Record<string, unknown> : {}),

--- a/apps/api/src/lib/worker/tickProcessor.ts
+++ b/apps/api/src/lib/worker/tickProcessor.ts
@@ -177,7 +177,16 @@ export async function processIntents(workerLog: Logger): Promise<void> {
                 symbol: true,
                 exchangeConnectionId: true,
                 exchangeConnection: {
-                  select: { apiKey: true, encryptedSecret: true },
+                  select: {
+                    apiKey: true,
+                    encryptedSecret: true,
+                    // docs/55-T5: optional spot scope keys consumed by
+                    // executeIntent for spot-category intents (funding-arb).
+                    // Null when the operator hasn't configured a dedicated
+                    // spot key — executor falls back to the linear pair.
+                    spotApiKey: true,
+                    spotEncryptedSecret: true,
+                  },
                 },
                 strategyVersion: {
                   select: { dslJson: true },

--- a/apps/api/tests/lib/worker/intentExecutor.test.ts
+++ b/apps/api/tests/lib/worker/intentExecutor.test.ts
@@ -247,6 +247,125 @@ describe("executeIntent", () => {
     );
   });
 
+  // -------------------------------------------------------------------------
+  // Spot category dispatch (docs/55-T2 follow-up)
+  //
+  // funding-arb hedge intents emitted by hedgeBotWorker carry
+  // `metaJson.category = "spot" | "linear"`. The executor must:
+  //   * route the spot intents to Bybit's spot scope (category=spot in the
+  //     order payload),
+  //   * use spot creds when present (single-key fallback when not),
+  //   * skip the linear-only normalizer (its lot/tick rules don't apply).
+  // Linear intents (default / no category) keep their existing path.
+  // -------------------------------------------------------------------------
+
+  it("spot intent routes to Bybit category=spot, skips linear normalizer", async () => {
+    mockDecrypt.mockReturnValue("plain-secret");
+    mockBybitPlaceOrder.mockResolvedValue({
+      orderId: "bybit-spot-1",
+      orderLinkId: "lnk-1",
+    });
+
+    const intent = makeIntent({
+      metaJson: { hedgeId: "h-1", legSide: "SPOT_BUY", category: "spot" },
+      botRun: {
+        id: "run-1",
+        bot: {
+          id: "bot-1",
+          symbol: "BTCUSDT",
+          exchangeConnectionId: "ec-1",
+          exchangeConnection: {
+            apiKey: "linear-key",
+            encryptedSecret: "linear-enc",
+            spotApiKey: "spot-key",
+            spotEncryptedSecret: "spot-enc",
+          },
+          strategyVersion: { dslJson: { enabled: true } },
+        },
+      },
+    });
+
+    await executeIntent(intent as never, mockLog);
+
+    expect(mockGetInstrument).not.toHaveBeenCalled();
+    expect(mockNormalizeOrder).not.toHaveBeenCalled();
+    expect(mockBybitPlaceOrder).toHaveBeenCalledOnce();
+
+    // Args: (apiKey, secret, params)
+    const callArgs = mockBybitPlaceOrder.mock.calls[0];
+    expect(callArgs?.[0]).toBe("spot-key");
+    // decryptWithFallback was called against the spot cipher.
+    expect(mockDecrypt).toHaveBeenCalledWith("spot-enc", expect.anything());
+    expect(callArgs?.[2]).toMatchObject({ category: "spot", side: "Buy", symbol: "BTCUSDT" });
+  });
+
+  it("spot intent with no spot key falls back to linear creds (single-key Bybit)", async () => {
+    mockDecrypt.mockReturnValue("plain-secret");
+    mockBybitPlaceOrder.mockResolvedValue({ orderId: "bybit-spot-2", orderLinkId: "lnk-2" });
+
+    const intent = makeIntent({
+      metaJson: { hedgeId: "h-2", legSide: "SPOT_BUY", category: "spot" },
+      botRun: {
+        id: "run-1",
+        bot: {
+          id: "bot-1",
+          symbol: "BTCUSDT",
+          exchangeConnectionId: "ec-1",
+          exchangeConnection: {
+            apiKey: "linear-key",
+            encryptedSecret: "linear-enc",
+            spotApiKey: null,
+            spotEncryptedSecret: null,
+          },
+          strategyVersion: { dslJson: { enabled: true } },
+        },
+      },
+    });
+
+    await executeIntent(intent as never, mockLog);
+
+    const callArgs = mockBybitPlaceOrder.mock.calls[0];
+    expect(callArgs?.[0]).toBe("linear-key");
+    expect(mockDecrypt).toHaveBeenCalledWith("linear-enc", expect.anything());
+    expect(callArgs?.[2]).toMatchObject({ category: "spot" });
+  });
+
+  it("linear intent (default — no category in metaJson) keeps the normalizer + linear creds", async () => {
+    mockDecrypt.mockReturnValue("plain-secret");
+    mockGetInstrument.mockResolvedValue({ lotSizeFilter: {}, priceFilter: {} });
+    mockNormalizeOrder.mockReturnValue({
+      valid: true,
+      order: { qty: "0.01", price: undefined, diagnostics: {} },
+    });
+    mockBybitPlaceOrder.mockResolvedValue({ orderId: "bybit-lin-1", orderLinkId: "lnk-3" });
+
+    const intent = makeIntent({
+      metaJson: {},
+      botRun: {
+        id: "run-1",
+        bot: {
+          id: "bot-1",
+          symbol: "BTCUSDT",
+          exchangeConnectionId: "ec-1",
+          exchangeConnection: {
+            apiKey: "linear-key",
+            encryptedSecret: "linear-enc",
+            spotApiKey: "spot-key",
+            spotEncryptedSecret: "spot-enc",
+          },
+          strategyVersion: { dslJson: { enabled: true } },
+        },
+      },
+    });
+
+    await executeIntent(intent as never, mockLog);
+
+    expect(mockNormalizeOrder).toHaveBeenCalledOnce();
+    const callArgs = mockBybitPlaceOrder.mock.calls[0];
+    expect(callArgs?.[0]).toBe("linear-key");
+    expect(callArgs?.[2]).toMatchObject({ category: "linear" });
+  });
+
   it("dead-letters when max retries exceeded", async () => {
     mockGetEncryptionKeyRaw.mockReturnValue(Buffer.alloc(32));
     mockDecrypt.mockReturnValue("secret");


### PR DESCRIPTION
## Summary

Closes the autonomous-worker spot-dispatch gap that #363 explicitly left for a follow-up. funding-arb hedge intents emitted by `hedgeBotWorker` carry `metaJson.category = "spot" | "linear"` per leg; before this change, `executeIntent` always called `bybitPlaceOrder` without a `category` arg, so spot intents silently routed to `category=linear` (wrong instrument scope). After this change the autonomous-worker tick path matches the synchronous REST path landed in #363.

Three coordinated changes — kept in one PR so the dispatch is end-to-end on the worker side.

## Changes

**1. `apps/api/src/lib/worker/intentExecutor.ts`**
- New `readIntentCategory(metaJson)` helper — defaults to `"linear"` so legacy DSL intents (no `category` in `metaJson`) keep their pre-#364 behaviour.
- Live-mode branch now performs:
  - **Per-category credential selection** (docs/55-T5 §4 single-key fallback): spot intents prefer `spotApiKey/spotEncryptedSecret` when present, otherwise reuse the linear pair. Linear intents always use the linear pair.
  - **Linear normalizer gating**: `getInstrument` + `normalizeOrder` only run for `category === "linear"`. Bybit's lot/tick rules differ between scopes; running a spot intent through the linear normalizer would either reject the order or pin it to wrong precision. Spot intents trust upstream sizing.
  - **`bybitPlaceOrder` receives `category`** in the params, so the Bybit API gets the correct scope.
- `IntentRecord` extended with `spotApiKey: string | null` and `spotEncryptedSecret: string | null`.

**2. `apps/api/src/lib/worker/tickProcessor.ts`**
- `processIntents` Prisma query now selects `spotApiKey` + `spotEncryptedSecret` on `bot.exchangeConnection`. Two extra columns; same query plan.

**3. `apps/api/src/lib/botWorker.ts`**
- Thin `executeIntent` wrapper updates its parameter type to match the extended `IntentRecord` (the `_executeIntentLegacy` dead-code shape is intentionally untouched — slated for removal per the existing TODO).

## Tests (+3 cases in `intentExecutor.test.ts`)

- **Spot intent**: `bybitPlaceOrder` called with `category: "spot"` + `spotApiKey`; `decryptWithFallback` invoked against the spot cipher; `getInstrument` / `normalizeOrder` never called.
- **Spot intent without spot key**: falls back to linear creds; `category: "spot"` still routed.
- **Linear intent (default — empty `metaJson`)**: normalizer runs, linear creds used, `category: "linear"` in the place call.

## Test plan

- [x] `pnpm --filter @botmarketplace/api exec tsc --noEmit` — clean
- [x] `pnpm --filter @botmarketplace/api exec vitest run tests/lib/worker/intentExecutor.test.ts` — 9/9
- [x] `pnpm --filter @botmarketplace/api test` — **2152/2152** (was 2149 baseline; +3 new)

https://claude.ai/code/session_01XoMMe56sv7QDkoovGn9Lww

---
_Generated by [Claude Code](https://claude.ai/code/session_01XoMMe56sv7QDkoovGn9Lww)_