### PR TITLE
ops(systemd): harden api/web/worker units (docs/30 Phase 9)

### DIFF
--- a/deploy/botmarket-api.service
+++ b/deploy/botmarket-api.service
@@ -41,5 +41,16 @@ SyslogIdentifier=botmarket-api
 Environment=NODE_ENV=production
 Environment=PATH=/usr/bin:/usr/local/bin:/usr/local/share/pnpm
 
+# Hardening (docs/30 Phase 9). MemoryDenyWriteExecute is intentionally
+# omitted — V8 JIT requires writable+executable pages.
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+NoNewPrivileges=true
+RestrictNamespaces=true
+LockPersonality=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+ReadWritePaths=/opt/-botmarketplace-site /var/log
+
 [Install]
 WantedBy=multi-user.target

--- a/deploy/botmarket-web.service
+++ b/deploy/botmarket-web.service
@@ -39,5 +39,18 @@ SyslogIdentifier=botmarket-web
 Environment=NODE_ENV=production
 Environment=PORT=3000
 
+# Hardening (docs/30 Phase 9). MemoryDenyWriteExecute is intentionally
+# omitted — V8 JIT requires writable+executable pages. Web only writes
+# to .next/cache at runtime (Next.js fetch cache, ISR), so the writable
+# path is scoped to the build output directory.
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+NoNewPrivileges=true
+RestrictNamespaces=true
+LockPersonality=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+ReadWritePaths=/opt/-botmarketplace-site/apps/web/.next
+
 [Install]
 WantedBy=multi-user.target

--- a/deploy/botmarket-worker.service
+++ b/deploy/botmarket-worker.service
@@ -37,5 +37,20 @@ SyslogIdentifier=botmarket-worker
 Environment=NODE_ENV=production
 Environment=PATH=/usr/bin:/usr/local/bin:/usr/local/share/pnpm
 
+# Hardening (docs/30 Phase 9). MemoryDenyWriteExecute is intentionally
+# omitted — V8 JIT requires writable+executable pages.
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+NoNewPrivileges=true
+RestrictNamespaces=true
+LockPersonality=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+ReadWritePaths=/opt/-botmarketplace-site /var/log
+
+# Worker never binds a listening socket — drop all capabilities.
+CapabilityBoundingSet=
+AmbientCapabilities=
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

Apply standard sandboxing directives to all three `botmarket-*` systemd
unit files. Closes the bulk of docs/30 Phase 9.

Common to all three units:

- `ProtectSystem=strict`
- `ProtectHome=true`
- `PrivateTmp=true`
- `NoNewPrivileges=true`
- `RestrictNamespaces=true`
- `LockPersonality=true`
- `RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX`
- `ReadWritePaths=` (scoped per-unit, see below)

Per-unit details:

| Unit | `ReadWritePaths` | Extras |
|---|---|---|
| `botmarket-api`    | `/opt/-botmarketplace-site /var/log` | — |
| `botmarket-worker` | `/opt/-botmarketplace-site /var/log` | `CapabilityBoundingSet=` + `AmbientCapabilities=` (worker never binds a listening socket) |
| `botmarket-web`    | `/opt/-botmarketplace-site/apps/web/.next` | scope limited to Next.js fetch cache / ISR output |

`MemoryDenyWriteExecute` is intentionally **not** set on any of the
three: V8 JIT requires writable+executable pages and the process would
crash on startup.

## Deploy path

`deploy/deploy.sh` already does `cmp` → `cp` → `daemon-reload` →
`systemctl restart botmarket-{api,web,worker}` whenever a `deploy/*.service`
file changes in the repo, so the hardening lands on the next prod deploy
without any extra ops steps.

`systemd-analyze verify` reports no syntactic issues (the only
complaint is the missing `/usr/bin/node` on the dev container, which
is expected and will resolve on the VPS).

## Test plan

- [x] `systemd-analyze verify` clean on all three unit files (modulo
      `/usr/bin/node` not present in dev container).
- [ ] Post-deploy on VPS: `systemctl status botmarket-{api,web,worker}`
      all `active (running)`; `journalctl -u botmarket-api -n 100`
      shows no sandbox-related write/EACCES errors; smoke-test.sh
      regression suite still passes.

https://claude.ai/code/session_01JTP1s4RcTuzLzXdmi4z4LS

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTP1s4RcTuzLzXdmi4z4LS)_