### PR TITLE
feat(scripts): demoSmoke harness for flagship acceptance gates (53-T3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,8 @@ packages/*/tests/**/*.d.ts.map
 
 # Claude Code secrets (never commit tokens)
 .claude/secrets
+
+# demoSmoke harness output (docs/53-T3 / 54-T1..T3 / 55-T6 sub-gate).
+# Reports may include workspace IDs and run identifiers — keep them off
+# git; operators excerpt summary lines into companion-docs by hand.
+apps/api/scripts/.smoke-output/

--- a/apps/api/scripts/demoSmoke.ts
+++ b/apps/api/scripts/demoSmoke.ts
@@ -1,0 +1,532 @@
+#!/usr/bin/env tsx
+/**
+ * Demo connectivity smoke harness — 30-минутный (по умолчанию) run одного
+ * preset-бота на Bybit demo с проверкой acceptance условий из docs/53-T3.
+ *
+ * Назначение:
+ *  - Подтвердить, что preset → бот → polling-loop → intents работает
+ *    end-to-end на реальном demo-эндпоинте Bybit.
+ *  - Дать operators воспроизводимый runbook для acceptance gate
+ *    (docs/53-T3 / docs/54-T1..T3 / docs/55-T6 sub-gate funding-arb).
+ *
+ * Что harness НЕ делает:
+ *  - Не оценивает торговую прибыль (это walk-forward в docs/53-T2 / 54-T1..T3).
+ *  - Не переключает visibility (это `publishPreset.ts`).
+ *  - Не работает с live trading (BYBIT_ALLOW_LIVE остаётся off — гарантия в
+ *    bybitPlaceOrder, не в этом скрипте).
+ *
+ * Использование (требует demo creds + локально запущенный API):
+ *
+ *   pnpm --filter @botmarketplace/api exec tsx scripts/demoSmoke.ts \
+ *     --preset adaptive-regime \
+ *     --workspace ws_xyz \
+ *     --token "$DEMO_JWT" \
+ *     --base-url http://localhost:3001/api/v1 \
+ *     --duration-min 30 \
+ *     --symbol BTCUSDT \
+ *     --quote-amount 50
+ *
+ * Результат: JSON-отчёт в `apps/api/scripts/.smoke-output/<timestamp>-<slug>.json`
+ * + summary в stdout. Exit code 0 = PASS, 1 = FAIL, 2 = INPUT_ERROR.
+ */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { PrismaClient } from "@prisma/client";
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing — exported pure for tests
+// ---------------------------------------------------------------------------
+
+export interface ParsedSmokeArgs {
+  preset?: string;
+  workspace?: string;
+  token?: string;
+  baseUrl?: string;
+  durationMin?: number;
+  pollIntervalSec?: number;
+  symbol?: string;
+  quoteAmount?: number;
+  outputDir?: string;
+  dryRun: boolean;
+}
+
+export function parseArgs(argv: readonly string[]): ParsedSmokeArgs {
+  const out: ParsedSmokeArgs = { dryRun: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--preset") out.preset = argv[++i];
+    else if (arg === "--workspace") out.workspace = argv[++i];
+    else if (arg === "--token") out.token = argv[++i];
+    else if (arg === "--base-url") out.baseUrl = argv[++i];
+    else if (arg === "--duration-min") out.durationMin = Number(argv[++i]);
+    else if (arg === "--poll-interval-sec") out.pollIntervalSec = Number(argv[++i]);
+    else if (arg === "--symbol") out.symbol = argv[++i];
+    else if (arg === "--quote-amount") out.quoteAmount = Number(argv[++i]);
+    else if (arg === "--output-dir") out.outputDir = argv[++i];
+    else if (arg === "--dry-run") out.dryRun = true;
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance evaluation — pure function, easy to unit test
+// ---------------------------------------------------------------------------
+
+export interface SmokeMetrics {
+  /** BotRunState на момент завершения скрипта (после stop). */
+  finalRunState: string;
+  /** Сколько polls было сделано (информативно). */
+  pollCount: number;
+  /** Общее число BotIntent для этого run'а. */
+  intentCount: number;
+  /** Число BotIntent с state="FAILED". */
+  failedIntentCount: number;
+  /** Число BotEvent, у которых type содержит "error" / "fail" (case-insensitive). */
+  errorEventCount: number;
+  /** Сколько HTTP запросов harness'а получили статус >= 400 (auth issues / rate limits). */
+  harnessHttpFailures: number;
+  /** Реальная длительность run'а в минутах. */
+  actualDurationMin: number;
+}
+
+export interface SmokeAcceptance {
+  pass: boolean;
+  /** Warning (не fail) если intentCount === 0 — может быть legit flat market. */
+  warnings: string[];
+  /** Конкретные причины fail (пусто если pass). */
+  failures: string[];
+}
+
+/**
+ * Acceptance критерии из docs/53-T3:
+ *   1. finalRunState !== "FAILED" / "TIMED_OUT"  → fail если нарушено.
+ *   2. errorEventCount === 0                      → fail если > 0.
+ *   3. harnessHttpFailures === 0                  → fail если > 0
+ *      (sustained 401/403/429 от Bybit или /api).
+ *   4. failedIntentCount === 0                    → fail если > 0.
+ *   5. intentCount > 0                            → warning если 0
+ *      (рынок может быть flat — operator решает rerun или принять).
+ */
+export function evaluateAcceptance(metrics: SmokeMetrics): SmokeAcceptance {
+  const failures: string[] = [];
+  const warnings: string[] = [];
+
+  if (metrics.finalRunState === "FAILED" || metrics.finalRunState === "TIMED_OUT") {
+    failures.push(`finalRunState=${metrics.finalRunState} (expected STOPPED)`);
+  }
+  if (metrics.errorEventCount > 0) {
+    failures.push(`errorEventCount=${metrics.errorEventCount} (expected 0)`);
+  }
+  if (metrics.harnessHttpFailures > 0) {
+    failures.push(`harnessHttpFailures=${metrics.harnessHttpFailures} (expected 0)`);
+  }
+  if (metrics.failedIntentCount > 0) {
+    failures.push(`failedIntentCount=${metrics.failedIntentCount} (expected 0)`);
+  }
+  if (metrics.intentCount === 0) {
+    warnings.push(
+      "intentCount=0 — strategy did not emit any intents; may be flat market or DSL bug, " +
+      "operator should review logs and rerun if needed",
+    );
+  }
+  return { pass: failures.length === 0, warnings, failures };
+}
+
+// ---------------------------------------------------------------------------
+// HTTP / DB seam — interface so tests can swap with in-memory fakes
+// ---------------------------------------------------------------------------
+
+export interface InstantiateResponse {
+  botId: string;
+  strategyId: string;
+  strategyVersionId: string;
+}
+
+export interface RunResponse {
+  id: string;
+  state: string;
+}
+
+export interface SmokeApi {
+  /** POST /presets/:slug/instantiate. */
+  instantiatePreset(input: {
+    slug: string;
+    workspaceId: string;
+    overrides?: { symbol?: string; quoteAmount?: number; name?: string };
+  }): Promise<InstantiateResponse>;
+
+  /** POST /bots/:botId/runs. */
+  startRun(input: { botId: string; durationMinutes: number }): Promise<RunResponse>;
+
+  /** POST /bots/:botId/runs/:runId/stop. */
+  stopRun(input: { botId: string; runId: string }): Promise<RunResponse>;
+
+  /** GET BotRun row by id (через Prisma — поллим состояние). */
+  getRun(runId: string): Promise<{ state: string; errorCode: string | null } | null>;
+
+  /** Aggregate intent counts for a run (через Prisma). */
+  countIntents(runId: string): Promise<{ total: number; failed: number }>;
+
+  /** Aggregate error-flavoured BotEvent for a run (через Prisma). */
+  countErrorEvents(runId: string): Promise<number>;
+}
+
+// ---------------------------------------------------------------------------
+// Core orchestration — signature suitable for unit testing
+// ---------------------------------------------------------------------------
+
+export interface RunDemoSmokeArgs {
+  presetSlug: string;
+  workspaceId: string;
+  durationMin: number;
+  pollIntervalSec: number;
+  overrides: { symbol?: string; quoteAmount?: number };
+  api: SmokeApi;
+  /** Inject sleep so tests advance virtual time without real waits. */
+  sleep: (ms: number) => Promise<void>;
+  /** Inject clock so tests can fix `actualDurationMin`. */
+  now: () => number;
+  /** Optional sink for progress lines. */
+  log?: (line: string) => void;
+}
+
+export interface SmokeReport {
+  presetSlug: string;
+  workspaceId: string;
+  startedAt: string;
+  finishedAt: string;
+  botId: string;
+  runId: string;
+  metrics: SmokeMetrics;
+  acceptance: SmokeAcceptance;
+}
+
+export async function runDemoSmoke(args: RunDemoSmokeArgs): Promise<SmokeReport> {
+  const log = args.log ?? ((line: string) => console.log(line));
+  const startedAt = args.now();
+  let harnessHttpFailures = 0;
+
+  // Helper that wraps each api call so a thrown error increments the
+  // failure counter instead of bubbling out — we want the harness to
+  // continue collecting metrics even after a transient network blip.
+  const safeCall = async <T>(fn: () => Promise<T>, fallback: T): Promise<T> => {
+    try {
+      return await fn();
+    } catch (err) {
+      harnessHttpFailures++;
+      log(`[demoSmoke] api call failed (#${harnessHttpFailures}): ${(err as Error).message}`);
+      return fallback;
+    }
+  };
+
+  log(`[demoSmoke] preset=${args.presetSlug} workspace=${args.workspaceId} duration=${args.durationMin}min`);
+
+  const created = await args.api.instantiatePreset({
+    slug: args.presetSlug,
+    workspaceId: args.workspaceId,
+    overrides: args.overrides,
+  });
+  log(`[demoSmoke] instantiated bot=${created.botId} strategy=${created.strategyId}`);
+
+  const run = await args.api.startRun({ botId: created.botId, durationMinutes: args.durationMin });
+  log(`[demoSmoke] started run=${run.id} state=${run.state}`);
+
+  const totalMs = args.durationMin * 60_000;
+  const pollMs = args.pollIntervalSec * 1000;
+  const deadline = startedAt + totalMs;
+  let pollCount = 0;
+  let lastIntents = { total: 0, failed: 0 };
+  let lastErrorEvents = 0;
+  let lastState = run.state;
+
+  while (args.now() < deadline) {
+    pollCount++;
+    await args.sleep(pollMs);
+
+    const fresh = await safeCall(() => args.api.getRun(run.id), null);
+    if (fresh) lastState = fresh.state;
+    lastIntents = await safeCall(() => args.api.countIntents(run.id), lastIntents);
+    lastErrorEvents = await safeCall(() => args.api.countErrorEvents(run.id), lastErrorEvents);
+
+    log(
+      `[demoSmoke] poll=${pollCount} state=${lastState} ` +
+      `intents=${lastIntents.total} (failed=${lastIntents.failed}) errorEvents=${lastErrorEvents}`,
+    );
+
+    // Early-exit: если run уже в terminal state — нет смысла продолжать поллить.
+    if (lastState === "FAILED" || lastState === "TIMED_OUT" || lastState === "STOPPED") {
+      log(`[demoSmoke] run reached terminal state ${lastState}, exiting poll loop`);
+      break;
+    }
+  }
+
+  // Try to stop the run gracefully — но не считаем ошибку остановки за
+  // failure если run уже в terminal state.
+  if (lastState !== "FAILED" && lastState !== "TIMED_OUT" && lastState !== "STOPPED") {
+    await safeCall(() => args.api.stopRun({ botId: created.botId, runId: run.id }), { id: run.id, state: lastState });
+    const final = await safeCall(() => args.api.getRun(run.id), null);
+    if (final) lastState = final.state;
+  }
+
+  // Final read-out — capture state after stop completed.
+  lastIntents = await safeCall(() => args.api.countIntents(run.id), lastIntents);
+  lastErrorEvents = await safeCall(() => args.api.countErrorEvents(run.id), lastErrorEvents);
+
+  const finishedAt = args.now();
+  const metrics: SmokeMetrics = {
+    finalRunState: lastState,
+    pollCount,
+    intentCount: lastIntents.total,
+    failedIntentCount: lastIntents.failed,
+    errorEventCount: lastErrorEvents,
+    harnessHttpFailures,
+    actualDurationMin: (finishedAt - startedAt) / 60_000,
+  };
+  const acceptance = evaluateAcceptance(metrics);
+
+  return {
+    presetSlug: args.presetSlug,
+    workspaceId: args.workspaceId,
+    startedAt: new Date(startedAt).toISOString(),
+    finishedAt: new Date(finishedAt).toISOString(),
+    botId: created.botId,
+    runId: run.id,
+    metrics,
+    acceptance,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Default API implementation: HTTP for write paths, Prisma for read paths
+// ---------------------------------------------------------------------------
+
+interface BuildApiInput {
+  baseUrl: string;
+  token: string;
+  prisma: PrismaClient;
+}
+
+export function buildDefaultApi(input: BuildApiInput): SmokeApi {
+  const headers = {
+    "content-type": "application/json",
+    authorization: `Bearer ${input.token}`,
+  };
+
+  async function postJson<T>(path: string, body: unknown): Promise<T> {
+    const res = await fetch(`${input.baseUrl}${path}`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`POST ${path} -> ${res.status} ${res.statusText}: ${text.slice(0, 200)}`);
+    }
+    return (await res.json()) as T;
+  }
+
+  return {
+    async instantiatePreset({ slug, workspaceId, overrides }) {
+      return postJson<InstantiateResponse>(
+        `/presets/${encodeURIComponent(slug)}/instantiate`,
+        { workspaceId, overrides },
+      );
+    },
+
+    async startRun({ botId, durationMinutes }) {
+      return postJson<RunResponse>(
+        `/bots/${encodeURIComponent(botId)}/runs`,
+        { durationMinutes },
+      );
+    },
+
+    async stopRun({ botId, runId }) {
+      return postJson<RunResponse>(
+        `/bots/${encodeURIComponent(botId)}/runs/${encodeURIComponent(runId)}/stop`,
+        {},
+      );
+    },
+
+    async getRun(runId) {
+      const row = await input.prisma.botRun.findUnique({
+        where: { id: runId },
+        select: { state: true, errorCode: true },
+      });
+      return row;
+    },
+
+    async countIntents(runId) {
+      const [total, failed] = await Promise.all([
+        input.prisma.botIntent.count({ where: { botRunId: runId } }),
+        input.prisma.botIntent.count({ where: { botRunId: runId, state: "FAILED" } }),
+      ]);
+      return { total, failed };
+    },
+
+    async countErrorEvents(runId) {
+      const events = await input.prisma.botEvent.findMany({
+        where: { botRunId: runId },
+        select: { type: true, payloadJson: true },
+      });
+      return events.filter((e) => isErrorEvent(e.type, e.payloadJson)).length;
+    },
+  };
+}
+
+/**
+ * Heuristic для error-event detection. Берём:
+ *   - явные RUN_FAILED / RUN_RECONCILED_FAILED / *_ERROR types,
+ *   - либо payload содержит `error` / `failed` ключ верхнего уровня.
+ * Намеренно простая логика — операторы сами читают smokeOutput JSON
+ * для разбора root cause.
+ */
+export function isErrorEvent(type: string, payload: unknown): boolean {
+  const t = type.toLowerCase();
+  if (t.includes("fail") || t.includes("error")) return true;
+  if (payload && typeof payload === "object") {
+    const obj = payload as Record<string, unknown>;
+    if ("error" in obj && obj.error != null) return true;
+    if ("failed" in obj && obj.failed === true) return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Process entry point
+// ---------------------------------------------------------------------------
+
+const __filename = fileURLToPath(import.meta.url);
+
+const isDirectInvocation = (() => {
+  if (typeof process === "undefined" || !process.argv[1]) return false;
+  const entry = process.argv[1];
+  return entry.endsWith("demoSmoke.ts") || entry.endsWith("demoSmoke.js");
+})();
+
+export interface ValidatedSmokeConfig {
+  preset: string;
+  workspace: string;
+  token: string;
+  baseUrl: string;
+  durationMin: number;
+  pollIntervalSec: number;
+  symbol?: string;
+  quoteAmount?: number;
+  outputDir: string;
+  dryRun: boolean;
+}
+
+export type ValidationResult =
+  | { kind: "ok"; config: ValidatedSmokeConfig }
+  | { kind: "error"; reason: string };
+
+/** Валидирует CLI-аргументы / env. Pure, чтобы тесты могли проверить
+ *  все error-paths без spawn'а процесса. */
+export function validateCliArgs(parsed: ParsedSmokeArgs, env: Record<string, string | undefined>): ValidationResult {
+  const preset = parsed.preset ?? env.DEMO_SMOKE_PRESET;
+  const workspace = parsed.workspace ?? env.DEMO_SMOKE_WORKSPACE;
+  const token = parsed.token ?? env.DEMO_SMOKE_TOKEN;
+  const baseUrl = parsed.baseUrl ?? env.DEMO_SMOKE_BASE_URL ?? "http://localhost:3001/api/v1";
+
+  if (!preset) return { kind: "error", reason: "--preset <slug> is required (or DEMO_SMOKE_PRESET)" };
+  if (!workspace) return { kind: "error", reason: "--workspace <id> is required (or DEMO_SMOKE_WORKSPACE)" };
+  if (!token) return { kind: "error", reason: "--token <jwt> is required (or DEMO_SMOKE_TOKEN)" };
+
+  const durationMin = parsed.durationMin ?? 30;
+  if (!Number.isFinite(durationMin) || durationMin < 1 || durationMin > 1440) {
+    return { kind: "error", reason: `--duration-min must be 1..1440 (got ${parsed.durationMin})` };
+  }
+
+  const pollIntervalSec = parsed.pollIntervalSec ?? 60;
+  if (!Number.isFinite(pollIntervalSec) || pollIntervalSec < 1 || pollIntervalSec > 600) {
+    return { kind: "error", reason: `--poll-interval-sec must be 1..600 (got ${parsed.pollIntervalSec})` };
+  }
+
+  const outputDir = parsed.outputDir ?? join(dirname(__filename), ".smoke-output");
+
+  return {
+    kind: "ok",
+    config: {
+      preset,
+      workspace,
+      token,
+      baseUrl,
+      durationMin,
+      pollIntervalSec,
+      symbol: parsed.symbol,
+      quoteAmount: parsed.quoteAmount,
+      outputDir,
+      dryRun: parsed.dryRun,
+    },
+  };
+}
+
+async function main(): Promise<number> {
+  const cli = parseArgs(process.argv.slice(2));
+  const validated = validateCliArgs(cli, process.env);
+  if (validated.kind === "error") {
+    console.error(`error: ${validated.reason}`);
+    return 2;
+  }
+
+  const cfg = validated.config;
+
+  if (cfg.dryRun) {
+    console.log("[demoSmoke] dry-run — config validated, no run executed:");
+    console.log(JSON.stringify({ ...cfg, token: "<redacted>" }, null, 2));
+    return 0;
+  }
+
+  const prisma = new PrismaClient();
+  const api = buildDefaultApi({ baseUrl: cfg.baseUrl, token: cfg.token, prisma });
+
+  try {
+    const report = await runDemoSmoke({
+      presetSlug: cfg.preset,
+      workspaceId: cfg.workspace,
+      durationMin: cfg.durationMin,
+      pollIntervalSec: cfg.pollIntervalSec,
+      overrides: { symbol: cfg.symbol, quoteAmount: cfg.quoteAmount },
+      api,
+      sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+      now: () => Date.now(),
+    });
+
+    await mkdir(cfg.outputDir, { recursive: true });
+    const ts = new Date().toISOString().replace(/[:.]/g, "-");
+    const outPath = join(cfg.outputDir, `${ts}-${cfg.preset}.json`);
+    await writeFile(outPath, JSON.stringify(report, null, 2), "utf-8");
+
+    console.log("\n=== demoSmoke summary ===");
+    console.log(`preset:        ${report.presetSlug}`);
+    console.log(`run:           ${report.runId}`);
+    console.log(`finalState:    ${report.metrics.finalRunState}`);
+    console.log(`intents:       ${report.metrics.intentCount} (failed=${report.metrics.failedIntentCount})`);
+    console.log(`errorEvents:   ${report.metrics.errorEventCount}`);
+    console.log(`httpFailures:  ${report.metrics.harnessHttpFailures}`);
+    console.log(`durationMin:   ${report.metrics.actualDurationMin.toFixed(2)}`);
+    console.log(`acceptance:    ${report.acceptance.pass ? "PASS" : "FAIL"}`);
+    if (report.acceptance.warnings.length) {
+      console.log(`warnings:      ${report.acceptance.warnings.join("; ")}`);
+    }
+    if (report.acceptance.failures.length) {
+      console.log(`failures:      ${report.acceptance.failures.join("; ")}`);
+    }
+    console.log(`report:        ${outPath}`);
+
+    return report.acceptance.pass ? 0 : 1;
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+if (isDirectInvocation) {
+  main()
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      console.error("[demoSmoke] fatal error:", err);
+      process.exit(1);
+    });
+}

--- a/apps/api/tests/scripts/demoSmoke.test.ts
+++ b/apps/api/tests/scripts/demoSmoke.test.ts
@@ -1,0 +1,427 @@
+/**
+ * demoSmoke harness — unit coverage (docs/53-T3).
+ *
+ * Покрывает:
+ *  1. parseArgs — все флаги.
+ *  2. validateCliArgs — required-проверки + диапазоны + env fallback.
+ *  3. evaluateAcceptance — все pass / fail / warning ветви.
+ *  4. isErrorEvent — type-heuristic + payload-heuristic.
+ *  5. runDemoSmoke — end-to-end оркестрация на mocked SmokeApi:
+ *       happy path, terminal-state early exit, http failures
+ *       аккумулируются, stop-after-deadline.
+ *
+ * Без сети, без БД, без real time — sleep / now инжектируются.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  parseArgs,
+  validateCliArgs,
+  evaluateAcceptance,
+  isErrorEvent,
+  runDemoSmoke,
+  type SmokeApi,
+  type SmokeMetrics,
+} from "../../scripts/demoSmoke.js";
+
+// ---------------------------------------------------------------------------
+// parseArgs
+// ---------------------------------------------------------------------------
+
+describe("demoSmoke.parseArgs", () => {
+  it("parses each known flag", () => {
+    const out = parseArgs([
+      "--preset", "adaptive-regime",
+      "--workspace", "ws-1",
+      "--token", "jwt",
+      "--base-url", "http://api.test/v1",
+      "--duration-min", "45",
+      "--poll-interval-sec", "30",
+      "--symbol", "ETHUSDT",
+      "--quote-amount", "75",
+      "--output-dir", "/tmp/x",
+      "--dry-run",
+    ]);
+    expect(out).toEqual({
+      preset: "adaptive-regime",
+      workspace: "ws-1",
+      token: "jwt",
+      baseUrl: "http://api.test/v1",
+      durationMin: 45,
+      pollIntervalSec: 30,
+      symbol: "ETHUSDT",
+      quoteAmount: 75,
+      outputDir: "/tmp/x",
+      dryRun: true,
+    });
+  });
+
+  it("returns dryRun=false and missing fields when nothing passed", () => {
+    expect(parseArgs([])).toEqual({ dryRun: false });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateCliArgs
+// ---------------------------------------------------------------------------
+
+describe("demoSmoke.validateCliArgs", () => {
+  const baseEnv = {} as Record<string, string | undefined>;
+
+  it("requires preset", () => {
+    const r = validateCliArgs({ workspace: "w", token: "t", dryRun: false }, baseEnv);
+    expect(r.kind).toBe("error");
+    if (r.kind === "error") expect(r.reason).toMatch(/preset/);
+  });
+
+  it("requires workspace", () => {
+    const r = validateCliArgs({ preset: "p", token: "t", dryRun: false }, baseEnv);
+    expect(r.kind).toBe("error");
+    if (r.kind === "error") expect(r.reason).toMatch(/workspace/);
+  });
+
+  it("requires token", () => {
+    const r = validateCliArgs({ preset: "p", workspace: "w", dryRun: false }, baseEnv);
+    expect(r.kind).toBe("error");
+    if (r.kind === "error") expect(r.reason).toMatch(/token/);
+  });
+
+  it("falls back to env vars", () => {
+    const r = validateCliArgs(
+      { dryRun: false },
+      {
+        DEMO_SMOKE_PRESET: "p",
+        DEMO_SMOKE_WORKSPACE: "w",
+        DEMO_SMOKE_TOKEN: "t",
+        DEMO_SMOKE_BASE_URL: "http://example/v1",
+      },
+    );
+    expect(r.kind).toBe("ok");
+    if (r.kind === "ok") {
+      expect(r.config.preset).toBe("p");
+      expect(r.config.workspace).toBe("w");
+      expect(r.config.token).toBe("t");
+      expect(r.config.baseUrl).toBe("http://example/v1");
+    }
+  });
+
+  it("rejects out-of-range durationMin", () => {
+    const r = validateCliArgs(
+      { preset: "p", workspace: "w", token: "t", durationMin: 9999, dryRun: false },
+      baseEnv,
+    );
+    expect(r.kind).toBe("error");
+  });
+
+  it("rejects out-of-range pollIntervalSec", () => {
+    const r = validateCliArgs(
+      { preset: "p", workspace: "w", token: "t", pollIntervalSec: 0, dryRun: false },
+      baseEnv,
+    );
+    expect(r.kind).toBe("error");
+  });
+
+  it("applies sensible defaults", () => {
+    const r = validateCliArgs(
+      { preset: "p", workspace: "w", token: "t", dryRun: false },
+      baseEnv,
+    );
+    expect(r.kind).toBe("ok");
+    if (r.kind === "ok") {
+      expect(r.config.durationMin).toBe(30);
+      expect(r.config.pollIntervalSec).toBe(60);
+      expect(r.config.baseUrl).toBe("http://localhost:3001/api/v1");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evaluateAcceptance
+// ---------------------------------------------------------------------------
+
+const baseMetrics = (): SmokeMetrics => ({
+  finalRunState: "STOPPED",
+  pollCount: 30,
+  intentCount: 5,
+  failedIntentCount: 0,
+  errorEventCount: 0,
+  harnessHttpFailures: 0,
+  actualDurationMin: 30,
+});
+
+describe("demoSmoke.evaluateAcceptance", () => {
+  it("passes on clean run", () => {
+    const r = evaluateAcceptance(baseMetrics());
+    expect(r.pass).toBe(true);
+    expect(r.failures).toEqual([]);
+    expect(r.warnings).toEqual([]);
+  });
+
+  it("warns (not fails) when intentCount=0", () => {
+    const r = evaluateAcceptance({ ...baseMetrics(), intentCount: 0 });
+    expect(r.pass).toBe(true);
+    expect(r.warnings.length).toBeGreaterThan(0);
+    expect(r.warnings[0]).toMatch(/intentCount=0/);
+  });
+
+  it("fails on FAILED finalRunState", () => {
+    const r = evaluateAcceptance({ ...baseMetrics(), finalRunState: "FAILED" });
+    expect(r.pass).toBe(false);
+    expect(r.failures.join(",")).toMatch(/finalRunState=FAILED/);
+  });
+
+  it("fails on TIMED_OUT finalRunState", () => {
+    const r = evaluateAcceptance({ ...baseMetrics(), finalRunState: "TIMED_OUT" });
+    expect(r.pass).toBe(false);
+  });
+
+  it("fails on errorEventCount > 0", () => {
+    const r = evaluateAcceptance({ ...baseMetrics(), errorEventCount: 3 });
+    expect(r.pass).toBe(false);
+    expect(r.failures.join(",")).toMatch(/errorEventCount=3/);
+  });
+
+  it("fails on harnessHttpFailures > 0", () => {
+    const r = evaluateAcceptance({ ...baseMetrics(), harnessHttpFailures: 2 });
+    expect(r.pass).toBe(false);
+    expect(r.failures.join(",")).toMatch(/harnessHttpFailures=2/);
+  });
+
+  it("fails on failedIntentCount > 0", () => {
+    const r = evaluateAcceptance({ ...baseMetrics(), failedIntentCount: 1 });
+    expect(r.pass).toBe(false);
+    expect(r.failures.join(",")).toMatch(/failedIntentCount=1/);
+  });
+
+  it("aggregates multiple failures", () => {
+    const r = evaluateAcceptance({
+      ...baseMetrics(),
+      finalRunState: "FAILED",
+      errorEventCount: 2,
+      failedIntentCount: 1,
+    });
+    expect(r.pass).toBe(false);
+    expect(r.failures).toHaveLength(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isErrorEvent heuristic
+// ---------------------------------------------------------------------------
+
+describe("demoSmoke.isErrorEvent", () => {
+  it("matches type containing 'fail'", () => {
+    expect(isErrorEvent("RUN_RECONCILED_FAILED", null)).toBe(true);
+  });
+
+  it("matches type containing 'error'", () => {
+    expect(isErrorEvent("ORDER_PLACEMENT_ERROR", null)).toBe(true);
+  });
+
+  it("ignores benign types", () => {
+    expect(isErrorEvent("signal_entry", null)).toBe(false);
+    expect(isErrorEvent("RUN_QUEUED", null)).toBe(false);
+  });
+
+  it("matches when payload has truthy `error` key", () => {
+    expect(isErrorEvent("intent_done", { error: "rate-limit" })).toBe(true);
+  });
+
+  it("ignores payload with null error", () => {
+    expect(isErrorEvent("intent_done", { error: null })).toBe(false);
+  });
+
+  it("matches when payload has failed=true", () => {
+    expect(isErrorEvent("intent_done", { failed: true })).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runDemoSmoke orchestration with mocked SmokeApi
+// ---------------------------------------------------------------------------
+
+interface FakeRunState {
+  state: string;
+  errorCode: string | null;
+}
+
+function buildFakeApi(opts: {
+  /** Sequence of run states returned by getRun on each poll. Last one is also final state. */
+  runStates: string[];
+  intentsByPoll?: { total: number; failed: number }[];
+  errorEventsByPoll?: number[];
+  /** If set, instantiatePreset throws once before succeeding. */
+  failFirstInstantiate?: boolean;
+  /** If true, getRun throws on every call. */
+  throwOnGetRun?: boolean;
+}): { api: SmokeApi; calls: { instantiate: number; start: number; stop: number; getRun: number; countIntents: number; countErrors: number } } {
+  let pollIdx = 0;
+  let instantiateCount = 0;
+  let stopped = false;
+  const calls = { instantiate: 0, start: 0, stop: 0, getRun: 0, countIntents: 0, countErrors: 0 };
+
+  const api: SmokeApi = {
+    async instantiatePreset() {
+      calls.instantiate++;
+      instantiateCount++;
+      if (opts.failFirstInstantiate && instantiateCount === 1) {
+        throw new Error("simulated instantiate failure");
+      }
+      return { botId: "bot-1", strategyId: "s-1", strategyVersionId: "sv-1" };
+    },
+    async startRun() {
+      calls.start++;
+      return { id: "run-1", state: opts.runStates[0] ?? "RUNNING" };
+    },
+    async stopRun() {
+      calls.stop++;
+      stopped = true;
+      return { id: "run-1", state: "STOPPED" };
+    },
+    async getRun(): Promise<FakeRunState | null> {
+      calls.getRun++;
+      if (opts.throwOnGetRun) throw new Error("simulated getRun failure");
+      // Once stopRun was called, subsequent reads observe STOPPED — same
+      // semantics as Postgres after the route's transition() runs.
+      if (stopped) return { state: "STOPPED", errorCode: null };
+      const state = opts.runStates[pollIdx] ?? opts.runStates[opts.runStates.length - 1] ?? "RUNNING";
+      pollIdx = Math.min(pollIdx + 1, opts.runStates.length - 1);
+      return { state, errorCode: null };
+    },
+    async countIntents() {
+      calls.countIntents++;
+      const i = Math.min(calls.countIntents - 1, (opts.intentsByPoll?.length ?? 1) - 1);
+      return opts.intentsByPoll?.[i] ?? { total: 0, failed: 0 };
+    },
+    async countErrorEvents() {
+      calls.countErrors++;
+      const i = Math.min(calls.countErrors - 1, (opts.errorEventsByPoll?.length ?? 1) - 1);
+      return opts.errorEventsByPoll?.[i] ?? 0;
+    },
+  };
+  return { api, calls };
+}
+
+describe("demoSmoke.runDemoSmoke", () => {
+  it("happy path: instantiates → starts → polls → stops → PASS", async () => {
+    const { api, calls } = buildFakeApi({
+      runStates: ["RUNNING", "RUNNING", "RUNNING"],
+      intentsByPoll: [
+        { total: 0, failed: 0 },
+        { total: 1, failed: 0 },
+        { total: 3, failed: 0 },
+        { total: 3, failed: 0 }, // post-stop final read
+      ],
+      errorEventsByPoll: [0, 0, 0, 0],
+    });
+
+    let now = 1_000_000;
+    const sleep = vi.fn(async (ms: number) => { now += ms; });
+
+    const report = await runDemoSmoke({
+      presetSlug: "adaptive-regime",
+      workspaceId: "ws-1",
+      durationMin: 2,        // 2 минуты × 60s polls = 2 итерации
+      pollIntervalSec: 60,
+      overrides: { symbol: "BTCUSDT", quoteAmount: 50 },
+      api,
+      sleep,
+      now: () => now,
+      log: () => {},
+    });
+
+    expect(calls.instantiate).toBe(1);
+    expect(calls.start).toBe(1);
+    expect(calls.stop).toBe(1);
+    expect(report.metrics.finalRunState).toBe("STOPPED");
+    expect(report.metrics.intentCount).toBe(3);
+    expect(report.metrics.failedIntentCount).toBe(0);
+    expect(report.metrics.harnessHttpFailures).toBe(0);
+    expect(report.acceptance.pass).toBe(true);
+    expect(report.botId).toBe("bot-1");
+    expect(report.runId).toBe("run-1");
+  });
+
+  it("early-exits on terminal FAILED state and skips stop call", async () => {
+    const { api, calls } = buildFakeApi({
+      runStates: ["RUNNING", "FAILED"],
+      intentsByPoll: [{ total: 0, failed: 0 }, { total: 0, failed: 0 }, { total: 0, failed: 0 }],
+      errorEventsByPoll: [0, 1, 1],
+    });
+
+    let now = 0;
+    const sleep = async (ms: number) => { now += ms; };
+
+    const report = await runDemoSmoke({
+      presetSlug: "adaptive-regime",
+      workspaceId: "ws-1",
+      durationMin: 10,
+      pollIntervalSec: 60,
+      overrides: {},
+      api,
+      sleep,
+      now: () => now,
+      log: () => {},
+    });
+
+    expect(calls.stop).toBe(0); // already terminal — no stop call
+    expect(report.metrics.finalRunState).toBe("FAILED");
+    expect(report.acceptance.pass).toBe(false);
+  });
+
+  it("counts harness http failures without aborting", async () => {
+    const { api } = buildFakeApi({
+      runStates: ["RUNNING"],
+      intentsByPoll: [{ total: 1, failed: 0 }],
+      errorEventsByPoll: [0],
+      throwOnGetRun: true,
+    });
+
+    let now = 0;
+    const sleep = async (ms: number) => { now += ms; };
+
+    const report = await runDemoSmoke({
+      presetSlug: "adaptive-regime",
+      workspaceId: "ws-1",
+      durationMin: 1,
+      pollIntervalSec: 60,
+      overrides: {},
+      api,
+      sleep,
+      now: () => now,
+      log: () => {},
+    });
+
+    // getRun fails on every poll AND in the post-stop read-out → harnessHttpFailures > 0.
+    expect(report.metrics.harnessHttpFailures).toBeGreaterThan(0);
+    expect(report.acceptance.pass).toBe(false);
+    expect(report.acceptance.failures.some((f) => f.includes("harnessHttpFailures"))).toBe(true);
+  });
+
+  it("warns when intentCount remains 0", async () => {
+    const { api } = buildFakeApi({
+      runStates: ["RUNNING"],
+      intentsByPoll: [{ total: 0, failed: 0 }, { total: 0, failed: 0 }],
+      errorEventsByPoll: [0, 0],
+    });
+
+    let now = 0;
+    const sleep = async (ms: number) => { now += ms; };
+
+    const report = await runDemoSmoke({
+      presetSlug: "adaptive-regime",
+      workspaceId: "ws-1",
+      durationMin: 1,
+      pollIntervalSec: 60,
+      overrides: {},
+      api,
+      sleep,
+      now: () => now,
+      log: () => {},
+    });
+
+    expect(report.acceptance.pass).toBe(true);
+    expect(report.acceptance.warnings.length).toBe(1);
+    expect(report.acceptance.warnings[0]).toMatch(/intentCount=0/);
+  });
+});

--- a/docs/53-baseline-results.md
+++ b/docs/53-baseline-results.md
@@ -1,0 +1,94 @@
+# 53. Adaptive Regime — Baseline Results
+
+> **Status:** template ready, awaiting filled-in runs
+> **Plan:** `docs/53-adaptive-regime-bot-activation.md`
+> **Last updated:** _populate when filling in for a real acceptance run_
+
+This is the companion-doc for the Adaptive Regime acceptance gate
+(`docs/53-T2` walk-forward + `docs/53-T3` demo smoke). Each section
+becomes filled in when the corresponding T-task runs. Until acceptance
+is recorded here, `publishPreset.ts --slug adaptive-regime --visibility
+PUBLIC` refuses to flip without `--force` (per `docs/53-T4`).
+
+---
+
+## 1. Walk-forward acceptance (53-T2)
+
+Status: PENDING
+
+Acceptance criteria (`docs/50 §A5`):
+- per-fold `pnlPct > 0`
+- aggregated `sharpe > 0.3`
+- aggregated `maxDrawdownPct > -25%`
+
+Evidence: `walkForwardRunId = …`
+
+Notes: _populate after run_
+
+---
+
+## 2. Demo smoke run (53-T3)
+
+Status: PENDING
+
+Harness:
+
+```
+pnpm --filter @botmarketplace/api exec tsx scripts/demoSmoke.ts \
+  --preset adaptive-regime \
+  --workspace <ws-id> \
+  --token "$DEMO_JWT" \
+  --base-url http://localhost:3001/api/v1 \
+  --duration-min 30 \
+  --symbol BTCUSDT \
+  --quote-amount 50
+```
+
+Acceptance (from `apps/api/scripts/demoSmoke.ts:evaluateAcceptance`):
+- `finalRunState ∉ {FAILED, TIMED_OUT}`
+- `errorEventCount === 0`
+- `failedIntentCount === 0`
+- `harnessHttpFailures === 0`
+- `intentCount > 0` (warning if 0; operator decides rerun)
+
+| Field | Value |
+| ----- | ----- |
+| Run timestamp |  |
+| Duration (min) |  |
+| Final run state |  |
+| Intent count |  |
+| Failed intents |  |
+| Error events |  |
+| Acceptance | PASS \| FAIL |
+| Report file | `apps/api/scripts/.smoke-output/<ts>-adaptive-regime.json` |
+
+Notes: _operator pastes summary excerpt + sign-off here_
+
+---
+
+## 3. Visibility flip (53-T4)
+
+Status: PENDING
+
+Acceptance: PASS marker (paste exact line below before invoking
+`publishPreset.ts`):
+
+```
+Acceptance: PASS
+```
+
+Flip log (one-line audit from `publishPreset.ts` stdout):
+
+```
+[publishPreset] OK adaptive-regime → PUBLIC (updatedAt=...)
+```
+
+Notes: _operator pastes flip timestamp + admin user_
+
+---
+
+## 4. Final decision
+
+Decision: PENDING
+
+Rationale: _populate when all three sections above PASS_

--- a/docs/54-baseline-results.md
+++ b/docs/54-baseline-results.md
@@ -1,0 +1,125 @@
+# 54. Flagship Rollout — Baseline Results (DCA / MTF / SMC)
+
+> **Status:** template ready, awaiting filled-in runs
+> **Plan:** `docs/54-flagship-rollout.md`
+> **Last updated:** _populate when filling in_
+
+Companion-doc for the three remaining non-funding flagships, mirroring
+`docs/53-baseline-results.md` structure but compacted into one file.
+Each section gets filled in as `54-T1` (DCA), `54-T2` (MTF Scalper) and
+`54-T3` (SMC Liquidity Sweep) close. Visibility flip via
+`publishPreset.ts` is gated on the `Acceptance: PASS` marker per
+preset.
+
+The smoke harness itself is preset-agnostic
+(`apps/api/scripts/demoSmoke.ts` — see `docs/53-baseline-results.md §2`
+for invocation shape). All three sections below reuse the same
+acceptance criteria as `docs/53-T3`.
+
+---
+
+## DCA Momentum
+
+Status: PENDING
+
+### Walk-forward acceptance (54-T1)
+
+Evidence: `walkForwardRunId = …`
+
+Notes: _populate after run_
+
+### Demo smoke run (54-T1)
+
+Invocation: `--preset dca-momentum --duration-min 30`.
+
+| Field | Value |
+| ----- | ----- |
+| Run timestamp |  |
+| Duration (min) |  |
+| Final run state |  |
+| Intent count |  |
+| Failed intents |  |
+| Error events |  |
+| Acceptance | PASS \| FAIL |
+| Report file | `apps/api/scripts/.smoke-output/<ts>-dca-momentum.json` |
+
+### Visibility flip (54-T1)
+
+Acceptance: PENDING
+
+Flip log: _populate after `publishPreset.ts --slug dca-momentum --visibility PUBLIC`_
+
+---
+
+## MTF Scalper
+
+Status: PENDING
+
+### Walk-forward acceptance (54-T2)
+
+Evidence: `walkForwardRunId = …`
+
+Notes: _populate after run_
+
+### Demo smoke run (54-T2)
+
+Invocation: `--preset mtf-scalper --duration-min 30`.
+
+| Field | Value |
+| ----- | ----- |
+| Run timestamp |  |
+| Duration (min) |  |
+| Final run state |  |
+| Intent count |  |
+| Failed intents |  |
+| Error events |  |
+| Acceptance | PASS \| FAIL |
+| Report file | `apps/api/scripts/.smoke-output/<ts>-mtf-scalper.json` |
+
+### Visibility flip (54-T2)
+
+Acceptance: PENDING
+
+Flip log: _populate after `publishPreset.ts --slug mtf-scalper --visibility PUBLIC`_
+
+---
+
+## SMC Liquidity Sweep
+
+Status: PENDING
+
+### Walk-forward acceptance (54-T3)
+
+Evidence: `walkForwardRunId = …`
+
+Notes: _populate after run_
+
+### Demo smoke run (54-T3)
+
+Invocation: `--preset smc-liquidity-sweep --duration-min 30`.
+
+| Field | Value |
+| ----- | ----- |
+| Run timestamp |  |
+| Duration (min) |  |
+| Final run state |  |
+| Intent count |  |
+| Failed intents |  |
+| Error events |  |
+| Acceptance | PASS \| FAIL |
+| Report file | `apps/api/scripts/.smoke-output/<ts>-smc-liquidity-sweep.json` |
+
+### Visibility flip (54-T3)
+
+Acceptance: PENDING
+
+Flip log: _populate after `publishPreset.ts --slug smc-liquidity-sweep --visibility PUBLIC`_
+
+---
+
+## Final decision
+
+Decision: PENDING
+
+Rationale: _populate when all three flagships PASS — feeds into
+`docs/54-go-no-go-gate.md §1` for the consolidated live gate_


### PR DESCRIPTION
## Summary

Closes the last functional gap in Track A flagship activation: the demo connectivity smoke harness used by `docs/53-T3` (Adaptive Regime), `docs/54-T1..T3` (DCA / MTF / SMC), and the `docs/55-T6` funding-arb sub-gate. With this in, every preset can be driven through the full acceptance lifecycle (golden DSL → walk-forward → demo smoke → publishPreset visibility flip) without bespoke per-preset tooling.

## What's in the PR

- **`apps/api/scripts/demoSmoke.ts`** — generic CLI parameterised by `--preset <slug>`. Instantiates a preset via the existing `POST /presets/:slug/instantiate` route, starts a run, polls `BotRun.state` / intent counts / error events at a configurable interval, gracefully stops on deadline, writes a JSON report, exits `0|1|2` per acceptance.
- **`evaluateAcceptance`** — pure function encoding the docs/53-T3 criteria (`finalRunState ∉ {FAILED, TIMED_OUT}`, `errorEventCount === 0`, `failedIntentCount === 0`, `harnessHttpFailures === 0`; `intentCount === 0` is a warning, not a fail).
- **`apps/api/tests/scripts/demoSmoke.test.ts`** — 27 unit tests covering arg parsing, env-var fallbacks, range validation, every acceptance branch, the error-event heuristic, and `runDemoSmoke` orchestration on an in-memory `SmokeApi` fake (no network, no DB, no real wall-clock — `sleep`/`now` are injected).
- **`docs/53-baseline-results.md` + `docs/54-baseline-results.md`** — companion-doc templates referenced from `publishPreset.ts` `--force` gate. Operators paste run summaries and the `Acceptance: PASS` marker before flipping a preset to PUBLIC.
- **`.gitignore`** — `apps/api/scripts/.smoke-output/` excluded; reports may contain workspace/run IDs.

## Design notes

- HTTP/Prisma I/O lives behind `SmokeApi` interface; tests run entirely in-process. The default implementation uses `fetch` for write paths (instantiate / start / stop) and Prisma for read paths (intents / events / run state).
- `harnessHttpFailures` is incremented by a `safeCall` wrapper rather than aborting — a transient blip should not lose accumulated metrics, but sustained 401/403/429 will fail acceptance loudly.
- Mirrors the `publishPreset.ts` shape: testable core + thin direct-invocation guard, no top-level await.
- No runtime/evaluator changes. No DB schema changes. Strictly an additive operator-tool + docs.

## Verification

- `pnpm exec tsc --noEmit` clean.
- `pnpm vitest run` — **2248 / 2248 pass** (was 2221 before; +27 from new tests).
- `vitest run tests/scripts/demoSmoke.test.ts` — 27/27 in 15ms.

## Test plan

- [ ] CI green.
- [ ] Operator dry-run: `pnpm --filter @botmarketplace/api exec tsx scripts/demoSmoke.ts --preset adaptive-regime --workspace <id> --token <jwt> --dry-run` prints redacted config.
- [ ] First real acceptance run on `adaptive-regime` (Bybit demo, 30 min) populates `docs/53-baseline-results.md §2`.

https://claude.ai/code/session_01RBdM6tb6c81Nu9saiDabco

---
_Generated by [Claude Code](https://claude.ai/code/session_01RBdM6tb6c81Nu9saiDabco)_