### PR TITLE
ops(smoke-test): extract embedded python3 from curl -d args (#380 follow-up)

### DIFF
--- a/deploy/smoke-test.sh
+++ b/deploy/smoke-test.sh
@@ -1165,17 +1165,20 @@ if [[ "$S18_AVAIL" != "true" ]]; then
   red "POST /ai/plan skipped — AI provider not available"
   ((++FAIL))
 else
-  # `|| true` guards against pipefail bubbling out of the embedded
-  # `echo … | python3 …` substitution. On AI rate-limit cooldown the
-  # response payload can be truncated/non-JSON; the embedded python3
-  # in -d is fine, but this pattern was the original §18.6 abort point
-  # in `set -euo pipefail`. Guard the whole assignment — the empty/bad
-  # response is then handled by the explicit `[[ -n "$S18_PLAN_ID" ]]`
-  # checks below (same posture as §3 helpers).
+  # Pre-encode the message as a JSON string in its own statement, NOT
+  # embedded inside the curl `-d` arg. The embedded `$(echo … | python3
+  # …)` pattern (used previously) interacts badly with `set -euo pipefail`:
+  # on AI rate-limit cooldown the inner pipe could fail in a way that
+  # caused the outer assignment to abort the whole script (#380's `||
+  # true` masked the loud abort but turned it into a silent halt of
+  # subsequent stages — observed 2026-05-06: smoke run terminated after
+  # §18.5 with exit 0, never reaching §19+). Decoupling lets us guard
+  # each step explicitly.
+  S18_PLAN_MSG_JSON=$(printf '%s' "$S18_PLAN_MSG" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read().strip()))' 2>/dev/null) || S18_PLAN_MSG_JSON='""'
   S18_PLAN_RESP=$(curl -s -X POST "$BASE_URL/api/v1/ai/plan" \
     -H "Authorization: Bearer $TOKEN" \
     -H "Content-Type: application/json" \
-    -d "{\"message\":$(echo "$S18_PLAN_MSG" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read().strip()))')}") || true
+    -d "{\"message\":$S18_PLAN_MSG_JSON}") || true
 
   S18_PLAN_ID=$(echo "$S18_PLAN_RESP" | grep -o '"planId":"[^"]*"' | head -1 | cut -d'"' -f4)
   S18_PLAN_HAS_ACTIONS=$(echo "$S18_PLAN_RESP" | grep -o '"actionId"' | head -1)
@@ -1251,10 +1254,11 @@ except: pass
 
   # 18.11 Chain test: CREATE_STRATEGY + CREATE_STRATEGY_VERSION with dependsOn
   S18_CHAIN_MSG='Create a new strategy named SmokeChain with RSI14 indicator, then create version 1 for it'
