### PR TITLE
feat(exchanges): spot key/secret/label end-to-end (55-T5 §UI + §API)

### DIFF
--- a/apps/api/src/routes/exchanges.ts
+++ b/apps/api/src/routes/exchanges.ts
@@ -16,6 +16,8 @@ function safeView(conn: {
   status: string;
   createdAt: Date;
   updatedAt: Date;
+  spotApiKey?: string | null;
+  spotKeyLabel?: string | null;
 }) {
   return {
     id: conn.id,
@@ -25,6 +27,11 @@ function safeView(conn: {
     status: conn.status,
     createdAt: conn.createdAt,
     updatedAt: conn.updatedAt,
+    // Boolean projection only — never expose the key string itself.
+    // The label IS shown so operators can recognise "is this the spot
+    // key I configured" without ever leaking the secret.
+    hasSpotKey: Boolean(conn.spotApiKey),
+    spotKeyLabel: conn.spotKeyLabel ?? null,
   };
 }
 
@@ -44,12 +51,41 @@ interface CreateBody {
   name: string;
   apiKey: string;
   secret: string;
+  /** Optional dedicated spot scope creds (docs/55-T5). When present, BOTH
+   *  spotApiKey AND spotSecret must be supplied — submitting only one is a
+   *  validation error so we never persist a half-configured spot key. */
+  spotApiKey?: string;
+  spotSecret?: string;
+  /** Free-form label shown alongside the spot key in the UI. Optional. */
+  spotKeyLabel?: string;
 }
 
 interface PatchBody {
   name?: string;
   apiKey?: string;
   secret?: string;
+  /** Same dual-field rule on PATCH: supplying spotApiKey OR spotSecret
+   *  alone is an error, except for the explicit clear path where BOTH
+   *  are passed as `null`. */
+  spotApiKey?: string | null;
+  spotSecret?: string | null;
+  spotKeyLabel?: string | null;
+}
+
+/** Validate an apiKey-shaped string. Returns an error message or null
+ *  when the value passes. Centralised so the same rules apply to the
+ *  linear `apiKey` and the optional `spotApiKey`. */
+function validateApiKeyShape(value: unknown, fieldName: string): string | null {
+  if (typeof value !== "string" || !value) {
+    return `${fieldName} is required`;
+  }
+  if (value.length > API_KEY_MAX_LENGTH) {
+    return `${fieldName} must not exceed ${API_KEY_MAX_LENGTH} characters`;
+  }
+  if (!API_KEY_PATTERN.test(value)) {
+    return `${fieldName} contains invalid characters (only alphanumeric, dash, underscore allowed)`;
+  }
+  return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -65,19 +101,34 @@ export async function exchangeRoutes(app: FastifyInstance) {
     const key = getEncryptionKey(reply);
     if (!key) return;
 
-    const { exchange, name, apiKey, secret } = request.body ?? {};
+    const { exchange, name, apiKey, secret, spotApiKey, spotSecret, spotKeyLabel } =
+      request.body ?? {};
 
     const errors: Array<{ field: string; message: string }> = [];
     if (!exchange || typeof exchange !== "string") errors.push({ field: "exchange", message: "exchange is required" });
     if (!name || typeof name !== "string") errors.push({ field: "name", message: "name is required" });
-    if (!apiKey || typeof apiKey !== "string") {
-      errors.push({ field: "apiKey", message: "apiKey is required" });
-    } else if (apiKey.length > API_KEY_MAX_LENGTH) {
-      errors.push({ field: "apiKey", message: `apiKey must not exceed ${API_KEY_MAX_LENGTH} characters` });
-    } else if (!API_KEY_PATTERN.test(apiKey)) {
-      errors.push({ field: "apiKey", message: "apiKey contains invalid characters (only alphanumeric, dash, underscore allowed)" });
-    }
+    const apiKeyErr = validateApiKeyShape(apiKey, "apiKey");
+    if (apiKeyErr) errors.push({ field: "apiKey", message: apiKeyErr });
     if (!secret || typeof secret !== "string") errors.push({ field: "secret", message: "secret is required" });
+
+    // Spot creds: both-or-neither rule. spotKeyLabel is independent.
+    const hasSpotKey = spotApiKey !== undefined && spotApiKey !== "";
+    const hasSpotSecret = spotSecret !== undefined && spotSecret !== "";
+    if (hasSpotKey !== hasSpotSecret) {
+      errors.push({
+        field: "spotApiKey",
+        message: "spotApiKey and spotSecret must be supplied together (or neither)",
+      });
+    } else if (hasSpotKey && hasSpotSecret) {
+      const spotKeyErr = validateApiKeyShape(spotApiKey, "spotApiKey");
+      if (spotKeyErr) errors.push({ field: "spotApiKey", message: spotKeyErr });
+      if (typeof spotSecret !== "string" || !spotSecret) {
+        errors.push({ field: "spotSecret", message: "spotSecret must be a non-empty string" });
+      }
+    }
+    if (spotKeyLabel !== undefined && typeof spotKeyLabel !== "string") {
+      errors.push({ field: "spotKeyLabel", message: "spotKeyLabel must be a string when provided" });
+    }
     if (errors.length > 0) {
       return problem(reply, 400, "Validation Error", "Invalid exchange connection payload", { errors });
     }
@@ -91,6 +142,8 @@ export async function exchangeRoutes(app: FastifyInstance) {
     }
 
     const encryptedSecret = encrypt(secret, key);
+    const spotEncryptedSecret =
+      hasSpotKey && hasSpotSecret ? encrypt(spotSecret as string, key) : null;
 
     const conn = await prisma.exchangeConnection.create({
       data: {
@@ -99,6 +152,9 @@ export async function exchangeRoutes(app: FastifyInstance) {
         name,
         apiKey,
         encryptedSecret,
+        spotApiKey: hasSpotKey ? (spotApiKey as string) : null,
+        spotEncryptedSecret,
+        spotKeyLabel: spotKeyLabel ?? null,
         status: "UNKNOWN",
       },
     });
@@ -146,7 +202,8 @@ export async function exchangeRoutes(app: FastifyInstance) {
       return problem(reply, 404, "Not Found", "Exchange connection not found");
     }
 
-    const { name, apiKey, secret } = request.body ?? {};
+    const { name, apiKey, secret, spotApiKey, spotSecret, spotKeyLabel } =
+      request.body ?? {};
 
     // Validate apiKey if provided
     if (apiKey !== undefined) {
@@ -172,12 +229,61 @@ export async function exchangeRoutes(app: FastifyInstance) {
       encryptedSecret = encrypt(secret, key);
     }
 
+    // Spot creds — three valid shapes:
+    //   1. Both omitted → no change.
+    //   2. Both null    → clear the spot key.
+    //   3. Both strings → rotate / set the spot key.
+    // Anything else is rejected so we never persist a half-configured key.
+    let spotEncryptedSecret: string | null | undefined; // undefined → no change
+    let spotApiKeyValue: string | null | undefined;
+    const spotKeyOmitted = spotApiKey === undefined && spotSecret === undefined;
+    const spotKeyCleared = spotApiKey === null && spotSecret === null;
+    const spotKeySet = typeof spotApiKey === "string" && typeof spotSecret === "string";
+    if (!spotKeyOmitted) {
+      if (spotKeyCleared) {
+        spotApiKeyValue = null;
+        spotEncryptedSecret = null;
+      } else if (spotKeySet) {
+        const spotKeyErr = validateApiKeyShape(spotApiKey, "spotApiKey");
+        if (spotKeyErr) return problem(reply, 400, "Validation Error", spotKeyErr);
+        if (!spotSecret) {
+          return problem(reply, 400, "Validation Error", "spotSecret must be a non-empty string");
+        }
+        const key = getEncryptionKey(reply);
+        if (!key) return;
+        spotApiKeyValue = spotApiKey;
+        spotEncryptedSecret = encrypt(spotSecret, key);
+      } else {
+        return problem(
+          reply,
+          400,
+          "Validation Error",
+          "spotApiKey and spotSecret must be supplied together (both string to set, both null to clear)",
+        );
+      }
+    }
+
+    if (spotKeyLabel !== undefined && spotKeyLabel !== null && typeof spotKeyLabel !== "string") {
+      return problem(reply, 400, "Validation Error", "spotKeyLabel must be a string or null");
+    }
+
     const updateData: Record<string, unknown> = {};
     if (name !== undefined) updateData.name = name;
     if (apiKey !== undefined) updateData.apiKey = apiKey;
     if (encryptedSecret !== undefined) updateData.encryptedSecret = encryptedSecret;
-    // Reset status to UNKNOWN whenever credentials change
-    if (apiKey !== undefined || secret !== undefined) updateData.status = "UNKNOWN";
+    if (spotApiKeyValue !== undefined) updateData.spotApiKey = spotApiKeyValue;
+    if (spotEncryptedSecret !== undefined) updateData.spotEncryptedSecret = spotEncryptedSecret;
+    if (spotKeyLabel !== undefined) updateData.spotKeyLabel = spotKeyLabel;
+    // Reset status to UNKNOWN whenever ANY credential pair changes — the
+    // operator should re-test the connection after rotation/clear.
+    if (
+      apiKey !== undefined ||
+      secret !== undefined ||
+      spotApiKeyValue !== undefined ||
+      spotEncryptedSecret !== undefined
+    ) {
+      updateData.status = "UNKNOWN";
+    }
 
     const updated = await prisma.exchangeConnection.update({
       where: { id: conn.id },

--- a/apps/api/tests/routes/exchanges.test.ts
+++ b/apps/api/tests/routes/exchanges.test.ts
@@ -4,7 +4,7 @@
  * Verifies that PATCH rejects empty/null apiKey the same way POST does.
  */
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Mock Prisma before any import that touches it
 vi.mock("@prisma/client", () => ({
@@ -17,13 +17,14 @@ vi.mock("@prisma/client", () => ({
 
 const mockFindUnique = vi.fn();
 const mockUpdate = vi.fn();
+const mockCreate = vi.fn();
 
 vi.mock("../../src/lib/prisma.js", () => ({
   prisma: {
     exchangeConnection: {
       findUnique: (...args: unknown[]) => mockFindUnique(...args),
       findMany: vi.fn().mockResolvedValue([]),
-      create: vi.fn(),
+      create: (...args: unknown[]) => mockCreate(...args),
       update: (...args: unknown[]) => mockUpdate(...args),
       delete: vi.fn(),
     },
@@ -192,6 +193,253 @@ describe("PATCH /exchanges/:id — apiKey validation", () => {
     });
 
     expect(res.statusCode).toBe(401);
+    await app.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// docs/55-T5 spot-key fields — POST + PATCH + safeView projection
+// ---------------------------------------------------------------------------
+
+describe("POST /exchanges — spot key fields", () => {
+  beforeEach(() => {
+    // Don't reset implementations (ours rely on a `mockResolvedValue` /
+    // `mockImplementation` per test) — just clear call history so
+    // `mock.calls[0]` is unambiguous.
+    mockFindUnique.mockClear();
+    mockUpdate.mockClear();
+    mockCreate.mockClear();
+  });
+
+  const baseBody = {
+    exchange: "BYBIT",
+    name: "spot-test",
+    apiKey: "linear-key",
+    secret: "linear-secret",
+  };
+
+  const baseRow = {
+    id: "conn-spot",
+    workspaceId: "ws-1",
+    exchange: "BYBIT",
+    name: "spot-test",
+    apiKey: "linear-key",
+    encryptedSecret: "iv:tag:cipher",
+    status: "UNKNOWN",
+    spotApiKey: null,
+    spotEncryptedSecret: null,
+    spotKeyLabel: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  it("accepts both spotApiKey + spotSecret + spotKeyLabel; safeView returns hasSpotKey=true + label", async () => {
+    const { app, token } = await getApp();
+    mockFindUnique.mockResolvedValue(null); // no existing
+    mockCreate.mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({
+      ...baseRow,
+      ...data,
+      id: "conn-spot-1",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }));
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/exchanges`,
+      headers: { authorization: `Bearer ${token}`, "x-workspace-id": "ws-1" },
+      payload: { ...baseBody, spotApiKey: "spot-key", spotSecret: "spot-secret", spotKeyLabel: "Funding-arb spot" },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = JSON.parse(res.payload);
+    expect(body.hasSpotKey).toBe(true);
+    expect(body.spotKeyLabel).toBe("Funding-arb spot");
+    // The key string itself MUST NOT leak in the response — defence-in-depth.
+    expect(body.spotApiKey).toBeUndefined();
+    expect(body.spotEncryptedSecret).toBeUndefined();
+    expect(body.encryptedSecret).toBeUndefined();
+    // Persisted shape — both spot fields populated, single-key fallback skipped.
+    const createCall = mockCreate.mock.calls[0]?.[0] as { data: Record<string, unknown> };
+    expect(createCall.data.spotApiKey).toBe("spot-key");
+    expect(createCall.data.spotEncryptedSecret).toBe("iv:tag:cipher");
+    await app.close();
+  });
+
+  it("omitting both spot fields → hasSpotKey=false, persisted fields are null (single-key fallback)", async () => {
+    const { app, token } = await getApp();
+    mockFindUnique.mockResolvedValue(null);
+    mockCreate.mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({
+      ...baseRow,
+      ...data,
+      id: "conn-single",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }));
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/exchanges`,
+      headers: { authorization: `Bearer ${token}`, "x-workspace-id": "ws-1" },
+      payload: baseBody,
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = JSON.parse(res.payload);
+    expect(body.hasSpotKey).toBe(false);
+    expect(body.spotKeyLabel).toBeNull();
+    const createCall = mockCreate.mock.calls[0]?.[0] as { data: Record<string, unknown> };
+    expect(createCall.data.spotApiKey).toBeNull();
+    expect(createCall.data.spotEncryptedSecret).toBeNull();
+    await app.close();
+  });
+
+  it("supplying spotApiKey without spotSecret → 400 'must be supplied together'", async () => {
+    const { app, token } = await getApp();
+    mockFindUnique.mockResolvedValue(null);
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/exchanges`,
+      headers: { authorization: `Bearer ${token}`, "x-workspace-id": "ws-1" },
+      payload: { ...baseBody, spotApiKey: "spot-key" },
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = JSON.parse(res.payload);
+    expect(JSON.stringify(body)).toContain("must be supplied together");
+    expect(mockCreate).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it("spotApiKey with invalid characters → 400 with field-pinned error", async () => {
+    const { app, token } = await getApp();
+    mockFindUnique.mockResolvedValue(null);
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/exchanges`,
+      headers: { authorization: `Bearer ${token}`, "x-workspace-id": "ws-1" },
+      payload: { ...baseBody, spotApiKey: "key with spaces!", spotSecret: "spot-secret" },
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = JSON.parse(res.payload);
+    expect(JSON.stringify(body)).toContain("spotApiKey");
+    expect(JSON.stringify(body)).toContain("invalid characters");
+    await app.close();
+  });
+});
+
+describe("PATCH /exchanges/:id — spot key rotation + clear", () => {
+  beforeEach(() => {
+    mockFindUnique.mockClear();
+    mockUpdate.mockClear();
+    mockCreate.mockClear();
+  });
+
+  const CONN_ID = "conn-spot-patch";
+  const EXISTING = {
+    id: CONN_ID,
+    workspaceId: "ws-1",
+    exchange: "BYBIT",
+    name: "rotate-me",
+    apiKey: "linear-key",
+    encryptedSecret: "iv:tag:cipher",
+    status: "CONNECTED",
+    spotApiKey: "old-spot-key",
+    spotEncryptedSecret: "iv:tag:old-spot-cipher",
+    spotKeyLabel: "Old label",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  it("rotates spot key when both spotApiKey + spotSecret are strings; status reset to UNKNOWN", async () => {
+    const { app, token } = await getApp();
+    mockFindUnique.mockResolvedValue(EXISTING);
+    mockUpdate.mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({
+      ...EXISTING,
+      ...data,
+      updatedAt: new Date(),
+    }));
+
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/exchanges/${CONN_ID}`,
+      headers: { authorization: `Bearer ${token}`, "x-workspace-id": "ws-1" },
+      payload: { spotApiKey: "new-spot-key", spotSecret: "new-spot-secret", spotKeyLabel: "New label" },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const updateCall = mockUpdate.mock.calls[0]?.[0] as { data: Record<string, unknown> };
+    expect(updateCall.data.spotApiKey).toBe("new-spot-key");
+    expect(updateCall.data.spotEncryptedSecret).toBe("iv:tag:cipher");
+    expect(updateCall.data.spotKeyLabel).toBe("New label");
+    // Cred change → status UNKNOWN, force re-test.
+    expect(updateCall.data.status).toBe("UNKNOWN");
+    await app.close();
+  });
+
+  it("clears spot key when both spotApiKey + spotSecret are null", async () => {
+    const { app, token } = await getApp();
+    mockFindUnique.mockResolvedValue(EXISTING);
+    mockUpdate.mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({
+      ...EXISTING,
+      ...data,
+      updatedAt: new Date(),
+    }));
+
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/exchanges/${CONN_ID}`,
+      headers: { authorization: `Bearer ${token}`, "x-workspace-id": "ws-1" },
+      payload: { spotApiKey: null, spotSecret: null, spotKeyLabel: null },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const updateCall = mockUpdate.mock.calls[0]?.[0] as { data: Record<string, unknown> };
+    expect(updateCall.data.spotApiKey).toBeNull();
+    expect(updateCall.data.spotEncryptedSecret).toBeNull();
+    expect(updateCall.data.spotKeyLabel).toBeNull();
+    expect(updateCall.data.status).toBe("UNKNOWN");
+    await app.close();
+  });
+
+  it("rejects half-cleared spot fields (spotApiKey=null but spotSecret=string)", async () => {
+    const { app, token } = await getApp();
+    mockFindUnique.mockResolvedValue(EXISTING);
+
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/exchanges/${CONN_ID}`,
+      headers: { authorization: `Bearer ${token}`, "x-workspace-id": "ws-1" },
+      payload: { spotApiKey: null, spotSecret: "still-here" },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(mockUpdate).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it("PATCH with no spot fields touches no spot data (omitted = no-op)", async () => {
+    const { app, token } = await getApp();
+    mockFindUnique.mockResolvedValue(EXISTING);
+    mockUpdate.mockResolvedValue({ ...EXISTING, name: "Renamed" });
+
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/exchanges/${CONN_ID}`,
+      headers: { authorization: `Bearer ${token}`, "x-workspace-id": "ws-1" },
+      payload: { name: "Renamed" },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const updateCall = mockUpdate.mock.calls[0]?.[0] as { data: Record<string, unknown> };
+    expect(updateCall.data).not.toHaveProperty("spotApiKey");
+    expect(updateCall.data).not.toHaveProperty("spotEncryptedSecret");
+    expect(updateCall.data).not.toHaveProperty("spotKeyLabel");
+    // status NOT reset because no creds changed.
+    expect(updateCall.data.status).toBeUndefined();
     await app.close();
   });
 });

--- a/apps/web/src/app/exchanges/page.tsx
+++ b/apps/web/src/app/exchanges/page.tsx
@@ -15,6 +15,10 @@ interface ExchangeConn {
   name: string;
   status: string;
   createdAt: string;
+  /** docs/55-T5: true when a dedicated spot key is configured. */
+  hasSpotKey?: boolean;
+  /** docs/55-T5: free-form label for the spot key. */
+  spotKeyLabel?: string | null;
 }
 
 interface TestResult {
@@ -23,7 +27,18 @@ interface TestResult {
   detail: string;
 }
 
-const EMPTY_FORM = { exchange: "BYBIT", name: "", apiKey: "", secret: "" };
+const EMPTY_FORM = {
+  exchange: "BYBIT",
+  name: "",
+  apiKey: "",
+  secret: "",
+  // docs/55-T5: optional dedicated spot scope creds. Empty strings = "not
+  // configured" — only sent to the API when both spotApiKey AND spotSecret
+  // are filled (the backend enforces the both-or-neither rule).
+  spotApiKey: "",
+  spotSecret: "",
+  spotKeyLabel: "",
+};
 
 // ---------------------------------------------------------------------------
 // Page
@@ -39,6 +54,7 @@ export default function ExchangesPage() {
   const [addForm, setAddForm] = useState(EMPTY_FORM);
   const [addError, setAddError] = useState<string | null>(null);
   const [addSaving, setAddSaving] = useState(false);
+  const [spotKeyExpanded, setSpotKeyExpanded] = useState(false);
 
   const [testResults, setTestResults] = useState<Record<string, TestResult>>({});
   const [testing, setTesting] = useState<Record<string, boolean>>({});
@@ -64,20 +80,47 @@ export default function ExchangesPage() {
 
   async function handleAdd() {
     setAddError(null);
-    const { exchange, name, apiKey, secret } = addForm;
+    const { exchange, name, apiKey, secret, spotApiKey, spotSecret, spotKeyLabel } = addForm;
     if (!name.trim() || !apiKey.trim() || !secret.trim()) {
-      setAddError("All fields are required.");
+      setAddError("Name, API key and secret are required.");
       return;
     }
+    // Both-or-neither rule for the spot pair. Mirrors the backend
+    // validator at apps/api/src/routes/exchanges.ts; surfacing it client-side
+    // means the operator gets immediate feedback instead of a round-trip
+    // 400.
+    const trimmedSpotKey = spotApiKey.trim();
+    const trimmedSpotSecret = spotSecret.trim();
+    if (Boolean(trimmedSpotKey) !== Boolean(trimmedSpotSecret)) {
+      setAddError(
+        "Spot API key and spot secret must be supplied together (or both left blank for single-key fallback).",
+      );
+      return;
+    }
+
+    const body: Record<string, unknown> = {
+      exchange,
+      name: name.trim(),
+      apiKey: apiKey.trim(),
+      secret: secret.trim(),
+    };
+    if (trimmedSpotKey && trimmedSpotSecret) {
+      body.spotApiKey = trimmedSpotKey;
+      body.spotSecret = trimmedSpotSecret;
+      const trimmedLabel = spotKeyLabel.trim();
+      if (trimmedLabel) body.spotKeyLabel = trimmedLabel;
+    }
+
     setAddSaving(true);
     const res = await apiFetch<ExchangeConn>("/exchanges", {
       method: "POST",
-      body: JSON.stringify({ exchange, name: name.trim(), apiKey: apiKey.trim(), secret: secret.trim() }),
+      body: JSON.stringify(body),
     });
     setAddSaving(false);
     if (res.ok) {
       setConnections((prev) => [res.data, ...prev]);
       setAddForm({ ...EMPTY_FORM });
+      setSpotKeyExpanded(false);
     } else if (res.problem.status === 401) {
       setSessionExpired(true);
     } else {
@@ -156,6 +199,18 @@ export default function ExchangesPage() {
               <strong style={{ color: "var(--text-primary)", fontSize: 14 }}>{conn.name}</strong>
               <span style={{ color: "var(--text-secondary)", fontSize: 12 }}>{conn.exchange}</span>
               <StatusBadge status={conn.status} />
+              {conn.hasSpotKey && (
+                <span
+                  style={spotPillStyle}
+                  title={
+                    conn.spotKeyLabel
+                      ? `Dedicated spot key: ${conn.spotKeyLabel}`
+                      : "Dedicated spot key configured"
+                  }
+                >
+                  + Spot
+                </span>
+              )}
               {tr && (
                 <span style={{ fontSize: 12, color: tr.status === "CONNECTED" ? "#3fb950" : "#f85149" }}>
                   {tr.detail}
@@ -216,6 +271,48 @@ export default function ExchangesPage() {
             style={inputStyle}
             autoComplete="new-password"
           />
+
+          {/* docs/55-T5: optional dedicated spot scope creds. Hidden by
+              default — single-key Bybit accounts work fine without them
+              (the executor falls back to the linear pair). Operators who
+              want a separate scope for funding-arb expand this section. */}
+          <button
+            type="button"
+            onClick={() => setSpotKeyExpanded((v) => !v)}
+            style={spotToggleStyle}
+          >
+            {spotKeyExpanded ? "▾" : "▸"} Spot key (optional, for funding arbitrage)
+          </button>
+          {spotKeyExpanded && (
+            <div style={spotSectionStyle}>
+              <input
+                placeholder="Spot API Key"
+                value={addForm.spotApiKey}
+                onChange={(e) => setAddForm((f) => ({ ...f, spotApiKey: e.target.value }))}
+                style={inputStyle}
+                autoComplete="off"
+              />
+              <input
+                type="password"
+                placeholder="Spot Secret"
+                value={addForm.spotSecret}
+                onChange={(e) => setAddForm((f) => ({ ...f, spotSecret: e.target.value }))}
+                style={inputStyle}
+                autoComplete="new-password"
+              />
+              <input
+                placeholder="Label (e.g. 'Funding-arb spot')"
+                value={addForm.spotKeyLabel}
+                onChange={(e) => setAddForm((f) => ({ ...f, spotKeyLabel: e.target.value }))}
+                style={inputStyle}
+              />
+              <p style={spotHintStyle}>
+                Required only for funding arbitrage strategy. Leave blank to
+                reuse the linear key for spot calls (single-key Bybit).
+              </p>
+            </div>
+          )}
+
           <button onClick={handleAdd} disabled={addSaving} style={primaryBtn}>
             {addSaving ? "Saving…" : "Add Connection"}
           </button>
@@ -287,4 +384,46 @@ const expiredBanner: React.CSSProperties = {
 const expiredBtn: React.CSSProperties = {
   background: "rgba(255,255,255,0.2)", border: "1px solid rgba(255,255,255,0.4)",
   borderRadius: 4, color: "#fff", cursor: "pointer", fontSize: 13, padding: "4px 12px",
+};
+
+// docs/55-T5: spot-key UI primitives. Same amber as the BETA badge so the
+// "this is the funding-arb feature" visual cue carries across pages.
+const spotPillStyle: React.CSSProperties = {
+  fontSize: 10,
+  fontWeight: 700,
+  textTransform: "uppercase",
+  letterSpacing: "0.04em",
+  padding: "1px 6px",
+  borderRadius: 4,
+  color: "#F59E0B",
+  background: "rgba(245, 158, 11, 0.12)",
+  border: "1px solid rgba(245, 158, 11, 0.45)",
+  cursor: "help",
+};
+
+const spotToggleStyle: React.CSSProperties = {
+  textAlign: "left",
+  background: "transparent",
+  border: "none",
+  color: "var(--text-secondary)",
+  cursor: "pointer",
+  fontSize: 12,
+  padding: "4px 0",
+  fontFamily: "inherit",
+};
+
+const spotSectionStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: 8,
+  paddingLeft: 12,
+  borderLeft: "2px solid rgba(245, 158, 11, 0.35)",
+  marginLeft: 2,
+};
+
+const spotHintStyle: React.CSSProperties = {
+  margin: 0,
+  fontSize: 11,
+  color: "var(--text-secondary)",
+  lineHeight: 1.4,
 };


### PR DESCRIPTION
## Summary

Production gap closer. Until this PR there was no UI to configure `ExchangeConnection.spotApiKey` / `spotEncryptedSecret` / `spotKeyLabel` — operators creating a funding-arb bot had to either run on the linear single-key fallback or have a backend admin populate those fields by hand. This wires the schema (#360 / docs/55-T5) all the way through the API + the `/exchanges` page form.

## Backend (`apps/api/src/routes/exchanges.ts`)

**POST `/exchanges`**
- Body extended with optional `spotApiKey`, `spotSecret`, `spotKeyLabel`. Strict **both-or-neither** rule: supplying `spotApiKey` without `spotSecret` (or vice versa) is a 400 with a field-pinned error message — we never persist a half-configured spot key.
- `validateApiKeyShape(value, fieldName)` helper extracted from the inline checks so `spotApiKey` gets the same length / character-class rules as the linear `apiKey`.
- When both spot fields are present, `spotSecret` is encrypted with the same key as the linear secret and persisted alongside it.

**PATCH `/exchanges/:id`**
- Spot creds support three valid shapes:
  1. Both omitted → no change.
  2. Both `null` → clear the spot key (single-key fallback).
  3. Both strings → rotate / set.
- Anything else (e.g. `spotApiKey: null` with `spotSecret: "x"`) is a 400.
- `status` reset to `UNKNOWN` on any credential pair change (linear OR spot).

**`safeView` projection**
- Adds `hasSpotKey: Boolean(conn.spotApiKey)` + `spotKeyLabel: conn.spotKeyLabel ?? null`. The key string itself is **never** projected — only the boolean + the label.

## Tests (+8 cases in `tests/routes/exchanges.test.ts`)

- POST both fields → 201, `hasSpotKey=true`, label round-trips, encrypted spot secret persisted, raw key/cipher absent from response.
- POST without spot fields → 201, persisted spot fields are `null` (single-key fallback).
- POST with spotApiKey only → 400 'must be supplied together'; create not called.
- POST with invalid spotApiKey char class → 400 with field-pinned error.
- PATCH rotate → both spot fields updated, label updated, status=UNKNOWN.
- PATCH clear (both `null`) → spot data nulled, status=UNKNOWN.
- PATCH half-clear → 400, no update call.
- PATCH with no spot fields → no spot keys touched, status NOT reset.

## Frontend (`apps/web/src/app/exchanges/page.tsx`)

- `ExchangeConn` type extended with `hasSpotKey?: boolean` + `spotKeyLabel?: string | null`.
- Connection row shows a `+ Spot` amber pill (same `#F59E0B` from the BETA badge #366) when `hasSpotKey === true`. Tooltip shows the label.
- Add-form has a collapsible **▸ Spot key (optional, for funding arbitrage)** section. When expanded: 3 fields (key, secret, label) + hint line explaining the single-key fallback. Default collapsed so the existing single-key path stays a one-click flow.
- Client-side validation enforces the both-or-neither rule before the network call.
- POST body is conditionally built — spot fields only included when both are filled.

## Test plan

- [x] `pnpm --filter @botmarketplace/api exec tsc --noEmit` — clean
- [x] `pnpm --filter @botmarketplace/web exec tsc --noEmit` — clean
- [x] `pnpm --filter @botmarketplace/api exec vitest run tests/routes/exchanges.test.ts` — 16/16
- [x] `pnpm --filter @botmarketplace/api test` — **2167/2167** (was 2159 baseline; +8 new)
- [ ] Browser smoke not performed in this session.

https://claude.ai/code/session_01XoMMe56sv7QDkoovGn9Lww

---
_Generated by [Claude Code](https://claude.ai/code/session_01XoMMe56sv7QDkoovGn9Lww)_