### PR TITLE
ops(domain): migrate hardcoded references from .store → .ru

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -94,7 +94,9 @@ export async function buildApp() {
 
   const corsOrigin = process.env.CORS_ORIGIN
     ? process.env.CORS_ORIGIN.split(",")
-    : (process.env.NODE_ENV === "production" ? ["https://botmarketplace.store"] : true);
+    : (process.env.NODE_ENV === "production"
+        ? ["https://botmarketplace.ru", "https://www.botmarketplace.ru"]
+        : true);
 
   await app.register(cors, {
     origin: corsOrigin,

--- a/apps/api/tests/routes/clientErrors.test.ts
+++ b/apps/api/tests/routes/clientErrors.test.ts
@@ -39,7 +39,7 @@ describe("POST /api/v1/client-errors", () => {
       payload: {
         message: "Cannot read property 'foo' of undefined",
         stack: "TypeError: Cannot read...\n  at Component",
-        url: "https://botmarketplace.store/terminal",
+        url: "https://botmarketplace.ru/terminal",
         timestamp: new Date().toISOString(),
       },
     });

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -10,16 +10,16 @@ upstream web_backend {
 
 server {
     listen 80;
-    server_name botmarketplace.store www.botmarketplace.store;
+    server_name botmarketplace.ru www.botmarketplace.ru;
     return 301 https://$host$request_uri;
 }
 
 server {
     listen 443 ssl http2;
-    server_name botmarketplace.store www.botmarketplace.store;
+    server_name botmarketplace.ru www.botmarketplace.ru;
 
-    ssl_certificate     /etc/letsencrypt/live/botmarketplace.store/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/botmarketplace.store/privkey.pem;
+    ssl_certificate     /etc/letsencrypt/live/botmarketplace.ru/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/botmarketplace.ru/privkey.pem;
 
     # Security headers — applied to all responses (including proxied /api/)
     # CSP is split per-location: see location / (web) and location ^~ /api/ (pass-through).

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 APP_DIR="/opt/-botmarketplace-site"
-DOMAIN="botmarketplace.store"
+DOMAIN="botmarketplace.ru"
 
 cd "$APP_DIR"
 

--- a/deploy/smoke-test.sh
+++ b/deploy/smoke-test.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # smoke-test.sh — MVP release smoke tests
-# Usage: bash deploy/smoke-test.sh [--base-url https://botmarketplace.store]
+# Usage: bash deploy/smoke-test.sh [--base-url https://botmarketplace.ru]
 # Exit code: 0 = all passed, 1 = failures found
 
 set -euo pipefail
 
-BASE_URL="${BASE_URL:-https://botmarketplace.store}"
+BASE_URL="${BASE_URL:-https://botmarketplace.ru}"
 TEST_EMAIL="smoke_$(date +%s)@test.com"
 TEST_PASS="Smoke1234!"
 TEST_EMAIL2="smoke2_$(date +%s)@test.com"

--- a/load/healthz.js
+++ b/load/healthz.js
@@ -9,7 +9,7 @@ import { Trend } from "k6/metrics";
 //
 // Usage:
 //   BASE_URL=http://localhost:4000 k6 run load/healthz.js
-//   BASE_URL=https://staging.botmarketplace.store k6 run load/healthz.js
+//   BASE_URL=https://staging.botmarketplace.ru k6 run load/healthz.js
 //
 // Output: JSON summary goes to stdout; p95/p99 latencies + error rate in
 // the trend metrics.


### PR DESCRIPTION
## Summary

Project domain moved from `botmarketplace.store` to `botmarketplace.ru`.
This PR updates **functional** code references only — the prod CORS
whitelist is the hard prod-blocker (without it, requests from
`botmarketplace.ru` would be rejected by Fastify's CORS plugin).

| File | Change |
|---|---|
| `apps/api/src/app.ts` | Production CORS fallback now whitelists `https://botmarketplace.ru` + `https://www.botmarketplace.ru`. `CORS_ORIGIN` env override unchanged (closes the docs/33 hardcoded-CORS follow-up). |
| `deploy/nginx.conf` | `server_name` + LE cert paths point at the new domain. **Reference template only** — VPS-active config is `/etc/nginx/sites-enabled/botmarketplace.conf` managed out-of-band — but the repo template should not lie. |
| `deploy/setup.sh` | `DOMAIN` var (used by certbot + nginx symlink on first-time install). |
| `deploy/smoke-test.sh` | `BASE_URL` default + usage hint. |
| `apps/api/tests/routes/clientErrors.test.ts` | Fixture URL. |
| `load/healthz.js` | k6 usage comment. |

## Out of scope (deferred docs sweep)

`docs/{30,31,32,33}*`, `docs/runbooks/RUNBOOK.md`,
`docs/release/RC_CHECKLIST.md`, `docs/steps/{13,14,19}*` — historical /
reference text, not consumed by any tooling. Will land as a separate PR
to keep this one tight.

## Test plan

- [x] `pnpm --filter @botmarketplace/api exec tsc --noEmit` — clean
- [x] `pnpm --filter @botmarketplace/api test` — **2221/2221 passed**
      (baseline preserved)
- [ ] Post-deploy: `curl -i -H "Origin: https://botmarketplace.ru" https://botmarketplace.ru/api/v1/healthz` returns
      `Access-Control-Allow-Origin: https://botmarketplace.ru`.
- [ ] Browser smoke: log in at `botmarketplace.ru/login`, watch
      DevTools Network for any CORS-blocked XHR.

https://claude.ai/code/session_01JTP1s4RcTuzLzXdmi4z4LS

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTP1s4RcTuzLzXdmi4z4LS)_