### PR TITLE
feat(funding-arb): real Bybit /v5/account/transaction-log query in windowDetector (55-T2 follow-up)

### DIFF
--- a/apps/api/src/lib/funding/windowDetector.ts
+++ b/apps/api/src/lib/funding/windowDetector.ts
@@ -1,57 +1,108 @@
 /**
  * Funding-window detector — derives the two upstream signals the
  * funding-arb runtime needs (`fundingWindowOpen`, `fundingPaymentReceived`)
- * from the most recent `FundingSnapshot.nextFundingAt` for a symbol.
+ * for a symbol at a given moment in time.
  *
- * This is the timestamp-based approximation. The "real" payment check
- * (Bybit `/v5/account/transaction-log` query) lands with docs/55-T2
- * once private API wiring is complete; until then the worker treats
- * the funding event timestamp itself as the proxy for "payment landed",
- * with a small lag buffer to absorb settlement latency.
+ * Two layers:
+ *
+ *   1. Timestamp proxy (no creds path).
+ *      Reads the most recent `FundingSnapshot.nextFundingAt` for the
+ *      symbol and approximates payment-received based on `nowMs - next`.
+ *      This is the path that runs when no Bybit credentials are
+ *      available (tests, demo workspaces, ExchangeConnection without
+ *      private API access). Behaviour is unchanged from the original
+ *      55-T4 implementation so that existing callers — including the
+ *      windowDetector unit suite — keep their assumptions intact.
+ *
+ *   2. Real ledger query (creds path, this PR).
+ *      When the caller supplies decrypted Bybit credentials, the
+ *      proxy `paymentReceived` signal is replaced by an authoritative
+ *      check against `/v5/account/transaction-log` filtered to
+ *      `category=linear`, `type=SETTLEMENT`, the funding event symbol,
+ *      and the time window (`nextFundingAt - 60s`, `nowMs`]. A
+ *      SETTLEMENT row in that window proves the funding payment landed;
+ *      no row means it has not, regardless of what the timestamp proxy
+ *      would have said. Transient ledger errors (HTTP non-OK, parse
+ *      failure, retCode != 0) fall back to the timestamp proxy with a
+ *      warning log — the worker must keep ticking even when Bybit's
+ *      private API is briefly unhappy.
  *
  * Bybit perpetual funding settles every 8 hours (00:00, 08:00, 16:00 UTC).
- * `FundingSnapshot.nextFundingAt` is populated by the ingestion cron
- * every 8 hours (`apps/api/src/lib/funding/ingestJob.ts`); the value is
- * read-only here — we never write to it.
- *
- * Window definitions:
- *   - Entry window: `nextFundingAt - now ∈ (0, ENTRY_PRE_BUFFER_MS]`.
- *     Opens 30 minutes before the funding event by default. Pre-buffer
- *     keeps the worker from racing the settlement tick.
- *   - Payment window: `now - nextFundingAt ∈ [PAYMENT_LAG_MS, PAYMENT_WINDOW_MS]`.
- *     Treats funding as "received" 1 minute after settlement and stays
- *     open for 30 minutes — long enough for a tick (60s cadence) to
- *     pick it up at least once but short enough that a stale snapshot
- *     does not falsely re-trigger an exit on a hedge that already
- *     closed.
+ * The ingestion cron (`apps/api/src/lib/funding/ingestJob.ts`) populates
+ * `FundingSnapshot.nextFundingAt`; this module is read-only on that table.
  */
 
+import { createHmac } from "node:crypto";
 import { prisma } from "../prisma.js";
+import { getBybitBaseUrl } from "../bybitOrder.js";
+import { logger } from "../logger.js";
+
+const log = logger.child({ module: "windowDetector" });
 
 export const ENTRY_PRE_BUFFER_MS = 30 * 60_000; // 30 min before funding
 export const PAYMENT_LAG_MS = 60_000;           // 1 min after funding
 export const PAYMENT_WINDOW_MS = 30 * 60_000;   // 30 min payment window
 
