### PR TITLE
feat(presets): BETA visibility badge in PresetCard (55-T6 §UI)

### DIFF
--- a/apps/web/src/app/lab/library/PresetCard.tsx
+++ b/apps/web/src/app/lab/library/PresetCard.tsx
@@ -23,6 +23,7 @@ export function PresetCard({
   onUse: (slug: string) => void;
 }) {
   const isPrivate = preset.visibility === "PRIVATE";
+  const isBeta = preset.visibility === "BETA";
   const categoryColor = CATEGORY_COLOR[preset.category] ?? "#6B7280";
 
   return (
@@ -30,6 +31,14 @@ export function PresetCard({
       <div style={headerStyle}>
         <div style={categoryBadgeStyle(categoryColor)}>{preset.category}</div>
         {isPrivate && <div style={privateBadgeStyle}>Private</div>}
+        {isBeta && (
+          <div
+            style={betaBadgeStyle}
+            title="BETA — multi-leg execution, monitor closely"
+          >
+            Beta
+          </div>
+        )}
       </div>
 
       <h3 style={titleStyle}>{preset.name}</h3>
@@ -96,6 +105,22 @@ const privateBadgeStyle: React.CSSProperties = {
   color: "rgba(255,255,255,0.55)",
   background: "rgba(255,255,255,0.06)",
   border: "1px solid rgba(255,255,255,0.18)",
+};
+
+// Yellow/amber accent — same shade family as the `scalping` category badge
+// (#F59E0B) so the visual vocabulary stays consistent. Tooltip carries the
+// operator-facing rationale; on hover the user sees the full advisory.
+const betaBadgeStyle: React.CSSProperties = {
+  fontSize: 10,
+  fontWeight: 700,
+  textTransform: "uppercase",
+  letterSpacing: "0.06em",
+  padding: "2px 8px",
+  borderRadius: 4,
+  color: "#F59E0B",
+  background: "rgba(245, 158, 11, 0.12)",
+  border: "1px solid rgba(245, 158, 11, 0.45)",
+  cursor: "help",
 };
 
 const titleStyle: React.CSSProperties = {

--- a/apps/web/src/lib/api/presets.ts
+++ b/apps/web/src/lib/api/presets.ts
@@ -14,7 +14,7 @@ import type { ProblemDetails } from "../api";
 // ---------------------------------------------------------------------------
 
 export type PresetCategory = "trend" | "dca" | "scalping" | "smc" | "arb";
-export type PresetVisibility = "PRIVATE" | "PUBLIC";
+export type PresetVisibility = "PRIVATE" | "BETA" | "PUBLIC";
 export type PresetTimeframe = "M1" | "M5" | "M15" | "H1";
 
 export interface PresetDefaultBotConfig {


### PR DESCRIPTION
## Summary

Visual surface for the three-tier visibility model landed in #360. The client-side `PresetVisibility` union was still `"PRIVATE" | "PUBLIC"` even though the backend Prisma enum has carried `BETA` since #360, so funding-arb (the first BETA preset) had no on-card cue distinguishing it from a fully-vetted PUBLIC preset.

## Changes

- **`apps/web/src/lib/api/presets.ts`** — `PresetVisibility` extended to `"PRIVATE" | "BETA" | "PUBLIC"`. Single export point; no other client-side consumers had to change (verified via grep).
- **`apps/web/src/app/lab/library/PresetCard.tsx`**
  - New `isBeta = preset.visibility === "BETA"` branch alongside the existing `isPrivate` one.
  - Yellow/amber `Beta` pill in the card header. Tooltip `"BETA — multi-leg execution, monitor closely"` carries the operator-facing rationale on hover.
  - Colour palette deliberately reuses the `scalping` category amber (`#F59E0B`) so the visual vocabulary stays consistent — yellow already reads as "elevated risk / new" across the rest of the lab UI.

## Test plan

- [x] `pnpm --filter @botmarketplace/web exec tsc --noEmit` — clean
- [x] `pnpm --filter @botmarketplace/api exec tsc --noEmit` — clean (defence-in-depth)
- [ ] Browser smoke not performed — no creds in this session. The visual is a verbatim mirror of the existing `Private` pill, just with the amber palette. The change is render-only and cannot affect any existing assertion (no PresetCard / library snapshot tests in `apps/web`).

https://claude.ai/code/session_01XoMMe56sv7QDkoovGn9Lww

---
_Generated by [Claude Code](https://claude.ai/code/session_01XoMMe56sv7QDkoovGn9Lww)_