### PR TITLE
feat(lab): funding scanner UI page at /lab/funding (55-T3)

### DIFF
--- a/apps/web/src/app/lab/funding/CandidatesTable.tsx
+++ b/apps/web/src/app/lab/funding/CandidatesTable.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  instantiatePreset,
+  type InstantiateOverrides,
+} from "../../../lib/api/presets";
+import type { FundingCandidate } from "../../../lib/api/funding";
+import type { ProblemDetails } from "../../../lib/api";
+
+/**
+ * Sortable funding candidates table (docs/55-T3 §UI).
+ *
+ * One row per candidate. Click any column header to sort; clicking the
+ * same column twice toggles asc/desc. The default sort is
+ * `annualizedYieldPct DESC` — the operator's "best opportunity" view.
+ *
+ * The "Open hedge bot" action instantiates the funding-arb preset with
+ * just the `symbol` overridden — every other field falls through to the
+ * preset's `defaultBotConfigJson` (BTCUSDT defaults). The current row's
+ * symbol replaces it. Successful instantiation routes to the new bot's
+ * factory page.
+ *
+ * Beta-state caveat: the funding-arb preset is published with
+ * `visibility = "BETA"` (PR #366), so non-admin operators can already
+ * use it from the library — the action button here is just a shortcut
+ * out of the scanner table.
+ */
+
+type SortKey = keyof Pick<
+  FundingCandidate,
+  "symbol" | "currentRate" | "annualizedYieldPct" | "basisBps" | "streak"
+> | "nextFundingAt";
+
+type SortDir = "asc" | "desc";
+
+const FUNDING_ARB_SLUG = "funding-arb";
+
+export function CandidatesTable({
+  candidates,
+}: {
+  candidates: FundingCandidate[];
+}) {
+  const router = useRouter();
+  const [sortKey, setSortKey] = useState<SortKey>("annualizedYieldPct");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<ProblemDetails | string | null>(null);
+
+  const sorted = useMemo(() => {
+    const copy = [...candidates];
+    copy.sort((a, b) => {
+      const av = a[sortKey];
+      const bv = b[sortKey];
+      // null `nextFundingAt` rows sink to the bottom regardless of dir.
+      if (av == null && bv == null) return 0;
+      if (av == null) return 1;
+      if (bv == null) return -1;
+      if (typeof av === "number" && typeof bv === "number") {
+        return sortDir === "asc" ? av - bv : bv - av;
+      }
+      const as = String(av);
+      const bs = String(bv);
+      return sortDir === "asc" ? as.localeCompare(bs) : bs.localeCompare(as);
+    });
+    return copy;
+  }, [candidates, sortKey, sortDir]);
+
+  function toggleSort(key: SortKey) {
+    if (sortKey === key) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      // First click on a new column picks the most-useful default
+      // direction for that field — descending for numeric metrics
+      // (higher yield first), ascending for symbol/time.
+      setSortDir(key === "symbol" || key === "nextFundingAt" ? "asc" : "desc");
+    }
+  }
+
+  async function handleOpenHedgeBot(symbol: string) {
+    setError(null);
+    setBusy(symbol);
+    const overrides: InstantiateOverrides = { symbol };
+    const res = await instantiatePreset(FUNDING_ARB_SLUG, { overrides });
+    setBusy(null);
+    if (!res.ok) {
+      setError(res.problem);
+      return;
+    }
+    router.push(`/factory/bots/${res.data.botId}`);
+  }
+
+  return (
+    <div>
+      {error && (
+        <div style={errorBoxStyle}>
+          {typeof error === "string" ? (
+            error
+          ) : (
+            <>
+              <strong>{error.title}:</strong> {error.detail}
+            </>
+          )}
+        </div>
+      )}
+      <div style={tableScrollStyle}>
+        <table style={tableStyle}>
+          <thead>
+            <tr>
+              <Th label="Symbol" sortKey="symbol" current={sortKey} dir={sortDir} onSort={toggleSort} />
+              <Th label="Funding (8h)" sortKey="currentRate" current={sortKey} dir={sortDir} onSort={toggleSort} align="right" />
+              <Th label="Annualized" sortKey="annualizedYieldPct" current={sortKey} dir={sortDir} onSort={toggleSort} align="right" />
+              <Th label="Basis (bps)" sortKey="basisBps" current={sortKey} dir={sortDir} onSort={toggleSort} align="right" />
+              <Th label="Streak" sortKey="streak" current={sortKey} dir={sortDir} onSort={toggleSort} align="right" />
+              <Th label="Next funding" sortKey="nextFundingAt" current={sortKey} dir={sortDir} onSort={toggleSort} />
+              <th style={thActionStyle}>Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((c) => (
+              <tr key={c.symbol} style={trStyle}>
+                <td style={tdSymbolStyle}>{c.symbol}</td>
+                <td style={tdNumStyle}>{formatFundingRate(c.currentRate)}</td>
+                <td style={tdNumStyle}>{formatPct(c.annualizedYieldPct)}</td>
+                <td style={tdNumStyle}>{c.basisBps.toFixed(1)}</td>
+                <td style={tdNumStyle}>{c.streak}</td>
+                <td style={tdStyle}>{formatNextFunding(c.nextFundingAt)}</td>
+                <td style={tdActionStyle}>
+                  <button
+                    type="button"
+                    onClick={() => handleOpenHedgeBot(c.symbol)}
+                    disabled={busy !== null}
+                    style={busy === c.symbol ? actionBtnBusyStyle : actionBtnStyle}
+                    title="Instantiate the funding-arb preset with this symbol"
+                  >
+                    {busy === c.symbol ? "Opening…" : "Open hedge bot"}
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function Th({
+  label,
+  sortKey,
+  current,
+  dir,
+  onSort,
+  align,
+}: {
+  label: string;
+  sortKey: SortKey;
+  current: SortKey;
+  dir: SortDir;
+  onSort: (k: SortKey) => void;
+  align?: "right";
+}) {
+  const active = current === sortKey;
+  const indicator = active ? (dir === "asc" ? " ▲" : " ▼") : "";
+  return (
+    <th
+      style={{
+        ...thStyle,
+        ...(align === "right" ? { textAlign: "right" } : null),
+        ...(active ? { color: "var(--text-primary)" } : null),
+      }}
+    >
+      <button type="button" onClick={() => onSort(sortKey)} style={thBtnStyle}>
+        {label}
+        {indicator}
+      </button>
+    </th>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Formatters
+// ---------------------------------------------------------------------------
+
+function formatFundingRate(rate: number): string {
+  // Decimal → percent, 4 sig digits. 0.0001 → "0.0100%".
+  return `${(rate * 100).toFixed(4)}%`;
+}
+
+function formatPct(pct: number): string {
+  return `${pct.toFixed(2)}%`;
+}
+
+function formatNextFunding(iso: string | null): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  // Shows in operator's local TZ. Format: "May 04 16:00".
+  return d.toLocaleString(undefined, {
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Styles — match the lab/library page conventions (CSS vars, no Tailwind).
+// ---------------------------------------------------------------------------
+
+const tableScrollStyle: React.CSSProperties = {
+  overflowX: "auto",
+  border: "1px solid var(--border)",
+  borderRadius: 6,
+};
+
+const tableStyle: React.CSSProperties = {
+  width: "100%",
+  borderCollapse: "collapse",
+  fontSize: 13,
+};
+
+const thStyle: React.CSSProperties = {
+  textAlign: "left",
+  padding: "10px 12px",
+  background: "var(--bg-secondary)",
+  borderBottom: "1px solid var(--border)",
+  color: "var(--text-secondary)",
+  fontWeight: 600,
+  whiteSpace: "nowrap",
+};
+
+const thActionStyle: React.CSSProperties = {
+  ...thStyle,
+  textAlign: "right",
+};
+
+const thBtnStyle: React.CSSProperties = {
+  background: "transparent",
+  border: "none",
+  color: "inherit",
+  font: "inherit",
+  padding: 0,
+  cursor: "pointer",
+  textTransform: "uppercase",
+  letterSpacing: "0.04em",
+  fontSize: 11,
+};
+
+const trStyle: React.CSSProperties = {
+  borderBottom: "1px solid var(--border)",
+};
+
+const tdStyle: React.CSSProperties = {
+  padding: "10px 12px",
+  color: "var(--text-primary)",
+  whiteSpace: "nowrap",
+};
+
+const tdSymbolStyle: React.CSSProperties = {
+  ...tdStyle,
+  fontWeight: 600,
+  fontFamily: "'SF Mono', 'Fira Code', monospace",
+};
+
+const tdNumStyle: React.CSSProperties = {
+  ...tdStyle,
+  textAlign: "right",
+  fontFamily: "'SF Mono', 'Fira Code', monospace",
+};
+
+const tdActionStyle: React.CSSProperties = {
+  padding: "8px 12px",
+  textAlign: "right",
+};
+
+const actionBtnStyle: React.CSSProperties = {
+  padding: "5px 10px",
+  background: "var(--accent)",
+  color: "#fff",
+  border: "none",
+  borderRadius: 4,
+  cursor: "pointer",
+  fontSize: 12,
+  fontWeight: 600,
+  fontFamily: "inherit",
+};
+
+const actionBtnBusyStyle: React.CSSProperties = {
+  ...actionBtnStyle,
+  background: "var(--bg-secondary)",
+  color: "var(--text-secondary)",
+  cursor: "wait",
+};
+
+const errorBoxStyle: React.CSSProperties = {
+  background: "rgba(248,113,113,0.08)",
+  border: "1px solid rgba(248,113,113,0.4)",
+  borderRadius: 6,
+  padding: "8px 12px",
+  marginBottom: 12,
+  fontSize: 13,
+  color: "#fca5a5",
+};

--- a/apps/web/src/app/lab/funding/page.tsx
+++ b/apps/web/src/app/lab/funding/page.tsx
@@ -1,0 +1,362 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  scanFundingCandidates,
+  type FundingCandidate,
+  type ScannerOptions,
+} from "../../../lib/api/funding";
+import { getToken, getWorkspaceId, type ProblemDetails } from "../../../lib/api";
+import { CandidatesTable } from "./CandidatesTable";
+
+/**
+ * Lab → Funding scanner page (docs/55-T3 §UI).
+ *
+ * Lists ranked funding-arb candidates returned by the API scanner with
+ * filter inputs (min yield, max basis, min streak, top-N). Each row
+ * carries an "Open hedge bot" action that instantiates the funding-arb
+ * preset with the row's symbol.
+ *
+ * Page-level concerns (auth, workspace, top-of-page error / empty state,
+ * filter form, scan trigger) live here. Per-row sort + action live in
+ * `CandidatesTable.tsx` to keep the file sizes manageable.
+ */
+
+const DEFAULT_OPTS: ScannerOptions = {
+  minYield: 5,
+  maxBasis: 50,
+  minStreak: 3,
+  limit: 20,
+};
+
+export default function LabFundingPage() {
+  const router = useRouter();
+
+  const [opts, setOpts] = useState<ScannerOptions>(DEFAULT_OPTS);
+  const [candidates, setCandidates] = useState<FundingCandidate[] | null>(null);
+  const [updatedAt, setUpdatedAt] = useState<string | null>(null);
+  const [scanning, setScanning] = useState(false);
+  const [error, setError] = useState<ProblemDetails | null>(null);
+
+  // Auth gate — same posture as /exchanges and other authenticated pages.
+  useEffect(() => {
+    if (!getToken()) {
+      router.push("/login");
+    }
+  }, [router]);
+
+  const runScan = useCallback(async () => {
+    setScanning(true);
+    setError(null);
+    const res = await scanFundingCandidates(opts);
+    setScanning(false);
+    if (!res.ok) {
+      setError(res.problem);
+      return;
+    }
+    setCandidates(res.data.candidates);
+    setUpdatedAt(res.data.updatedAt);
+  }, [opts]);
+
+  // Run an initial scan on mount so the page is not blank — matches the
+  // expected operator workflow ("open the page → see today's candidates").
+  useEffect(() => {
+    void runScan();
+    // Intentionally not depending on runScan: we only auto-scan on first
+    // mount. Subsequent scans are explicit via the button.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const workspaceId = getWorkspaceId();
+
+  return (
+    <div style={pageStyle}>
+      <header style={headerStyle}>
+        <div>
+          <h1 style={titleStyle}>Funding Scanner</h1>
+          <p style={subtitleStyle}>
+            Ranked funding-arbitrage candidates from the last 7 days. Click
+            a column header to sort. Use{" "}
+            <strong style={{ color: "#F59E0B" }}>Open hedge bot</strong> to
+            spin up a funding-arb bot on that symbol.
+          </p>
+        </div>
+        <div style={updatedStyle}>
+          {updatedAt ? (
+            <>
+              <span style={{ color: "var(--text-secondary)" }}>Last scan:</span>{" "}
+              {new Date(updatedAt).toLocaleTimeString()}
+            </>
+          ) : (
+            <span style={{ color: "var(--text-secondary)" }}>Not scanned yet</span>
+          )}
+        </div>
+      </header>
+
+      {!workspaceId && (
+        <div style={warnBoxStyle}>
+          No active workspace. Set one on the Factory page before opening a
+          hedge bot — instantiation will otherwise fail.
+        </div>
+      )}
+
+      <FilterBar
+        opts={opts}
+        scanning={scanning}
+        onChange={setOpts}
+        onScan={runScan}
+      />
+
+      {error && (
+        <div style={errorBoxStyle}>
+          <strong>{error.title}:</strong> {error.detail}
+        </div>
+      )}
+
+      {scanning && candidates === null && (
+        <p style={emptyStyle}>Scanning…</p>
+      )}
+
+      {!scanning && candidates !== null && candidates.length === 0 && (
+        <div style={emptyBoxStyle}>
+          <p style={{ margin: 0, fontSize: 14, color: "var(--text-primary)" }}>
+            No candidates match the current filters.
+          </p>
+          <p style={{ margin: "6px 0 0", fontSize: 13, color: "var(--text-secondary)" }}>
+            Try lowering Min yield or relaxing Max basis. The scanner reads
+            from the last 7 days of funding snapshots — make sure the data
+            cron has run recently.
+          </p>
+        </div>
+      )}
+
+      {candidates !== null && candidates.length > 0 && (
+        <CandidatesTable candidates={candidates} />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Filter bar
+// ---------------------------------------------------------------------------
+
+function FilterBar({
+  opts,
+  scanning,
+  onChange,
+  onScan,
+}: {
+  opts: ScannerOptions;
+  scanning: boolean;
+  onChange: (next: ScannerOptions) => void;
+  onScan: () => void;
+}) {
+  function setField<K extends keyof ScannerOptions>(key: K, raw: string) {
+    const n = Number(raw);
+    onChange({ ...opts, [key]: Number.isFinite(n) ? n : undefined });
+  }
+
+  return (
+    <form
+      style={filterRowStyle}
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (!scanning) onScan();
+      }}
+    >
+      <Field label="Min yield (%)" hint="Default 5">
+        <input
+          type="number"
+          inputMode="decimal"
+          step="0.5"
+          min={0}
+          value={opts.minYield ?? ""}
+          onChange={(e) => setField("minYield", e.target.value)}
+          style={filterInputStyle}
+        />
+      </Field>
+      <Field label="Max basis (bps)" hint="Default 50">
+        <input
+          type="number"
+          inputMode="decimal"
+          step="1"
+          min={0}
+          value={opts.maxBasis ?? ""}
+          onChange={(e) => setField("maxBasis", e.target.value)}
+          style={filterInputStyle}
+        />
+      </Field>
+      <Field label="Min streak" hint="Default 3">
+        <input
+          type="number"
+          inputMode="numeric"
+          step="1"
+          min={1}
+          value={opts.minStreak ?? ""}
+          onChange={(e) => setField("minStreak", e.target.value)}
+          style={filterInputStyle}
+        />
+      </Field>
+      <Field label="Top N" hint="Default 20">
+        <input
+          type="number"
+          inputMode="numeric"
+          step="1"
+          min={1}
+          max={50}
+          value={opts.limit ?? ""}
+          onChange={(e) => setField("limit", e.target.value)}
+          style={filterInputStyle}
+        />
+      </Field>
+      <button type="submit" disabled={scanning} style={scanBtnStyle}>
+        {scanning ? "Scanning…" : "Scan now"}
+      </button>
+    </form>
+  );
+}
+
+function Field({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <label style={fieldLabelStyle}>
+      <span style={fieldLabelTextStyle}>
+        {label}
+        {hint && <span style={fieldHintStyle}> · {hint}</span>}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Styles — mirror lab/library/page.tsx (CSS variables, inline objects).
+// ---------------------------------------------------------------------------
+
+const pageStyle: React.CSSProperties = {
+  padding: "32px 24px 64px",
+  maxWidth: 1200,
+  margin: "0 auto",
+};
+
+const headerStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "flex-start",
+  justifyContent: "space-between",
+  gap: 16,
+  marginBottom: 20,
+  flexWrap: "wrap",
+};
+
+const titleStyle: React.CSSProperties = {
+  margin: 0,
+  fontSize: 22,
+  fontWeight: 600,
+  color: "var(--text-primary)",
+};
+
+const subtitleStyle: React.CSSProperties = {
+  margin: "4px 0 0",
+  color: "var(--text-secondary)",
+  fontSize: 13,
+  maxWidth: 720,
+  lineHeight: 1.5,
+};
+
+const updatedStyle: React.CSSProperties = {
+  fontSize: 12,
+  fontFamily: "'SF Mono', 'Fira Code', monospace",
+  color: "var(--text-primary)",
+};
+
+const filterRowStyle: React.CSSProperties = {
+  display: "flex",
+  gap: 12,
+  marginBottom: 16,
+  flexWrap: "wrap",
+  alignItems: "flex-end",
+};
+
+const fieldLabelStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: 4,
+};
+
+const fieldLabelTextStyle: React.CSSProperties = {
+  fontSize: 11,
+  textTransform: "uppercase",
+  letterSpacing: "0.05em",
+  color: "var(--text-secondary)",
+};
+
+const fieldHintStyle: React.CSSProperties = {
+  textTransform: "none",
+  letterSpacing: "0",
+  color: "rgba(255,255,255,0.35)",
+};
+
+const filterInputStyle: React.CSSProperties = {
+  padding: "6px 10px",
+  background: "var(--bg-secondary)",
+  border: "1px solid var(--border)",
+  borderRadius: 4,
+  color: "var(--text-primary)",
+  fontSize: 13,
+  fontFamily: "'SF Mono', 'Fira Code', monospace",
+  width: 110,
+};
+
+const scanBtnStyle: React.CSSProperties = {
+  padding: "8px 18px",
+  background: "var(--accent)",
+  color: "#fff",
+  border: "none",
+  borderRadius: 6,
+  cursor: "pointer",
+  fontSize: 13,
+  fontWeight: 600,
+  fontFamily: "inherit",
+};
+
+const emptyStyle: React.CSSProperties = {
+  color: "var(--text-secondary)",
+  fontSize: 14,
+};
+
+const emptyBoxStyle: React.CSSProperties = {
+  background: "var(--bg-secondary)",
+  border: "1px solid var(--border)",
+  borderRadius: 8,
+  padding: 24,
+  textAlign: "center",
+};
+
+const errorBoxStyle: React.CSSProperties = {
+  background: "rgba(248,113,113,0.08)",
+  border: "1px solid rgba(248,113,113,0.4)",
+  borderRadius: 6,
+  padding: "8px 12px",
+  marginBottom: 16,
+  fontSize: 13,
+  color: "#fca5a5",
+};
+
+const warnBoxStyle: React.CSSProperties = {
+  background: "rgba(251,191,36,0.08)",
+  border: "1px solid rgba(251,191,36,0.4)",
+  borderRadius: 6,
+  padding: "8px 12px",
+  marginBottom: 16,
+  fontSize: 13,
+  color: "#fbbf24",
+};

--- a/apps/web/src/lib/api/funding.ts
+++ b/apps/web/src/lib/api/funding.ts
@@ -1,0 +1,73 @@
+/**
+ * Typed client for the funding scanner endpoint (docs/55-T3 §UI).
+ *
+ * Wraps GET /terminal/funding/scanner. The route runs the
+ * `scanFundingCandidates` library against the last 7 days of
+ * FundingSnapshot rows joined with the latest SpreadSnapshot per
+ * symbol — see `apps/api/src/routes/funding.ts` for the
+ * implementation. This client is the single import point for the
+ * lab/funding page.
+ */
+
+import { apiFetch } from "../api";
+
+// ---------------------------------------------------------------------------
+// Types — match `apps/api/src/lib/funding/types.ts` exactly. The route
+// serialises `nextFundingAt` from ms epoch to ISO string before returning.
+// ---------------------------------------------------------------------------
+
+export interface FundingCandidate {
+  symbol: string;
+  /** Current funding rate (decimal, e.g. 0.0001 = 0.01%). */
+  currentRate: number;
+  /** Annualized funding yield as a percentage (e.g. 10.95). */
+  annualizedYieldPct: number;
+  /** Current basis in basis points: (perp - spot) / spot * 10_000. */
+  basisBps: number;
+  /** Number of consecutive same-sign funding periods. */
+  streak: number;
+  /** Average funding rate over the lookback window (decimal). */
+  avgRate: number;
+  /** Next funding settlement time as ISO-8601 string, or null when no
+   *  snapshot is available yet for the candidate. */
+  nextFundingAt: string | null;
+}
+
+export interface ScannerResponse {
+  candidates: FundingCandidate[];
+  /** Server-side scan timestamp (ISO-8601). Useful so the UI can show a
+   *  "scanned at" label distinct from the page load time. */
+  updatedAt: string;
+}
+
+export interface ScannerOptions {
+  /** Minimum absolute annualized yield (%) to qualify. Default 5. */
+  minYield?: number;
+  /** Maximum absolute basis (bps) to qualify. Default 50. */
+  maxBasis?: number;
+  /** Minimum consecutive same-sign funding streak. Default 3. */
+  minStreak?: number;
+  /** Top-N candidates to return. Default 10. */
+  limit?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint
+// ---------------------------------------------------------------------------
+
+function buildQuery(opts: ScannerOptions): string {
+  const params: string[] = [];
+  if (opts.minYield !== undefined) params.push(`minYield=${opts.minYield}`);
+  if (opts.maxBasis !== undefined) params.push(`maxBasis=${opts.maxBasis}`);
+  if (opts.minStreak !== undefined) params.push(`minStreak=${opts.minStreak}`);
+  if (opts.limit !== undefined) params.push(`limit=${opts.limit}`);
+  return params.length > 0 ? `?${params.join("&")}` : "";
+}
+
+/**
+ * Run the funding scanner with the given thresholds. Returns the ranked
+ * candidates plus the server-side `updatedAt` timestamp.
+ */
+export function scanFundingCandidates(opts: ScannerOptions = {}) {
+  return apiFetch<ScannerResponse>(`/terminal/funding/scanner${buildQuery(opts)}`);
+}


### PR DESCRIPTION
## Summary

Closes the **docs/55-T3 §UI** deliverable. The funding scanner page lives under `/lab/` alongside the strategy library — it's the strategic-level view ("which symbols are worth a long-running funding-arb bot right now"). Calls existing `GET /terminal/funding/scanner` (landed in #356) and wires "Open hedge bot" actions to the funding-arb preset (#357 / #366).

## Coexistence note: `/terminal/funding` (existing) vs `/lab/funding` (new)

Both pages already share the scanner backend but address different operator workflows:

| | `/terminal/funding` (663 LOC, pre-existing) | `/lab/funding` (this PR) |
|--|--|--|
| Audience | Manual operator | Strategy operator |
| Action | POSTs `/hedges/entry` + `/hedges/:id/execute` directly — fires a one-shot hedge | Instantiates `funding-arb` preset → creates a long-running Bot |
| Lifecycle | Manual creation → manual exit | Bot runs the full cycle (scan → entry → wait funding → exit) |

They are complementary; this PR doesn't touch the existing terminal page.

## Files

**1. `apps/web/src/lib/api/funding.ts` (~70 LOC)**
- Typed `FundingCandidate` matching `apps/api/src/lib/funding/types.ts`. The route serialises `nextFundingAt: number → ISO string`, reflected in the client type.
- `scanFundingCandidates(opts)` → `GET /terminal/funding/scanner?minYield&maxBasis&minStreak&limit`.

**2. `apps/web/src/app/lab/funding/page.tsx` (~280 LOC)**
- Auth gate (redirect to `/login` if no token, same posture as `/exchanges`).
- Workspace warning when `X-Workspace-Id` is unset — instantiation would otherwise fail downstream.
- Filter bar: 4 numeric inputs (Min yield, Max basis, Min streak, Top N) with sensible defaults (5, 50, 3, 20).
- Auto-runs an initial scan on mount; subsequent scans are explicit via the "Scan now" submit button.
- Last-scan timestamp shown in operator's local TZ.

**3. `apps/web/src/app/lab/funding/CandidatesTable.tsx` (~250 LOC)**
- Sortable: clicking a column header sets sortKey + flips direction; new column picks the most-useful default (descending for numeric metrics, ascending for symbol / nextFundingAt).
- Default sort: `annualizedYieldPct DESC`.
- Null `nextFundingAt` rows sink to the bottom regardless of direction.
- **"Open hedge bot"** action: `instantiatePreset("funding-arb", { overrides: { symbol } })` → `router.push` to the new bot's factory page on success. Only `symbol` is overridden; everything else falls through to the preset's `defaultBotConfigJson` (BTCUSDT-shaped baseline, M15, FUNDING_ARB mode).
- Per-row busy state — only the clicked button shows "Opening…".
- Formatters: funding rate → percent (4 decimals), annualised yield → 2-decimal percent, basis → 1-decimal bps, next funding → operator-local time.

## Test plan

- [x] `pnpm --filter @botmarketplace/web exec tsc --noEmit` — clean.
- [x] `pnpm --filter @botmarketplace/web exec next build` — clean. New `/lab/funding` route is statically rendered (4.18 kB / 106 kB shared).
- [x] `pnpm --filter @botmarketplace/api test` — **2178/2178** (unchanged; no API surface touched).
- [ ] No `apps/web` test infrastructure exists — visual / flow smoke deferred to post-deploy mobile browser pass.

https://claude.ai/code/session_01XoMMe56sv7QDkoovGn9Lww

---
_Generated by [Claude Code](https://claude.ai/code/session_01XoMMe56sv7QDkoovGn9Lww)_