+const RECV_WINDOW = "5000";
+const USER_AGENT = "botmarketplace-funding/1";
+/** Pull a few rows in case multiple SETTLEMENT events land in the same
+ *  query window; we only need to know that ≥1 matches. Bybit's max here
+ *  is 50; 10 is a comfortable cushion without paying for what we don't read. */
+const LEDGER_PAGE_LIMIT = "10";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Decrypted Bybit credentials for the linear scope. Funding settles on
+ *  the perpetual side, so the linear pair is always the right one to sign
+ *  the ledger query — no spot-key fallback needed here. */
+export interface FundingLedgerCreds {
+  apiKey: string;
+  /** Plaintext secret. Caller is responsible for decryption. */
+  secret: string;
+}
+
+export interface DetectFundingWindowOptions {
+  /** When provided AND the symbol has a `FundingSnapshot`, the
+   *  `paymentReceived` signal is sourced from a real Bybit
+   *  `/v5/account/transaction-log` query. Without creds the timestamp
+   *  proxy is used (legacy behaviour). */
+  creds?: FundingLedgerCreds;
+}
+
 export interface FundingWindow {
   /** True when `now` is in the entry pre-buffer (before settlement). */
   open: boolean;
-  /** True when settlement has cleared and the payment window is still open. */
+  /** True when the funding payment has landed AND we are still inside
+   *  the (creds path: real-ledger) / (proxy path: 30-min) post-window. */
   paymentReceived: boolean;
   /** ms epoch of the next funding settlement, or null if no snapshot. */
   nextFundingAtMs: number | null;
+  /** Where `paymentReceived` came from. Useful for operator dashboards
+   *  + debugging "why did my hedge not exit yet". */
+  paymentSource: "ledger" | "ledger-empty" | "proxy";
 }
