### PR TITLE
fix(lab): SSR/client hydration mismatch on /lab root (severe variant of #371/#374)

### DIFF
--- a/apps/web/src/app/lab/page.tsx
+++ b/apps/web/src/app/lab/page.tsx
@@ -1,12 +1,35 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { getWorkspaceId } from "../../lib/api";
 import { AuthLabClassicMode, GuestLabClassicMode } from "./ClassicMode";
 
 // Classic mode — default tab for /lab.
 // The LabShell wrapper (tabs, context bar, inspector, diagnostics) is
 // provided by layout.tsx; this page only returns the tab content.
+//
+// The Auth ↔ Guest split is decided by the presence of a workspaceId in
+// localStorage, which is undefined on the server. Reading it directly at
+// render time produced two completely different component trees on SSR
+// (Guest, no workspace) vs hydration (Auth, workspace present) — a much
+// larger DOM diff than a single conditional warning box, guaranteed to
+// trigger React error #418 for any logged-in operator. Defer the read
+// to a mount-time effect and render a tiny placeholder during the
+// pre-mount window so SSR + first client render agree.
 export default function LabPage() {
-  const hasWorkspace = !!getWorkspaceId();
+  const [mounted, setMounted] = useState(false);
+  const [hasWorkspace, setHasWorkspace] = useState(false);
+
+  useEffect(() => {
+    setHasWorkspace(!!getWorkspaceId());
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    // Tiny non-committal placeholder. Same DOM on SSR and the first
+    // client render, no localStorage read. The flicker is sub-frame on
+    // hydration so operators don't see it; the React tree just resolves.
+    return <div aria-hidden="true" style={{ minHeight: 1 }} />;
+  }
   return hasWorkspace ? <AuthLabClassicMode /> : <GuestLabClassicMode />;
 }


### PR DESCRIPTION
## Summary

Same root cause as PR #371 (`/lab/funding`) and #374 (`/lab/library`) — `getWorkspaceId()` reads `localStorage`, which is undefined on the server, so SSR and the first client render disagree on the workspace state. **This file's manifestation was the most severe of the three**: the value gates which **component tree** renders.

```tsx
// Before:
const hasWorkspace = !!getWorkspaceId();
return hasWorkspace ? <AuthLabClassicMode /> : <GuestLabClassicMode />;
```

| | `hasWorkspace` | Renders |
|--|--|--|
| SSR | `false` | `<GuestLabClassicMode>` |
| Client (logged-in operator) | `true` | `<AuthLabClassicMode>` |

Two **completely different DOM subtrees** collide at hydration. Guaranteed React #418 for every logged-in operator hitting `/lab`. Smoke didn't catch this earlier only because the runs hit `/lab/funding` and `/lab/library` directly without first stopping at `/lab`.

## Fix

Move the localStorage read into a `useEffect` and render a 1px non-committal placeholder during the pre-mount window so SSR + first client render produce the SAME DOM. After the effect runs, the real component swaps in.

```tsx
const [mounted, setMounted] = useState(false);
const [hasWorkspace, setHasWorkspace] = useState(false);
useEffect(() => {
  setHasWorkspace(!!getWorkspaceId());
  setMounted(true);
}, []);
if (!mounted) return <div aria-hidden="true" style={{ minHeight: 1 }} />;
return hasWorkspace ? <AuthLabClassicMode /> : <GuestLabClassicMode />;
```

**Why a placeholder instead of always rendering Guest first:** `GuestLabClassicMode` likely contains the public landing copy + log-in CTA. Rendering it during SSR for an authenticated operator would briefly flash "log in to continue" content before the auth view mounts — bad UX. The empty placeholder avoids both the hydration mismatch AND the unwanted content flash. Sub-frame flicker on hydration is invisible to operators.

## Other `getWorkspaceId()` callers — verified safe

Audited all `getWorkspaceId()` usages in `apps/web/src`:
- `ClassicMode.tsx` (lines 494, 508, 536): inside event handlers / callbacks, not at render time. **Safe.**
- `WalkForwardPanel.tsx`, `OptimisePanel.tsx`, `lab/test/page.tsx`: same — inside `if (!getWorkspaceId()) return` guards in submit / launch handlers. Not render-time. **Safe.**
- The three render-time consumers were `/lab/funding` (#371), `/lab/library` (#374), and `/lab` itself (this PR). With this PR all are fixed.

## Test plan

- [x] `pnpm --filter @botmarketplace/web exec tsc --noEmit` — clean.
- [x] `pnpm --filter @botmarketplace/web exec next build` — clean.
- [ ] No web test infra; visual confirmation deferred to post-deploy re-smoke. Browser console should no longer log #418 on `/lab`.

https://claude.ai/code/session_01XoMMe56sv7QDkoovGn9Lww

---
_Generated by [Claude Code](https://claude.ai/code/session_01XoMMe56sv7QDkoovGn9Lww)_