### PR TITLE
fix(lab/library): SSR/client hydration mismatch on workspace warning (mirror of #371)

### DIFF
--- a/apps/web/src/app/lab/library/page.tsx
+++ b/apps/web/src/app/lab/library/page.tsx
@@ -71,7 +71,21 @@ export default function LabLibraryPage() {
   }
 
   const selected = selectedSlug ? presets.find((p) => p.slug === selectedSlug) ?? null : null;
-  const workspaceId = getWorkspaceId();
+
+  // workspaceId is read from localStorage which is undefined on the server.
+  // Reading it at render time produces SSR HTML with the "no workspace"
+  // warning visible, then the client may have a workspaceId and not render
+  // the warning → React error #418 hydration mismatch (same bug as
+  // /lab/funding hit in PR #371). Defer the read into a mount-time
+  // `useEffect` so the first client render matches SSR, and gate the
+  // warning on `mounted` so it never flickers for users who do have a
+  // workspace set.
+  const [mounted, setMounted] = useState(false);
+  const [workspaceId, setWorkspaceIdState] = useState<string | null>(null);
+  useEffect(() => {
+    setWorkspaceIdState(getWorkspaceId());
+    setMounted(true);
+  }, []);
 
   return (
     <div style={pageStyle}>
@@ -91,7 +105,7 @@ export default function LabLibraryPage() {
         />
       </header>
 
-      {!workspaceId && (
+      {mounted && !workspaceId && (
         <div style={warnBoxStyle}>
           No active workspace. Set one on the Factory page before instantiating
           a preset.


### PR DESCRIPTION
## Summary

Same bug pattern that PR #370 surfaced + PR #371 fixed for `/lab/funding`, applied here to `/lab/library`. The smoke that caught it on `/lab/funding` explicitly noted the same issue exists in `/lab/library` but didn't surface because the test account had a workspace and the symptom path differs. Fix it now while the pattern is fresh.

## Root cause (verbatim from #371)

The page reads `getWorkspaceId()` at render time. The helper is SSR-safe (`if (typeof window === "undefined") return null`), so server renders with `workspaceId = null` → renders the "No active workspace" warning. On the client, `localStorage` may have a workspaceId, so the client renders without the warning. Hydration sees the DOM diverge → **React error #418**.

## Fix

Defer the localStorage read into a mount-time `useEffect`, and gate the warning on a `mounted` flag so users WITH a workspace don't briefly flash the warning before the effect resolves.

```ts
const [mounted, setMounted] = useState(false);
const [workspaceId, setWorkspaceIdState] = useState<string | null>(null);
useEffect(() => {
  setWorkspaceIdState(getWorkspaceId());
  setMounted(true);
}, []);
// ...
{mounted && !workspaceId && <warnBox … />}
```

`useState` / `useEffect` were already imported (used by the existing admin-token + load callbacks); no new imports needed.

## Test plan

- [x] `pnpm --filter @botmarketplace/web exec tsc --noEmit` — clean.
- [x] `pnpm --filter @botmarketplace/web exec next build` — clean. `/lab/library` bundle size unchanged.
- [ ] No web test infra; visual confirmation deferred to post-deploy re-smoke. Browser console should no longer log #418 on `/lab/library` for authenticated operators.

https://claude.ai/code/session_01XoMMe56sv7QDkoovGn9Lww

---
_Generated by [Claude Code](https://claude.ai/code/session_01XoMMe56sv7QDkoovGn9Lww)_