+
+// ---------------------------------------------------------------------------
+// Public entry-point
+// ---------------------------------------------------------------------------
 
 /**
  * Read the latest `FundingSnapshot.nextFundingAt` for `symbol` and
- * derive the entry / payment signals at `nowMs`.
+ * derive the entry / payment signals at `nowMs`. When `options.creds`
+ * is supplied, `paymentReceived` is sourced from the Bybit ledger
+ * (authoritative); otherwise the timestamp proxy is used.
  *
- * Returns `{ open: false, paymentReceived: false, nextFundingAtMs: null }`
- * when no snapshot exists for the symbol (the funding ingestion cron
- * has not seen it yet, or symbol is not on Bybit perpetuals).
+ * Returns `{ open: false, paymentReceived: false, nextFundingAtMs: null,
+ * paymentSource: "proxy" }` when no snapshot exists for the symbol —
+ * the caller has nothing to anchor the time window to, so consulting
+ * the ledger would be meaningless.
  */
 export async function detectFundingWindow(
   symbol: string,
   nowMs: number,
+  options: DetectFundingWindowOptions = {},
 ): Promise<FundingWindow> {
   const snap = await prisma.fundingSnapshot.findFirst({
     where: { symbol },
@@ -59,17 +110,133 @@ export async function detectFundingWindow(
     select: { nextFundingAt: true },
   });
   if (!snap) {
-    return { open: false, paymentReceived: false, nextFundingAtMs: null };
+    return {
+      open: false,
+      paymentReceived: false,
+      nextFundingAtMs: null,
+      paymentSource: "proxy",
+    };
   }
 
   const nextFundingAtMs = snap.nextFundingAt.getTime();
   const untilFunding = nextFundingAtMs - nowMs;
   const sinceFunding = nowMs - nextFundingAtMs;
 
-  return {
-    open: untilFunding > 0 && untilFunding <= ENTRY_PRE_BUFFER_MS,
-    paymentReceived:
-      sinceFunding >= PAYMENT_LAG_MS && sinceFunding <= PAYMENT_WINDOW_MS,
-    nextFundingAtMs,
+  const open = untilFunding > 0 && untilFunding <= ENTRY_PRE_BUFFER_MS;
+  const proxyPaymentReceived =
+    sinceFunding >= PAYMENT_LAG_MS && sinceFunding <= PAYMENT_WINDOW_MS;
+
+  // No-creds path → unchanged legacy behaviour.
+  if (!options.creds) {
+    return {
+      open,
+      paymentReceived: proxyPaymentReceived,
+      nextFundingAtMs,
+      paymentSource: "proxy",
+    };
+  }
+
+  // Pre-settlement: no payment can possibly exist on Bybit's books yet,
+  // so skip the network call entirely.
+  if (sinceFunding <= 0) {
+    return { open, paymentReceived: false, nextFundingAtMs, paymentSource: "proxy" };
+  }
+
+  // Creds path: query the ledger. On any error, fall back to the
+  // timestamp proxy + log — the worker must keep ticking.
+  try {
+    const settled = await queryFundingLedger({
+      creds: options.creds,
+      symbol,
+      startTimeMs: nextFundingAtMs - 60_000,
+      endTimeMs: nowMs,
+    });
+    return {
+      open,
+      paymentReceived: settled,
+      nextFundingAtMs,
+      paymentSource: settled ? "ledger" : "ledger-empty",
+    };
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err), symbol },
+      "Bybit ledger query failed — falling back to timestamp proxy",
+    );
+    return {
+      open,
+      paymentReceived: proxyPaymentReceived,
+      nextFundingAtMs,
+      paymentSource: "proxy",
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Bybit /v5/account/transaction-log query
+// ---------------------------------------------------------------------------
+
+interface FundingLedgerQuery {
+  creds: FundingLedgerCreds;
+  symbol: string;
+  startTimeMs: number;
+  endTimeMs: number;
+}
+
+interface BybitTransactionLogResponse {
+  retCode: number;
+  retMsg: string;
+  result?: {
+    list?: Array<{
+      symbol: string;
+      type: string;
+      transactionTime: string;
+    }>;
   };
+}
+
+/** Returns true iff the ledger has at least one `type=SETTLEMENT` row
+ *  for `symbol` in `(startTimeMs, endTimeMs]`. Throws on transport,
+ *  parse, or Bybit-API errors so the caller can fall back to the proxy. */
+async function queryFundingLedger(q: FundingLedgerQuery): Promise<boolean> {
+  const params = {
+    accountType: "UNIFIED",
+    category: "linear",
+    symbol: q.symbol,
+    type: "SETTLEMENT",
+    startTime: q.startTimeMs.toString(),
+    endTime: q.endTimeMs.toString(),
+    limit: LEDGER_PAGE_LIMIT,
+  };
+  const qs = new URLSearchParams(params).toString();
+  const timestamp = Date.now().toString();
+  const sign = createHmac("sha256", q.creds.secret)
+    .update(`${timestamp}${q.creds.apiKey}${RECV_WINDOW}${qs}`)
+    .digest("hex");
+
+  const url = `${getBybitBaseUrl()}/v5/account/transaction-log?${qs}`;
+  const res = await fetch(url, {
+    headers: {
+      "X-BAPI-API-KEY": q.creds.apiKey,
+      "X-BAPI-SIGN": sign,
+      "X-BAPI-TIMESTAMP": timestamp,
+      "X-BAPI-RECV-WINDOW": RECV_WINDOW,
+      "User-Agent": USER_AGENT,
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`Bybit ledger HTTP ${res.status} ${res.statusText}`);
+  }
+  let json: BybitTransactionLogResponse;
+  try {
+    json = (await res.json()) as BybitTransactionLogResponse;
+  } catch (err) {
+    throw new Error(
+      `Bybit ledger parse error: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (json.retCode !== 0) {
+    throw new Error(`Bybit ledger retCode=${json.retCode}: ${json.retMsg}`);
+  }
+  const list = json.result?.list ?? [];
+  return list.some((row) => row.symbol === q.symbol && row.type === "SETTLEMENT");
 }

--- a/apps/api/src/lib/hedgeBotWorker.ts
+++ b/apps/api/src/lib/hedgeBotWorker.ts
@@ -43,6 +43,7 @@
 import { randomUUID } from "node:crypto";
 import { prisma } from "./prisma.js";
 import { logger } from "./logger.js";
+import { decryptWithFallback } from "./crypto.js";
 import { classifyExecutionError } from "./errorClassifier.js";
 import {
   reconcileBalances,
@@ -523,8 +524,35 @@ export async function tickHedgeBotWorkerForBotRun(
 async function buildDefaultInput(
   hedge: { id: string; symbol: string; botRunId: string },
 ): Promise<HedgeAdvanceInput> {
-  const window = await detectFundingWindow(hedge.symbol, Date.now());
   const creds = await loadHedgeCreds(hedge.botRunId);
+
+  // When creds are present we feed them into windowDetector so the
+  // funding-payment signal comes from Bybit's transaction-log
+  // (authoritative). Without creds the timestamp proxy is the only
+  // option — same fallback the windowDetector itself does internally.
+  // The linear key/secret pair signs the ledger query because funding
+  // settles on the perp side; the spot fallback isn't relevant here.
+  //
+  // A decrypt failure (key rotated out, payload corrupt) must NOT take
+  // down the tick — fall back to the timestamp proxy with a warning,
+  // same posture the ledger path itself takes on transport / API errors.
+  let ledgerCreds: { apiKey: string; secret: string } | undefined;
+  if (creds) {
+    try {
+      ledgerCreds = {
+        apiKey: creds.apiKey,
+        secret: decryptWithFallback(creds.encryptedSecret),
+      };
+    } catch (err) {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err), hedgeId: hedge.id },
+        "decrypt linear secret failed — windowDetector will use timestamp proxy",
+      );
+    }
+  }
+  const window = await detectFundingWindow(hedge.symbol, Date.now(), {
+    creds: ledgerCreds,
+  });
 
   if (!creds) {
     log.warn(

--- a/apps/api/tests/lib/funding/windowDetector.test.ts
+++ b/apps/api/tests/lib/funding/windowDetector.test.ts
@@ -51,7 +51,14 @@ describe("detectFundingWindow — no snapshot", () => {
   it("returns all-false / null when fundingSnapshot.findFirst yields nothing", async () => {
     canned = null;
     const out = await detectFundingWindow("BTCUSDT", NEXT_FUNDING_MS - 60_000);
-    expect(out).toEqual({ open: false, paymentReceived: false, nextFundingAtMs: null });
+    expect(out).toMatchObject({
+      open: false,
+      paymentReceived: false,
+      nextFundingAtMs: null,
+    });
+    // Without a snapshot the source is "proxy" — there is nothing for the
+    // ledger path to anchor a query window to, so it never runs.
+    expect(out.paymentSource).toBe("proxy");
   });
 });
 
@@ -104,6 +111,186 @@ describe("detectFundingWindow — exact funding moment", () => {
   it("now == nextFundingAt → both false (atomic settlement)", async () => {
     const out = await detectFundingWindow("BTCUSDT", NEXT_FUNDING_MS);
     expect(out).toMatchObject({ open: false, paymentReceived: false });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Real-ledger path (creds passed) — overrides the timestamp proxy.
+// ---------------------------------------------------------------------------
+
+interface LedgerCall {
+  url: string;
+  apiKey: string;
+}
+
+const realFetch = globalThis.fetch;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function installLedgerFetch(opts: {
+  body?: unknown;
+  status?: number;
+  bodyFn?: (call: LedgerCall) => unknown;
+}): LedgerCall[] {
+  const calls: LedgerCall[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    const call = { url, apiKey: headers["X-BAPI-API-KEY"] ?? "" };
+    calls.push(call);
+    const body = opts.bodyFn ? opts.bodyFn(call) : opts.body;
+    return jsonResponse(body, opts.status ?? 200);
+  }) as typeof fetch;
+  return calls;
+}
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+const TEST_CREDS = { apiKey: "test-key", secret: "test-secret" };
+
+describe("detectFundingWindow — ledger path (creds supplied)", () => {
+  it("ledger has SETTLEMENT row → paymentReceived=true, paymentSource='ledger'", async () => {
+    const calls = installLedgerFetch({
+      body: {
+        retCode: 0,
+        retMsg: "OK",
+        result: {
+          list: [
+            {
+              symbol: "BTCUSDT",
+              type: "SETTLEMENT",
+              transactionTime: String(NEXT_FUNDING_MS + 5_000),
+            },
+          ],
+        },
+      },
+    });
+
+    const out = await detectFundingWindow(
+      "BTCUSDT",
+      NEXT_FUNDING_MS + 5 * 60_000,
+      { creds: TEST_CREDS },
+    );
+
+    expect(out.paymentReceived).toBe(true);
+    expect(out.paymentSource).toBe("ledger");
+    expect(out.nextFundingAtMs).toBe(NEXT_FUNDING_MS);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toContain("/v5/account/transaction-log");
+    expect(calls[0]?.url).toContain("symbol=BTCUSDT");
+    expect(calls[0]?.url).toContain("type=SETTLEMENT");
+    expect(calls[0]?.apiKey).toBe("test-key");
+  });
+
+  it("ledger empty → paymentReceived=false even when timestamp proxy would say true", async () => {
+    // now is INSIDE the proxy window (would have returned true), but
+    // ledger is empty — authoritative override.
+    installLedgerFetch({
+      body: { retCode: 0, retMsg: "OK", result: { list: [] } },
+    });
+
+    const out = await detectFundingWindow(
+      "BTCUSDT",
+      NEXT_FUNDING_MS + 5 * 60_000,
+      { creds: TEST_CREDS },
+    );
+
+    expect(out.paymentReceived).toBe(false);
+    expect(out.paymentSource).toBe("ledger-empty");
+  });
+
+  it("ledger HTTP error → falls back to timestamp proxy + paymentSource='proxy'", async () => {
+    installLedgerFetch({ body: { retCode: 0, result: {} }, status: 503 });
+
+    const out = await detectFundingWindow(
+      "BTCUSDT",
+      NEXT_FUNDING_MS + 5 * 60_000,
+      { creds: TEST_CREDS },
+    );
+
+    // proxy says paymentReceived=true at this offset; we get that.
+    expect(out.paymentReceived).toBe(true);
+    expect(out.paymentSource).toBe("proxy");
+  });
+
+  it("ledger retCode != 0 → falls back to timestamp proxy", async () => {
+    installLedgerFetch({
+      body: { retCode: 10001, retMsg: "params error" },
+    });
+
+    const out = await detectFundingWindow(
+      "BTCUSDT",
+      NEXT_FUNDING_MS + 5 * 60_000,
+      { creds: TEST_CREDS },
+    );
+
+    expect(out.paymentReceived).toBe(true); // proxy fallback
+    expect(out.paymentSource).toBe("proxy");
+  });
+
+  it("pre-settlement (sinceFunding ≤ 0) → no ledger call, paymentReceived=false", async () => {
+    const calls = installLedgerFetch({
+      body: { retCode: 0, result: { list: [] } },
+    });
+
+    // 1 minute BEFORE funding — we are inside the entry window, but the
+    // ledger query is meaningless because no payment can have landed yet.
+    const out = await detectFundingWindow(
+      "BTCUSDT",
+      NEXT_FUNDING_MS - 60_000,
+      { creds: TEST_CREDS },
+    );
+
+    expect(out.open).toBe(true);
+    expect(out.paymentReceived).toBe(false);
+    expect(out.paymentSource).toBe("proxy");
+    expect(calls).toHaveLength(0);
+  });
+
+  it("ledger row for a different symbol → paymentReceived=false (filter pinned)", async () => {
+    installLedgerFetch({
+      body: {
+        retCode: 0,
+        result: {
+          list: [
+            {
+              symbol: "ETHUSDT",
+              type: "SETTLEMENT",
+              transactionTime: String(NEXT_FUNDING_MS + 5_000),
+            },
+          ],
+        },
+      },
+    });
+
+    const out = await detectFundingWindow(
+      "BTCUSDT",
+      NEXT_FUNDING_MS + 5 * 60_000,
+      { creds: TEST_CREDS },
+    );
+
+    expect(out.paymentReceived).toBe(false);
+    expect(out.paymentSource).toBe("ledger-empty");
+  });
+
+  it("no snapshot + creds supplied → no ledger call (nothing to anchor window to)", async () => {
+    canned = null;
+    const calls = installLedgerFetch({ body: { retCode: 0, result: { list: [] } } });
+
+    const out = await detectFundingWindow("BTCUSDT", NEXT_FUNDING_MS + 5 * 60_000, {
+      creds: TEST_CREDS,
+    });
+
+    expect(out.paymentReceived).toBe(false);
+    expect(out.nextFundingAtMs).toBeNull();
+    expect(calls).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Summary

Replaces the timestamp-proxy approximation for `paymentReceived` with an authoritative Bybit ledger query when the caller supplies decrypted linear credentials. Without creds the legacy timestamp behaviour is preserved verbatim so existing callers (tests, demo workspaces, ExchangeConnection without private API access) keep working.

**Why now:** `hedgeBotWorker`'s ACTIVE → EXIT_PLACED transition has been firing on a heuristic — `sinceFunding ∈ [60s, 30min]` — that says "funding *probably* landed". A bot that exits without confirming the payment can leak the funding cashflow on partial settlements or sporadic Bybit clock drift. With the real ledger query the worker now exits only when Bybit's books actually show a SETTLEMENT row for the hedge symbol in the post-funding window.

## Changes

**1. `apps/api/src/lib/funding/windowDetector.ts`**
- Signature extended: `detectFundingWindow(symbol, nowMs, options?)`. `options.creds` is the new optional `FundingLedgerCreds` (apiKey + plaintext secret).
- Real-ledger path: `GET /v5/account/transaction-log` filtered to `category=linear`, `type=SETTLEMENT`, hedge symbol, `(nextFundingAt - 60s, nowMs]`. A matching row → `paymentReceived=true`; no row → `false` (overrides the proxy).
- New `paymentSource` field on `FundingWindow`: `"ledger" | "ledger-empty" | "proxy"` — operator dashboards can show this so "why hasn't my hedge exited" has a concrete answer.
- Pre-settlement (`sinceFunding ≤ 0`) skips the network call — no payment can have landed yet.
- Transient ledger errors (HTTP non-OK, parse failure, `retCode != 0`) fall back to the timestamp proxy with `log.warn` — the worker must keep ticking.
- HMAC signing mirrors `bybitOrder.ts` / `balanceReconciler.ts` patterns. The third copy is a known duplication slated for a future shared `bybitAuth.ts` extraction (out of scope here).

**2. `apps/api/src/lib/hedgeBotWorker.ts`**
- `buildDefaultInput` decrypts the linear secret via `decryptWithFallback` and passes `{apiKey, secret}` into `detectFundingWindow`. A decrypt failure (key rotated out, payload corrupt) is caught + logged + falls through to the proxy path — must NOT take down the tick.
- The `reconcileBalances` wiring (entry-gate balance check) is unchanged.

## Tests (+7 cases)

`tests/lib/funding/windowDetector.test.ts` — new "ledger path" describe block, mocks `globalThis.fetch` following the `balanceReconciler.test.ts` pattern:
- SETTLEMENT row for the symbol → `paymentReceived=true`, `paymentSource="ledger"`, URL contains right filters, `X-BAPI-API-KEY` header set.
- Empty ledger when proxy would say true → `paymentReceived=false` (authoritative override).
- HTTP 503 → fallback to proxy + `paymentSource="proxy"`.
- `retCode != 0` → fallback to proxy.
- Pre-settlement → no fetch call at all.
- Row for a different symbol → filtered out.
- No snapshot + creds → no fetch call (nothing to anchor window to).
- Existing single test using `toEqual` updated to `toMatchObject` + separate assert on `paymentSource` (additive shape change).

## Test plan

- [x] `pnpm --filter @botmarketplace/api exec tsc --noEmit` — clean
- [x] `pnpm --filter @botmarketplace/api exec vitest run tests/lib/funding/windowDetector.test.ts` — 18/18
- [x] `pnpm --filter @botmarketplace/api exec vitest run tests/lib/hedgeBotWorker.test.ts` — 24/24 (creds wiring transparent)
- [x] `pnpm --filter @botmarketplace/api test` — **2159/2159** (was 2152 baseline; +7 new)

https://claude.ai/code/session_01XoMMe56sv7QDkoovGn9Lww

---
_Generated by [Claude Code](https://claude.ai/code/session_01XoMMe56sv7QDkoovGn9Lww)_