### PR TITLE
deploy(ops): restart botmarket-worker + sync its unit file (session backlog)

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -80,7 +80,7 @@ fi
 # 6. Sync systemd units (reinstall if deploy/*.service changed in the repo)
 echo "[6/7] Syncing systemd units..."
 UNITS_CHANGED=0
-for svc in botmarket-api botmarket-web; do
+for svc in botmarket-api botmarket-web botmarket-worker; do
   src="$APP_DIR/deploy/$svc.service"
   dst="/etc/systemd/system/$svc.service"
   if [[ -f "$src" ]] && ! cmp -s "$src" "$dst" 2>/dev/null; then
@@ -98,13 +98,20 @@ fi
 echo "[7/7] Restarting services..."
 systemctl restart botmarket-api
 systemctl restart botmarket-web
+# botmarket-worker hosts the funding-arb hedge runtime + the DSL evaluator
+# loop. Skipping it leaves long-lived worker code stale across deploys —
+# any change to botWorker.ts / hedgeBotWorker.ts / intentExecutor.ts /
+# windowDetector.ts / preset evaluator does NOT take effect until the
+# unit is restarted explicitly. Always restart all three.
+systemctl restart botmarket-worker
 
 # Wait a moment and show status
 sleep 3
 echo ""
 echo "Service status:"
-systemctl is-active botmarket-api && echo "  ✓ botmarket-api is running" || echo "  ✗ botmarket-api FAILED"
-systemctl is-active botmarket-web  && echo "  ✓ botmarket-web is running"  || echo "  ✗ botmarket-web FAILED"
+systemctl is-active botmarket-api    && echo "  ✓ botmarket-api is running"    || echo "  ✗ botmarket-api FAILED"
+systemctl is-active botmarket-web    && echo "  ✓ botmarket-web is running"    || echo "  ✗ botmarket-web FAILED"
+systemctl is-active botmarket-worker && echo "  ✓ botmarket-worker is running" || echo "  ✗ botmarket-worker FAILED"
 
 echo ""
 DEPLOYED_REF=$(git describe --tags --always 2>/dev/null || git rev-parse --short HEAD)
@@ -113,6 +120,7 @@ echo ""
 echo "Done. Check logs with:"
 echo "  journalctl -u botmarket-api -f"
 echo "  journalctl -u botmarket-web -f"
+echo "  journalctl -u botmarket-worker -f"
 echo ""
 echo "Run smoke tests with:"
 echo "  bash deploy/smoke-test.sh"


### PR DESCRIPTION
## Summary

Session-flagged operational gap: `deploy.sh` restarts api + web but **not the worker**. The funding-arb pack landed in this session (#362–#371) ships substantial worker-side code — bot-scoped `hedgeBotWorker` delegation (#362), spot-leg execution + `processIntents` category dispatch (#363, #364), real Bybit ledger query in windowDetector (#365), shared `bybitAuth` helpers (#368), `executeIntentLegacy` removal (#369). Without a worker restart, all of that stays as cold `dist/worker.js` bytes, served by the old worker process across deploy boundaries.

Two production deploys this session (#370 + #371) hit the same workaround:

```sh
sudo systemctl restart botmarket-worker
```

run manually after `deploy.sh` exited. Closing the gap so future deploys don't need an out-of-band step.

## Changes (`deploy/deploy.sh` only)

1. **Step 6 (systemd unit sync)** — extend the sync loop from `{botmarket-api, botmarket-web}` to `{botmarket-api, botmarket-web, botmarket-worker}`. The unit file already exists in `deploy/` but was never copied to `/etc/systemd/system/` as part of deploy. Any future change to `botmarket-worker.service` (e.g. new `EnvironmentFile` entry) now propagates the same way as the api/web units.
2. **Step 7 (restart)** — append `systemctl restart botmarket-worker` after api + web. Honours the unit's existing `TimeoutStopSec` / `SendSIGKILL` config.
3. **Status check + log hint** — add `botmarket-worker` to both the per-service `is-active` probe and the `journalctl` command list at the end of the script.
4. **Inline comment** explaining WHY worker must restart on every deploy — makes the cost of skipping it explicit for any future operator considering a "minimal restart" optimisation.

## Verification

- [x] `bash -n deploy/deploy.sh` — syntax clean.
- [ ] No tests for shell scripts in this repo; first real exercise is the next production deploy. Expected outcome: VPS Claude no longer needs to call `sudo systemctl restart botmarket-worker` manually.

https://claude.ai/code/session_01XoMMe56sv7QDkoovGn9Lww

---
_Generated by [Claude Code](https://claude.ai/code/session_01XoMMe56sv7QDkoovGn9Lww)_