### PR TITLE
fix(lab/funding): SSR/client hydration mismatch on workspace warning (#370 follow-up)

### DIFF
--- a/apps/web/src/app/lab/funding/page.tsx
+++ b/apps/web/src/app/lab/funding/page.tsx
@@ -39,6 +39,20 @@ export default function LabFundingPage() {
   const [scanning, setScanning] = useState(false);
   const [error, setError] = useState<ProblemDetails | null>(null);
 
+  // workspaceId is read from localStorage which is undefined on the server.
+  // Reading it at render time produces SSR HTML with the "no workspace"
+  // warning visible, then the client may have a workspaceId and not render
+  // the warning → React error #418 hydration mismatch. Defer the read into
+  // a mount-time effect so the first client render matches the SSR pass,
+  // and gate the warning on `mounted` so it never flickers for users who
+  // do have a workspace set.
+  const [mounted, setMounted] = useState(false);
+  const [workspaceId, setWorkspaceIdState] = useState<string | null>(null);
+  useEffect(() => {
+    setWorkspaceIdState(getWorkspaceId());
+    setMounted(true);
+  }, []);
+
   // Auth gate — same posture as /exchanges and other authenticated pages.
   useEffect(() => {
     if (!getToken()) {
@@ -68,8 +82,6 @@ export default function LabFundingPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const workspaceId = getWorkspaceId();
-
   return (
     <div style={pageStyle}>
       <header style={headerStyle}>
@@ -94,7 +106,7 @@ export default function LabFundingPage() {
         </div>
       </header>
 
-      {!workspaceId && (
+      {mounted && !workspaceId && (
         <div style={warnBoxStyle}>
           No active workspace. Set one on the Factory page before opening a
           hedge bot — instantiation will otherwise fail.


### PR DESCRIPTION
## Summary

Smoke pass on the production deploy of PR #370 surfaced minified React error #418 ("HTML hydration mismatch") on `/lab/funding` render. This PR fixes it.

## Root cause

The page read `getWorkspaceId()` directly at render time. That helper:
```ts
export function getWorkspaceId(): string | null {
  if (typeof window === "undefined") return null;
  return localStorage.getItem("workspaceId");
}
```

For an authenticated operator with a workspace set:
- **SSR**: `workspaceId = null` → renders the "No active workspace" warn box.
- **Client**: `workspaceId = "ws-…"` → doesn't render the warn box.

Hydration sees the DOM tree differ → #418. Page recovers but logs a noisy error every load.

## Fix

Gate the localStorage read behind a mount-time `useEffect` so the first client render uses the same `null` as SSR, then update via state. A second `mounted` flag suppresses the warning until after the effect has resolved — without it, users **with** a workspace would briefly flash the warning on every navigation.

```ts
const [mounted, setMounted] = useState(false);
const [workspaceId, setWorkspaceIdState] = useState<string | null>(null);
useEffect(() => {
  setWorkspaceIdState(getWorkspaceId());
  setMounted(true);
}, []);
// ...
{mounted && !workspaceId && <warnBox … />}
```

## Note on `/lab/library`

That page has the **same bug** (calls `getWorkspaceId()` at render time + uses it in conditional rendering) but did not surface in the smoke because the test account had a workspace AND the symptom path differs. Fixing it is out of scope for this PR — opened as a backlog item alongside the deploy-key + auth-race issues from the smoke report.

## Test plan

- [x] `pnpm --filter @botmarketplace/web exec tsc --noEmit` — clean.
- [x] `pnpm --filter @botmarketplace/web exec next build` — clean. `/lab/funding` bundle size unchanged (4.18 kB).
- [ ] No web test infra in this repo; visual confirmation via re-smoke after deploy (browser console should no longer log #418 on `/lab/funding`).

https://claude.ai/code/session_01XoMMe56sv7QDkoovGn9Lww

---
_Generated by [Claude Code](https://claude.ai/code/session_01XoMMe56sv7QDkoovGn9Lww)_