### PR TITLE
ops(systemd): add AF_NETLINK to RestrictAddressFamilies (#377 hotfix)

### DIFF
--- a/deploy/botmarket-api.service
+++ b/deploy/botmarket-api.service
@@ -42,14 +42,17 @@ Environment=NODE_ENV=production
 Environment=PATH=/usr/bin:/usr/local/bin:/usr/local/share/pnpm
 
 # Hardening (docs/30 Phase 9). MemoryDenyWriteExecute is intentionally
-# omitted — V8 JIT requires writable+executable pages.
+# omitted — V8 JIT requires writable+executable pages. AF_NETLINK is
+# required by getifaddrs(3) which Node's os.networkInterfaces() calls
+# during Fastify listen() — without it, startup aborts with
+# EAFNOSUPPORT (errno 97). See incident 2026-05-06.
 ProtectSystem=strict
 ProtectHome=true
 PrivateTmp=true
 NoNewPrivileges=true
 RestrictNamespaces=true
 LockPersonality=true
-RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX AF_NETLINK
 ReadWritePaths=/opt/-botmarketplace-site /var/log
 
 [Install]

--- a/deploy/botmarket-web.service
+++ b/deploy/botmarket-web.service
@@ -40,7 +40,10 @@ Environment=NODE_ENV=production
 Environment=PORT=3000
 
 # Hardening (docs/30 Phase 9). MemoryDenyWriteExecute is intentionally
-# omitted — V8 JIT requires writable+executable pages. Web only writes
+# omitted — V8 JIT requires writable+executable pages. AF_NETLINK is
+# required by getifaddrs(3) which Node's os.networkInterfaces() calls
+# during Next.js listen() — without it, startup aborts with
+# EAFNOSUPPORT (errno 97). See incident 2026-05-06. Web only writes
 # to .next/cache at runtime (Next.js fetch cache, ISR), so the writable
 # path is scoped to the build output directory.
 ProtectSystem=strict
@@ -49,7 +52,7 @@ PrivateTmp=true
 NoNewPrivileges=true
 RestrictNamespaces=true
 LockPersonality=true
-RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX AF_NETLINK
 ReadWritePaths=/opt/-botmarketplace-site/apps/web/.next
 
 [Install]

--- a/deploy/botmarket-worker.service
+++ b/deploy/botmarket-worker.service
@@ -38,14 +38,17 @@ Environment=NODE_ENV=production
 Environment=PATH=/usr/bin:/usr/local/bin:/usr/local/share/pnpm
 
 # Hardening (docs/30 Phase 9). MemoryDenyWriteExecute is intentionally
-# omitted — V8 JIT requires writable+executable pages.
+# omitted — V8 JIT requires writable+executable pages. AF_NETLINK is
+# kept for consistency with api/web — worker never calls listen(), but
+# any future code path that touches os.networkInterfaces() will fail
+# without it. See incident 2026-05-06.
 ProtectSystem=strict
 ProtectHome=true
 PrivateTmp=true
 NoNewPrivileges=true
 RestrictNamespaces=true
 LockPersonality=true
-RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX AF_NETLINK
 ReadWritePaths=/opt/-botmarketplace-site /var/log
 
 # Worker never binds a listening socket — drop all capabilities.


### PR DESCRIPTION
## Incident summary

Hotfix for **prod outage 2026-05-06** triggered by #377 systemd
hardening. After the 26-commit jump to `a8befac` was deployed, both
`botmarket-api` and `botmarket-web` entered a crash-loop on first
restart. Worker survived.

## Root cause

Node's `os.networkInterfaces()` is called by both Fastify (logServerAddress)
and Next.js (`get-network-host.js`) on `listen()` to log the bound
address. That path delegates to `getifaddrs(3)` in libc, which requires
an `AF_NETLINK` socket on Linux to enumerate interfaces.

The strict whitelist introduced in #377:

    RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX

omitted `AF_NETLINK`. Both processes aborted on listen with:

    SystemError ERR_SYSTEM_ERROR errno 97 (EAFNOSUPPORT)
    syscall: uv_interface_addresses

Worker is unaffected because it never calls `listen()` and therefore
never enters the `os.networkInterfaces()` path.

## Fix

Add `AF_NETLINK` to all three units. Comment in each `.service` explains
why so a future hardening pass doesn't strip it back out.

```diff
-RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX AF_NETLINK
```

## Recovery sequence

1. **Immediate** (in flight as of this PR open): VPS `systemd` drop-in
   override at `/etc/systemd/system/botmarket-{api,web,worker}.service.d/
   override.conf` adds `AF_NETLINK` and restarts services. ~30 s downtime
   continuation.
2. **This PR**: bakes the fix into the repo unit files. Once merged and
   `deploy.sh` runs again, the in-repo unit files are reconciled into
   `/etc/systemd/system/`, the drop-in override becomes a no-op
   (re-asserts the same value), and the override file can be removed
   in a subsequent ops pass.

## Test plan

- [x] Local `systemd-analyze verify` clean (modulo missing `/usr/bin/node`
      on the dev container, expected).
- [ ] Post-deploy: `systemctl show -p RestrictAddressFamilies
      botmarket-api` includes `AF_NETLINK`. journal shows `Server listening`
      within 5 s of start. No `EAFNOSUPPORT` / `errno 97` regression.
- [ ] After confirming green, remove the drop-in override files and
      `daemon-reload` (separate ops follow-up, not this PR).

## Follow-ups (out of scope)

- `deploy.sh` exits 0 even though api+web reported `FAILED` in its own
  status print. That's how this incident slipped past automated detection.
  Worth a small PR to gate `deploy.sh` exit on `is-active` checks.

https://claude.ai/code/session_01JTP1s4RcTuzLzXdmi4z4LS

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTP1s4RcTuzLzXdmi4z4LS)_