### PR TITLE
ops(deploy): gate deploy.sh exit on real service health (incident 2026-05-06 follow-up)

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -105,13 +105,67 @@ systemctl restart botmarket-web
 # unit is restarted explicitly. Always restart all three.
 systemctl restart botmarket-worker
 
-# Wait a moment and show status
-sleep 3
+# Wait for services to stabilize. With RestartSec=5s in the unit files,
+# sleeping 7s ensures at least one full restart cycle has completed if
+# the service is crash-looping — otherwise we'd catch the brief
+# "activating" window between crash and auto-restart and report success.
+# Incident 2026-05-06 (#377 hardening missing AF_NETLINK) slipped past
+# the previous 3s sleep + `is-active && echo OK || echo FAIL` check
+# because is-active returns 0 for "activating" state.
+sleep 7
+
 echo ""
-echo "Service status:"
-systemctl is-active botmarket-api    && echo "  ✓ botmarket-api is running"    || echo "  ✗ botmarket-api FAILED"
-systemctl is-active botmarket-web    && echo "  ✓ botmarket-web is running"    || echo "  ✗ botmarket-web FAILED"
-systemctl is-active botmarket-worker && echo "  ✓ botmarket-worker is running" || echo "  ✗ botmarket-worker FAILED"
+echo "Service health check:"
+DEPLOY_FAILED=0
+
+# API: must respond with HTTP 2xx on /healthz. Curling the bound port
+# is stronger than systemctl is-active because it confirms the port is
+# actually open and the request handler is alive.
+if curl -sf -m 5 http://127.0.0.1:4000/api/v1/healthz > /dev/null 2>&1; then
+  echo "  ✓ botmarket-api → /healthz 200"
+else
+  echo "  ✗ botmarket-api → /healthz unreachable or non-200"
+  echo "    Last 30 journal lines:"
+  journalctl -u botmarket-api -n 30 --no-pager 2>&1 | sed 's/^/      /'
+  DEPLOY_FAILED=1
+fi
+
+# Web: 3xx is acceptable (Next.js may redirect / to /login when
+# unauthenticated), so accept any 2xx or 3xx.
+WEB_HTTP=$(curl -s -o /dev/null -w "%{http_code}" -m 5 http://127.0.0.1:3000/ 2>/dev/null || echo "000")
+if [[ "$WEB_HTTP" =~ ^[23] ]]; then
+  echo "  ✓ botmarket-web → / HTTP $WEB_HTTP"
+else
+  echo "  ✗ botmarket-web → / HTTP $WEB_HTTP"
+  echo "    Last 30 journal lines:"
+  journalctl -u botmarket-web -n 30 --no-pager 2>&1 | sed 's/^/      /'
+  DEPLOY_FAILED=1
+fi
+
+# Worker: no HTTP endpoint. ActiveState="active" is the only OK value;
+# "activating" can mean crash-loop auto-restart, so reject it.
+WORKER_STATE=$(systemctl show -p ActiveState --value botmarket-worker 2>/dev/null || echo "unknown")
+if [[ "$WORKER_STATE" == "active" ]]; then
+  echo "  ✓ botmarket-worker → ActiveState=active"
+else
+  echo "  ✗ botmarket-worker → ActiveState=$WORKER_STATE"
+  echo "    Last 30 journal lines:"
+  journalctl -u botmarket-worker -n 30 --no-pager 2>&1 | sed 's/^/      /'
+  DEPLOY_FAILED=1
+fi
+
+if [[ $DEPLOY_FAILED -eq 1 ]]; then
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  [!] DEPLOY FAILED — services not healthy"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  One or more services are not healthy. See journal output above."
+  echo "  Rollback options:"
+  echo "    1. git checkout <previous-ref> && bash deploy/deploy.sh"
+  echo "    2. If you tagged the previous prod state before this deploy,"
+  echo "       check it out and re-run deploy.sh."
+  exit 1
+fi
 
 echo ""
 DEPLOYED_REF=$(git describe --tags --always 2>/dev/null || git rev-parse --short HEAD)


### PR DESCRIPTION
## Summary

Incident 2026-05-06 follow-up. The previous final block in `deploy.sh`
had two structural problems that let the #377 hardening crash slip
past detection:

```bash
sleep 3
systemctl is-active botmarket-api    && echo "  ✓ ..."    || echo "  ✗ FAILED"
systemctl is-active botmarket-web    && echo "  ✓ ..."    || echo "  ✗ FAILED"
systemctl is-active botmarket-worker && echo "  ✓ ..."    || echo "  ✗ FAILED"
```

1. The `&& ... || ...` chain always evaluates to 0 — even when "✗
   FAILED" was printed, the script exited 0. Wrapper / CI scripts
   that rely on `bash deploy.sh && next-step` saw the deploy as
   successful even when api+web were crash-looping.
2. `systemctl is-active` returns 0 for the `"activating"` state, which
   is exactly what an auto-restarting crash-loop sits in for ~5s
   (RestartSec=5s in the unit files). Combined with the previous
   `sleep 3` (shorter than RestartSec), the script could check status
   in the brief window between crash and next restart attempt and
   report green for a service that was about to crash again.

## Fix

| | Before | After |
|---|---|---|
| Post-restart sleep | 3s | **7s** (longer than RestartSec=5s) |
| api check | `is-active` | `curl -sf http://127.0.0.1:4000/api/v1/healthz` (HTTP 2xx) |
| web check | `is-active` | `curl http://127.0.0.1:3000/` (any 2xx/3xx — Next.js may 308 to /login) |
| worker check | `is-active` | `systemctl show -p ActiveState`, only `"active"` passes (not `"activating"`) |
| Failure output | `"✗ FAILED"` only | `"✗ FAILED"` + inline last 30 journal lines + rollback hint |
| Exit code on failure | **0** (silent) | **1** |

If this gate had been in place on 2026-05-06, the api+web crash-loop
would have aborted `deploy.sh` with non-zero, the operator would have
seen the `EAFNOSUPPORT` trace inline, and the incident would have been
resolved before the manual `override.conf` had to be hand-crafted.

## Test plan

- [x] `bash -n deploy/deploy.sh` — clean
- [ ] Next prod deploy: status block shows "✓ /healthz 200", "✓ / HTTP
      308", "✓ ActiveState=active" instead of the old style.
- [ ] Negative test (offline, controllable): if a future deploy ever
      has a service that crashes on startup, deploy.sh should now
      print journal output inline and exit non-zero.

## Out of scope

- The smoke-test `||  true` follow-up (real bug — silent halt after
  §18.5 in #380) is a separate investigation.

https://claude.ai/code/session_01JTP1s4RcTuzLzXdmi4z4LS

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTP1s4RcTuzLzXdmi4z4LS)_