### PR TITLE
ops(smoke-test): disable strict mode inside AI block (real #380 fix)

### DIFF
--- a/deploy/smoke-test.sh
+++ b/deploy/smoke-test.sh
@@ -1112,6 +1112,24 @@ fi
 # ─── 18. Stage 18b — AI Actions Execute ──────────────────────────────────────
 header "18. Stage 18b — AI Actions Execute"
 
+# AI block (§18 + §19) deals with optional response shapes from a
+# rate-limit-prone provider. Many extractions are `S..._FOO=$(echo
+# "$RESP" | grep -o '"foo":...' | cut ...)`; under `set -euo pipefail`,
+# a no-match (which is a totally normal outcome here) makes the inner
+# pipe exit 1, the substitution exit 1, and the script aborts on the
+# next command. That's the silent halt observed 2026-05-06: bash -x
+# trace pinpointed `S18_PLAN_ID=` (empty) right before the script
+# stopped — set -e fired on the empty extraction, not on python3
+# substitution as #380/#384 hypothesised.
+#
+# Solution: locally drop strict mode for the AI block. Each test still
+# uses explicit `[[ -n "$S..._ID" ]]` / `check "..." "$expected"
+# "$actual"` guards to convert a missing field into a regular FAIL,
+# so we don't lose error detection — we just stop conflating "test
+# failed" with "harness aborted before reaching test". Re-enabled
+# before §20 (datasets), which uses the strict-mode-friendly pattern.
+set +eo pipefail
+
 # 18.0 GET /ai/status — public endpoint, no auth needed
 S18_STATUS=$(curl -s "$BASE_URL/api/v1/ai/status")
 S18_AVAIL=$(echo "$S18_STATUS" | grep -o '"available":[^,}]*' | cut -d: -f2 | tr -d ' "')
@@ -1530,6 +1548,11 @@ except: pass
     ((++PASS))
   fi
 fi
+
+# Re-enable strict mode for the remaining §20+ stages, which use simple
+# curl probes + `check` helpers and don't depend on best-effort field
+# extraction the way the AI block did.
+set -eo pipefail
 
 # ─── 20. Stage 19 — Datasets & Reproducibility ──────────────────────────────
 header "20. Stage 19 — Datasets & Reproducibility"


### PR DESCRIPTION
## Summary

Real fix for the silent-halt-after-§18.5 issue. Supersedes #380 and
#384 — both made the script *quieter* about the abort but didn't
address the actual cause.

## Root cause (from `bash -x` trace of 2026-05-06 prod smoke)

The last command before script termination was:

```bash
S18_PLAN_ID=$(echo "$S18_PLAN_RESP" | grep -o '"planId":"[^"]*"' | head -1 | cut -d'"' -f4)
```

When `/ai/plan` doesn't return a `planId` (rate-limit 429, auth 401,
provider 5xx — all expected outcomes that should report as FAIL,
not abort), `grep -o` matches nothing and exits 1. Under
`set -o pipefail` the inner pipe inherits exit 1, the substitution
exits 1, and `set -e` aborts. Subsequent `(( ++FAIL ))` and `fi`
exits are 0, so the eventual script exit ends up 0 — which **looks**
like success but skipped §18.6 → §19 → §20 → §21 → §20a-§20e (≈half
the test surface).

So `#380` outer `|| true` and `#384` decoupled python3 didn't help —
the failure point is downstream of both, on the next innocuous
field-extraction line.

## Fix

Bracket the AI block (§18 + §19) with:

```bash
set +eo pipefail
…
set -eo pipefail
```

Why this is safe (and not a "hide errors" anti-pattern):

- Every individual test inside the AI block already uses an explicit
  `[[ -n "$S..._ID" ]]` / `check "..." "$expected" "$actual"` guard
  that converts missing fields into a regular `red "✗ …"` + `((++FAIL))`
  output. Coverage / detection are preserved.
- We're un-conflating "**test** failed" (expected, reportable) from
  "**harness** aborted before reaching the test" (silent, unreportable).
- Strict mode is re-armed before §20 (datasets), which uses the
  pipefail-friendly curl-probe pattern and stays under strict mode.

## Relationship to prior PRs

- `#380` (`|| true` on outer curl assignments) — kept as
  defense-in-depth.
- `#384` (extract embedded python3 to standalone variable) — kept
  for code clarity & for protection against transport-layer /
  encoding edge cases. The two-statement form is just better code
  regardless.
- Together with this PR, the AI block is now triply-guarded. Any
  one of the three could fail without the others noticing.

## Test plan

- [x] `bash -n deploy/smoke-test.sh` — clean
- [x] `set +eo pipefail` on entry to §18 (line 1131), `set -eo
      pipefail` on entry to §20 (line 1555) — verified by `grep -n`
- [ ] **Verification on next prod smoke run** (the criterion this PR
      ships against):
  - log grows past 131 lines
  - stage headers §19, §20, §21, §20a-§20e all printed
  - final "Total: …" tally line present
  - individual AI-section FAILs (e.g. rate-limited cross-workspace
    probe) appear as red ✗ in the body, not as a silent script abort

## Out of scope

- The deploy.sh status-block anomaly the VPS report flagged — VPS
  saw the **old** format ("✓ … is running") even though `#383` was
  in HEAD `72eed6a`. That's a separate "is the gate actually
  deployed?" question; folded into the next deploy promt's
  diagnostic step rather than a separate PR.

https://claude.ai/code/session_01JTP1s4RcTuzLzXdmi4z4LS

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTP1s4RcTuzLzXdmi4z4LS)_