+  S18_CHAIN_MSG_JSON=$(printf '%s' "$S18_CHAIN_MSG" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read().strip()))' 2>/dev/null) || S18_CHAIN_MSG_JSON='""'
   S18_CHAIN_RESP=$(curl -s -X POST "$BASE_URL/api/v1/ai/plan" \
     -H "Authorization: Bearer $TOKEN" \
     -H "Content-Type: application/json" \
-    -d "{\"message\":$(echo "$S18_CHAIN_MSG" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read().strip()))')}") || true
+    -d "{\"message\":$S18_CHAIN_MSG_JSON}") || true
 
   S18_CHAIN_PLAN_ID=$(echo "$S18_CHAIN_RESP" | grep -o '"planId":"[^"]*"' | head -1 | cut -d'"' -f4)
   S18_CHAIN_COUNT=$(echo "$S18_CHAIN_RESP" | python3 -c "
@@ -1339,10 +1343,11 @@ else
   # 19.2 Full bot lifecycle plan: CREATE_BOT + START_RUN + STOP_RUN
   S19_BOT_MSG='Create a new bot named SmokeBot18c from the most recent strategy version available, then start a run for 1 minute, then stop that run'
 
+  S19_BOT_MSG_JSON=$(printf '%s' "$S19_BOT_MSG" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read().strip()))' 2>/dev/null) || S19_BOT_MSG_JSON='""'
   S19_PLAN_RESP=$(curl -s -X POST "$BASE_URL/api/v1/ai/plan" \
     -H "Authorization: Bearer $TOKEN" \
     -H "Content-Type: application/json" \
-    -d "{\"message\":$(echo "$S19_BOT_MSG" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read().strip()))')}") || true
+    -d "{\"message\":$S19_BOT_MSG_JSON}") || true
 
   S19_PLAN_ID=$(echo "$S19_PLAN_RESP" | grep -o '"planId":"[^"]*"' | head -1 | cut -d'"' -f4)
   S19_ACTION_COUNT=$(echo "$S19_PLAN_RESP" | python3 -c "
@@ -1471,10 +1476,11 @@ except: pass
 
   # 19.6 CREATE_BOT with invalid strategyVersionId → 404 (cross-workspace / not found)
   S19_BADBOT_MSG='Create a bot named BadBot with strategyVersionId 00000000-0000-0000-0000-000000000000, symbol BTCUSDT, timeframe M15'
+  S19_BADBOT_MSG_JSON=$(printf '%s' "$S19_BADBOT_MSG" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read().strip()))' 2>/dev/null) || S19_BADBOT_MSG_JSON='""'
   S19_BADPLAN_RESP=$(curl -s -X POST "$BASE_URL/api/v1/ai/plan" \
     -H "Authorization: Bearer $TOKEN" \
     -H "Content-Type: application/json" \
-    -d "{\"message\":$(echo "$S19_BADBOT_MSG" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read().strip()))')}") || true
+    -d "{\"message\":$S19_BADBOT_MSG_JSON}") || true
   S19_BADPLAN_ID=$(echo "$S19_BADPLAN_RESP" | grep -o '"planId":"[^"]*"' | head -1 | cut -d'"' -f4)
   S19_BAD_ACT_ID=$(echo "$S19_BADPLAN_RESP" | python3 -c "
 import sys,json
@@ -1498,10 +1504,11 @@ except: pass
 
   # 19.7 START_RUN with non-existent botId → 404
   S19_BADRUN_MSG='Start a run for bot 00000000-0000-0000-0000-000000000000'
+  S19_BADRUN_MSG_JSON=$(printf '%s' "$S19_BADRUN_MSG" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read().strip()))' 2>/dev/null) || S19_BADRUN_MSG_JSON='""'
   S19_BADRUN_PLAN_RESP=$(curl -s -X POST "$BASE_URL/api/v1/ai/plan" \
     -H "Authorization: Bearer $TOKEN" \
     -H "Content-Type: application/json" \
-    -d "{\"message\":$(echo "$S19_BADRUN_MSG" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read().strip()))')}") || true
+    -d "{\"message\":$S19_BADRUN_MSG_JSON}") || true
   S19_BADRUN_PLAN_ID=$(echo "$S19_BADRUN_PLAN_RESP" | grep -o '"planId":"[^"]*"' | head -1 | cut -d'"' -f4)
   S19_BADRUN_ACT_ID=$(echo "$S19_BADRUN_PLAN_RESP" | python3 -c "
 import sys,json


### PR DESCRIPTION
## Summary

#380 follow-up: hypothesis-based fix for the silent-halt-after-§18.5
behaviour observed on the 2026-05-06 prod smoke run (script terminated
with exit 0 after §18.5, never reached §19+, no "Total:" tally in log).

## Hypothesis

The previous pattern nests a pipe inside a command-substitution inside
another command-substitution, all under `set -euo pipefail`:

```bash
S18_PLAN_RESP=$(curl ... \
  -d "{\"message\":$(echo "$MSG" | python3 -c '...')}") || true
```

When the inner pipe fails (AI rate-limit cooldown truncates the
upstream response, python3 hits transient `SIGPIPE`), the outer
assignment's `|| true` catches the immediate non-zero, but the parent
shell appears to be left in a state that silently terminates execution
shortly after. This pattern is the smoking gun:

- It was the original §18.6 abort point pre-#380.
- It's the only structural change between "loud abort" pre-#380 and
  "quiet halt" post-#380.
- All five occurrences in §18-§19 follow the same shape.

## Fix

Decouple JSON encoding from the curl command. Each AI POST now:

```bash
S18_PLAN_MSG_JSON=$(printf '%s' "$MSG" | python3 -c '...' \
  2>/dev/null) || S18_PLAN_MSG_JSON='""'
S18_PLAN_RESP=$(curl ... -d "{\"message\":$S18_PLAN_MSG_JSON}") || true
```

Improvements bundled in:

- Inner pipe is its own top-level assignment with explicit `||
  VAR='""'` fallback to a JSON-valid empty string. No nested
  substitution inside curl's argv.
- `printf '%s'` instead of `echo` — no backslash-escape interpretation
  surprises if a future message contains escapes.
- Curl gets a syntactically valid JSON body even when python3 fails
  (`{"message":""}` instead of broken `{"message":}`).
- Outer `|| true` retained for transport-layer failures (network/DNS).

## Applied to (5 occurrences)

| Section | Variable |
|---|---|
| §18.6 | `S18_PLAN_RESP` / `S18_PLAN_MSG_JSON` |
| §18.11 | `S18_CHAIN_RESP` / `S18_CHAIN_MSG_JSON` |
| §19.2 | `S19_PLAN_RESP` / `S19_BOT_MSG_JSON` |
| §19.6 | `S19_BADPLAN_RESP` / `S19_BADBOT_MSG_JSON` |
| §19.7 | `S19_BADRUN_PLAN_RESP` / `S19_BADRUN_MSG_JSON` |

## Test plan

- [x] `bash -n deploy/smoke-test.sh` — clean
- [x] `grep python3.*sys.stdin` confirms zero embedded substitutions
      remain inside curl `-d` args
- [ ] **Hypothesis verification** — next prod smoke run reaches §19+
      and ends with a "Total:" tally line. If it still halts at §18.5,
      hypothesis is wrong and we add `bash -x` instrumentation in a
      follow-up to find the actual halt point.

Cannot reproduce the silent halt locally — needs a live AI endpoint
with rate-limit cooldown.

https://claude.ai/code/session_01JTP1s4RcTuzLzXdmi4z4LS

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTP1s4RcTuzLzXdmi4z4LS)_