### PR TITLE
refactor(exchange): extract shared Bybit V5 auth helpers (DRY cleanup)

### DIFF
--- a/apps/api/src/lib/bybitOrder.ts
+++ b/apps/api/src/lib/bybitOrder.ts
@@ -11,8 +11,8 @@
  *   BYBIT_BASE_URL  → explicit override (takes precedence)
  */
 
-import { createHmac } from "node:crypto";
 import { assertTradingEnabled } from "./tradingKillSwitch.js";
+import { bybitAuthHeaders } from "./exchange/bybitAuth.js";
 
 // ---------------------------------------------------------------------------
 // Environment-aware base URL
@@ -45,31 +45,7 @@ export function isBybitLive(): boolean {
   return getBybitBaseUrl() === BYBIT_LIVE_URL;
 }
 
-const RECV_WINDOW = "5000";
-
-// ---------------------------------------------------------------------------
-// Signing
-// ---------------------------------------------------------------------------
-
-function sign(secret: string, timestamp: string, apiKey: string, payload: string): string {
-  const preSign = `${timestamp}${apiKey}${RECV_WINDOW}${payload}`;
-  return createHmac("sha256", secret).update(preSign).digest("hex");
-}
-
-function authHeaders(
-  apiKey: string,
-  secret: string,
-  timestamp: string,
-  payload: string,
-): Record<string, string> {
-  return {
-    "X-BAPI-API-KEY": apiKey,
-    "X-BAPI-SIGN": sign(secret, timestamp, apiKey, payload),
-    "X-BAPI-TIMESTAMP": timestamp,
-    "X-BAPI-RECV-WINDOW": RECV_WINDOW,
-    "User-Agent": "botmarketplace-terminal/1",
-  };
-}
+const USER_AGENT = "botmarketplace-terminal/1";
 
 // ---------------------------------------------------------------------------
 // Place order
@@ -128,7 +104,7 @@ export async function bybitPlaceOrder(
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      ...authHeaders(apiKey, secret, timestamp, body),
+      ...bybitAuthHeaders(apiKey, secret, timestamp, body, USER_AGENT),
     },
     body,
   });
@@ -213,7 +189,7 @@ async function _fetchOrderFromEndpoint(
   const timestamp = Date.now().toString();
 
   const res = await fetch(`${getBybitBaseUrl()}${path}?${qs}`, {
-    headers: authHeaders(apiKey, secret, timestamp, qs),
+    headers: bybitAuthHeaders(apiKey, secret, timestamp, qs, USER_AGENT),
   });
 
   if (!res.ok) {

--- a/apps/api/src/lib/exchange/balanceReconciler.ts
+++ b/apps/api/src/lib/exchange/balanceReconciler.ts
@@ -28,14 +28,13 @@
  * so callers can branch without parsing free-form messages.
  */
 
-import { createHmac } from "node:crypto";
 import { logger } from "../logger.js";
 import { decryptWithFallback } from "../crypto.js";
 import { getBybitBaseUrl } from "../bybitOrder.js";
+import { bybitAuthHeaders } from "./bybitAuth.js";
 
 const log = logger.child({ module: "balanceReconciler" });
 
-const RECV_WINDOW = "5000";
 const USER_AGENT = "botmarketplace-reconciler/1";
 /** `||perp| - spot| / max(|perp|, spot)` accepted as 'balanced'. */
 const HEDGE_BALANCE_TOLERANCE = 0.005;
@@ -128,29 +127,8 @@ interface WalletBalanceResponse {
 }
 
 // ---------------------------------------------------------------------------
-// Signing — mirrors apps/api/src/lib/bybitOrder.ts
+// HTTP wrapper — auth helpers live in `./bybitAuth.ts`.
 // ---------------------------------------------------------------------------
-
-function sign(secret: string, timestamp: string, apiKey: string, payload: string): string {
-  return createHmac("sha256", secret)
-    .update(`${timestamp}${apiKey}${RECV_WINDOW}${payload}`)
-    .digest("hex");
-}
-
-function authHeaders(
-  apiKey: string,
-  secret: string,
-  timestamp: string,
-  payload: string,
-): Record<string, string> {
-  return {
-    "X-BAPI-API-KEY": apiKey,
-    "X-BAPI-SIGN": sign(secret, timestamp, apiKey, payload),
-    "X-BAPI-TIMESTAMP": timestamp,
-    "X-BAPI-RECV-WINDOW": RECV_WINDOW,
-    "User-Agent": USER_AGENT,
-  };
-}
 
 async function bybitGet<T extends { retCode: number; retMsg: string }>(
   apiKey: string,
@@ -163,7 +141,7 @@ async function bybitGet<T extends { retCode: number; retMsg: string }>(
   const url = `${getBybitBaseUrl()}${path}?${qs}`;
 
   const res = await fetch(url, {
-    headers: authHeaders(apiKey, secret, timestamp, qs),
+    headers: bybitAuthHeaders(apiKey, secret, timestamp, qs, USER_AGENT),
   });
   if (!res.ok) {
     throw new BalanceReconcilerError(

--- a/apps/api/src/lib/exchange/bybitAuth.ts
+++ b/apps/api/src/lib/exchange/bybitAuth.ts
@@ -1,0 +1,81 @@
+/**
+ * Bybit V5 private-API authentication helpers — shared by every module
+ * that signs HMAC requests against Bybit (`bybitOrder.ts`,
+ * `balanceReconciler.ts`, `funding/windowDetector.ts`).
+ *
+ * Before this module the same `sign` + `authHeaders` pair had been
+ * duplicated three times. Extracting them into one place removes the
+ * obvious DRY violation and gives every Bybit caller a single canonical
+ * implementation of the V5 signature scheme to test against.
+ *
+ * Spec reference:
+ *   https://bybit-exchange.github.io/docs/v5/guide/authentication
+ *
+ * Pre-sign string layout (HMAC-SHA256 input):
+ *   `${timestamp}${apiKey}${recvWindow}${payload}`
+ *
+ * Where:
+ *   - `timestamp`   — ms epoch as decimal string (matches `Date.now().toString()`).
+ *   - `apiKey`      — the public half of the credential pair.
+ *   - `recvWindow`  — Bybit-side allowed clock skew, in ms. Default 5000.
+ *   - `payload`     — for POST: the JSON request body (exact bytes Bybit
+ *                     receives). For GET: the URL-encoded query string
+ *                     (no leading `?`).
+ *
+ * The header set returned by `bybitAuthHeaders` is intentionally minimal:
+ * just the four required `X-BAPI-*` headers plus a caller-supplied
+ * User-Agent. Callers add `Content-Type` themselves on the request side
+ * because GETs do not need it.
+ */
+
+import { createHmac } from "node:crypto";
+
+/** Default Bybit `recvWindow` (ms) — five seconds, which is what every
+ *  inline copy in the codebase used. Bybit's documented max is 60_000ms
+ *  but the project does not need a wider window. */
+export const BYBIT_RECV_WINDOW = "5000";
+
+/** Compute the Bybit V5 HMAC-SHA256 signature.
+ *
+ *  Returns the signature as a lowercase hex string — same format Bybit's
+ *  `X-BAPI-SIGN` header expects. The output is deterministic for a given
+ *  set of inputs, which is what makes the unit tests in
+ *  `tests/lib/exchange/bybitAuth.test.ts` possible. */
+export function signBybit(
+  secret: string,
+  timestamp: string,
+  apiKey: string,
+  payload: string,
+  recvWindow: string = BYBIT_RECV_WINDOW,
+): string {
+  return createHmac("sha256", secret)
+    .update(`${timestamp}${apiKey}${recvWindow}${payload}`)
+    .digest("hex");
+}
+
+/** Build the four standard `X-BAPI-*` headers plus a User-Agent string.
+ *
+ *  `userAgent` is required (no default) — Bybit-side traffic logs are
+ *  much easier to debug when each module identifies itself, and we never
+ *  want a generic Node-default UA leaking out. The existing call sites
+ *  use:
+ *    - bybitOrder         → "botmarketplace-terminal/1"
+ *    - balanceReconciler  → "botmarketplace-balance/1"
+ *    - windowDetector     → "botmarketplace-funding/1"
+ */
+export function bybitAuthHeaders(
+  apiKey: string,
+  secret: string,
+  timestamp: string,
+  payload: string,
+  userAgent: string,
+  recvWindow: string = BYBIT_RECV_WINDOW,
+): Record<string, string> {
+  return {
+    "X-BAPI-API-KEY": apiKey,
+    "X-BAPI-SIGN": signBybit(secret, timestamp, apiKey, payload, recvWindow),
+    "X-BAPI-TIMESTAMP": timestamp,
+    "X-BAPI-RECV-WINDOW": recvWindow,
+    "User-Agent": userAgent,
+  };
+}

--- a/apps/api/src/lib/funding/windowDetector.ts
+++ b/apps/api/src/lib/funding/windowDetector.ts
@@ -32,9 +32,9 @@
  * `FundingSnapshot.nextFundingAt`; this module is read-only on that table.
  */
 
-import { createHmac } from "node:crypto";
 import { prisma } from "../prisma.js";
 import { getBybitBaseUrl } from "../bybitOrder.js";
+import { bybitAuthHeaders } from "../exchange/bybitAuth.js";
 import { logger } from "../logger.js";
 
 const log = logger.child({ module: "windowDetector" });
@@ -43,7 +43,6 @@ export const ENTRY_PRE_BUFFER_MS = 30 * 60_000; // 30 min before funding
 export const PAYMENT_LAG_MS = 60_000;           // 1 min after funding
 export const PAYMENT_WINDOW_MS = 30 * 60_000;   // 30 min payment window
 
-const RECV_WINDOW = "5000";
 const USER_AGENT = "botmarketplace-funding/1";
 /** Pull a few rows in case multiple SETTLEMENT events land in the same
  *  query window; we only need to know that ≥1 matches. Bybit's max here
@@ -209,19 +208,10 @@ async function queryFundingLedger(q: FundingLedgerQuery): Promise<boolean> {
   };
   const qs = new URLSearchParams(params).toString();
   const timestamp = Date.now().toString();
-  const sign = createHmac("sha256", q.creds.secret)
-    .update(`${timestamp}${q.creds.apiKey}${RECV_WINDOW}${qs}`)
-    .digest("hex");
 
   const url = `${getBybitBaseUrl()}/v5/account/transaction-log?${qs}`;
   const res = await fetch(url, {
-    headers: {
-      "X-BAPI-API-KEY": q.creds.apiKey,
-      "X-BAPI-SIGN": sign,
-      "X-BAPI-TIMESTAMP": timestamp,
-      "X-BAPI-RECV-WINDOW": RECV_WINDOW,
-      "User-Agent": USER_AGENT,
-    },
+    headers: bybitAuthHeaders(q.creds.apiKey, q.creds.secret, timestamp, qs, USER_AGENT),
   });
   if (!res.ok) {
     throw new Error(`Bybit ledger HTTP ${res.status} ${res.statusText}`);

--- a/apps/api/tests/lib/exchange/bybitAuth.test.ts
+++ b/apps/api/tests/lib/exchange/bybitAuth.test.ts
@@ -1,0 +1,122 @@
+/**
+ * bybitAuth — deterministic-output unit coverage for the shared
+ * Bybit V5 HMAC signature helpers.
+ *
+ * The signature is the linchpin every Bybit caller (`bybitOrder`,
+ * `balanceReconciler`, `windowDetector`) depends on, so the test
+ * suite pins the exact spec layout — `${ts}${apiKey}${recvWindow}${payload}`
+ * — and asserts every part of the header bundle. If any of these
+ * drift, every Bybit request from the platform would silently start
+ * returning Bybit's `-101` "invalid signature" response.
+ */
+
+import { createHmac } from "node:crypto";
+import { describe, it, expect } from "vitest";
+
+import {
+  signBybit,
+  bybitAuthHeaders,
+  BYBIT_RECV_WINDOW,
+} from "../../../src/lib/exchange/bybitAuth.js";
+
+// Reference inputs — chosen so the signature is easy to recompute by
+// hand if the spec ever needs to be re-verified.
+const SECRET = "test-secret-abc";
+const API_KEY = "test-key-123";
+const TIMESTAMP = "1714665600000";
+const PAYLOAD_GET = "category=linear&symbol=BTCUSDT";
+const PAYLOAD_POST = JSON.stringify({ category: "spot", side: "Buy" });
+const USER_AGENT = "test-suite/1";
+
+function expectedSig(payload: string, recvWindow: string = BYBIT_RECV_WINDOW): string {
+  return createHmac("sha256", SECRET)
+    .update(`${TIMESTAMP}${API_KEY}${recvWindow}${payload}`)
+    .digest("hex");
+}
+
+describe("signBybit", () => {
+  it("matches the V5 pre-sign layout: ts + apiKey + recvWindow + payload", () => {
+    const got = signBybit(SECRET, TIMESTAMP, API_KEY, PAYLOAD_GET);
+    expect(got).toBe(expectedSig(PAYLOAD_GET));
+  });
+
+  it("is deterministic — same inputs produce the same hex", () => {
+    const a = signBybit(SECRET, TIMESTAMP, API_KEY, PAYLOAD_POST);
+    const b = signBybit(SECRET, TIMESTAMP, API_KEY, PAYLOAD_POST);
+    expect(a).toBe(b);
+  });
+
+  it("changes when ANY input changes — defence against silent partial-input bugs", () => {
+    const baseline = signBybit(SECRET, TIMESTAMP, API_KEY, PAYLOAD_GET);
+    expect(signBybit("other-secret", TIMESTAMP, API_KEY, PAYLOAD_GET)).not.toBe(baseline);
+    expect(signBybit(SECRET, "9999999999999", API_KEY, PAYLOAD_GET)).not.toBe(baseline);
+    expect(signBybit(SECRET, TIMESTAMP, "other-key", PAYLOAD_GET)).not.toBe(baseline);
+    expect(signBybit(SECRET, TIMESTAMP, API_KEY, "other=payload")).not.toBe(baseline);
+  });
+
+  it("honours an explicit non-default recvWindow", () => {
+    const got = signBybit(SECRET, TIMESTAMP, API_KEY, PAYLOAD_GET, "10000");
+    expect(got).toBe(expectedSig(PAYLOAD_GET, "10000"));
+    // And differs from the default recvWindow signature.
+    expect(got).not.toBe(signBybit(SECRET, TIMESTAMP, API_KEY, PAYLOAD_GET));
+  });
+
+  it("returns lowercase hex — Bybit V5 expects this format on the wire", () => {
+    const got = signBybit(SECRET, TIMESTAMP, API_KEY, PAYLOAD_GET);
+    expect(got).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe("bybitAuthHeaders", () => {
+  it("returns the four X-BAPI-* headers + User-Agent", () => {
+    const headers = bybitAuthHeaders(API_KEY, SECRET, TIMESTAMP, PAYLOAD_GET, USER_AGENT);
+    expect(Object.keys(headers).sort()).toEqual([
+      "User-Agent",
+      "X-BAPI-API-KEY",
+      "X-BAPI-RECV-WINDOW",
+      "X-BAPI-SIGN",
+      "X-BAPI-TIMESTAMP",
+    ]);
+  });
+
+  it("X-BAPI-SIGN matches signBybit() for the same inputs", () => {
+    const headers = bybitAuthHeaders(API_KEY, SECRET, TIMESTAMP, PAYLOAD_GET, USER_AGENT);
+    expect(headers["X-BAPI-SIGN"]).toBe(signBybit(SECRET, TIMESTAMP, API_KEY, PAYLOAD_GET));
+  });
+
+  it("populates the simple-passthrough headers verbatim", () => {
+    const headers = bybitAuthHeaders(API_KEY, SECRET, TIMESTAMP, PAYLOAD_GET, USER_AGENT);
+    expect(headers["X-BAPI-API-KEY"]).toBe(API_KEY);
+    expect(headers["X-BAPI-TIMESTAMP"]).toBe(TIMESTAMP);
+    expect(headers["X-BAPI-RECV-WINDOW"]).toBe(BYBIT_RECV_WINDOW);
+    expect(headers["User-Agent"]).toBe(USER_AGENT);
+  });
+
+  it("propagates a custom recvWindow into both X-BAPI-RECV-WINDOW and the signature", () => {
+    const headers = bybitAuthHeaders(
+      API_KEY,
+      SECRET,
+      TIMESTAMP,
+      PAYLOAD_GET,
+      USER_AGENT,
+      "10000",
+    );
+    expect(headers["X-BAPI-RECV-WINDOW"]).toBe("10000");
+    expect(headers["X-BAPI-SIGN"]).toBe(expectedSig(PAYLOAD_GET, "10000"));
+  });
+
+  it("does NOT leak the secret in any header", () => {
+    const headers = bybitAuthHeaders(API_KEY, SECRET, TIMESTAMP, PAYLOAD_GET, USER_AGENT);
+    for (const value of Object.values(headers)) {
+      expect(value).not.toContain(SECRET);
+    }
+  });
+});
+
+describe("BYBIT_RECV_WINDOW", () => {
+  it("is the legacy 5000ms value the inline copies all used", () => {
+    // Pinning this prevents a quiet bump that would invalidate every
+    // production signature on Bybit.
+    expect(BYBIT_RECV_WINDOW).toBe("5000");
+  });
+});


### PR DESCRIPTION
## Summary

Removes a 3-copy DRY violation that had been explicitly flagged in two prior PR descriptions (#365 funding ledger, #363 hedge executor): the same `sign(...)` HMAC-SHA256 helper plus a `authHeaders(...)` header builder had been duplicated verbatim across `bybitOrder.ts`, `balanceReconciler.ts`, and `funding/windowDetector.ts`. A divergence in any of the three would silently produce `-101` invalid-signature responses from Bybit on a single subset of the platform's requests, with no compile-time signal.

## Changes

**1. New `apps/api/src/lib/exchange/bybitAuth.ts`**
- `signBybit(secret, timestamp, apiKey, payload, recvWindow?)` — canonical Bybit V5 HMAC-SHA256 hex digest. Pre-sign layout `${ts}${apiKey}${recvWindow}${payload}` is pinned by tests.
- `bybitAuthHeaders(apiKey, secret, timestamp, payload, userAgent, recvWindow?)` — returns the four `X-BAPI-*` headers + a caller-supplied User-Agent. UA is required (no default) so each module identifies itself in Bybit-side traffic logs.
- `BYBIT_RECV_WINDOW = "5000"` named constant, pinned by test.

**2. `bybitOrder.ts`** — Inline `sign` + `authHeaders` deleted; two call sites now use the shared helper. `USER_AGENT = "botmarketplace-terminal/1"` retained.
**3. `balanceReconciler.ts`** — Same cleanup; `USER_AGENT = "botmarketplace-reconciler/1"` retained.
**4. `funding/windowDetector.ts`** — Inline `createHmac` block in `queryFundingLedger` replaced; `USER_AGENT = "botmarketplace-funding/1"` retained.

## Tests

`tests/lib/exchange/bybitAuth.test.ts` — 11 cases covering:
- Spec-layout pin (`${ts}${apiKey}${recvWindow}${payload}`).
- Determinism, sensitivity to each input changing, custom `recvWindow`.
- Lowercase-hex format (`/^[0-9a-f]{64}$/`).
- Header bundle shape (exactly 5 keys).
- `X-BAPI-SIGN` ↔ `signBybit` consistency.
- Secret never leaks into any header value.
- `BYBIT_RECV_WINDOW = "5000"` pin.

Existing tests for the three refactored callers (`balanceReconciler` 9/9, `windowDetector` 18/18, `bybitOrder` consumers in `routes/terminal` + `intentExecutor` + `hedges` + others) **pass unchanged** — refactor preserves behaviour, no test surface needed updating.

## Test plan

- [x] `pnpm --filter @botmarketplace/api exec tsc --noEmit` — clean
- [x] `pnpm --filter @botmarketplace/api exec vitest run tests/lib/exchange/bybitAuth.test.ts tests/lib/exchange/balanceReconciler.test.ts tests/lib/funding/windowDetector.test.ts` — 38/38
- [x] `pnpm --filter @botmarketplace/api test` — **2178/2178** (was 2167; +11 new)

## Net diff

56 lines deleted from callers, 60 LOC added in the shared module — break-even on volume but eliminates divergence risk.

https://claude.ai/code/session_01XoMMe56sv7QDkoovGn9Lww

---
_Generated by [Claude Code](https://claude.ai/code/session_01XoMMe56sv7QDkoovGn9Lww)_