### PR TITLE
feat(exchanges): real /test endpoint hits /v5/user/query-api

### DIFF
--- a/apps/api/src/lib/exchange/bybitVerify.ts
+++ b/apps/api/src/lib/exchange/bybitVerify.ts
@@ -1,0 +1,201 @@
+/**
+ * Verify a Bybit API key by calling the read-only `/v5/user/query-api`
+ * endpoint and parsing the credential metadata it returns.
+ *
+ * Used by `POST /exchanges/:id/test` to give operators an instant
+ * answer when they wire up a fresh demo / live key — was the key
+ * accepted, against which environment, with what permissions, and when
+ * does it expire.
+ *
+ * Network/HTTP/Bybit-side errors are funnelled into a single typed
+ * result so the route handler does not have to discriminate between
+ * `throw` and "valid but failed" — both surface as
+ * `{ ok: false, code, detail }`.
+ */
+
+import { bybitAuthHeaders } from "./bybitAuth.js";
+import { getBybitBaseUrl, isBybitLive } from "../bybitOrder.js";
+
+const USER_AGENT = "botmarketplace-verify/1";
+const QUERY_API_PATH = "/v5/user/query-api";
+const REQUEST_TIMEOUT_MS = 10_000;
+
+/** Bybit-side response shape — only the fields we need; extra fields ignored. */
+interface BybitQueryApiResult {
+  apiKey?: string;
+  readOnly?: number;
+  /** ISO timestamp string, empty string, or "0" when no expiry set. */
+  expiredAt?: string;
+  /** Object whose keys are permission groups, each mapped to a string[] of granted scopes. */
+  permissions?: Record<string, string[]>;
+  type?: number;
+}
+
+interface BybitEnvelope {
+  retCode: number;
+  retMsg: string;
+  result?: BybitQueryApiResult;
+}
+
+export type VerifyFailureCode =
+  | "NETWORK"
+  | "TIMEOUT"
+  | "HTTP"
+  | "BYBIT"
+  | "MALFORMED";
+
+export interface VerifySuccess {
+  ok: true;
+  /** Inferred from the configured base URL — `live` if BYBIT_ENV=live or BYBIT_BASE_URL points at the live host, else `demo`. */
+  env: "demo" | "live";
+  /** Flat list of granted permissions in `Group:Scope` form (e.g. `ContractTrade:Order`). */
+  permissions: string[];
+  /** ISO timestamp when the key expires, or `null` when Bybit reports no expiry. */
+  expiresAt: string | null;
+  /** True when Bybit reports `readOnly: 1` — i.e. no Trade/Order scope was granted. */
+  readOnly: boolean;
+}
+
+export interface VerifyFailure {
+  ok: false;
+  code: VerifyFailureCode;
+  /** Human-friendly reason. Already operator-readable; safe to render verbatim. */
+  detail: string;
+  /** Bybit `retCode` when `code === "BYBIT"`. */
+  retCode?: number;
+  /** HTTP status when `code === "HTTP"`. */
+  httpStatus?: number;
+}
+
+export type VerifyResult = VerifySuccess | VerifyFailure;
+
+/**
+ * Hit Bybit `/v5/user/query-api` with the given credentials and translate
+ * the response into a `VerifyResult`. Never throws — every failure mode
+ * is a typed `VerifyFailure`.
+ *
+ * Optional `fetchImpl` is exposed only for tests; production callers use
+ * the global `fetch`.
+ */
+export async function bybitVerifyApiKey(
+  apiKey: string,
+  secret: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<VerifyResult> {
+  const baseUrl = getBybitBaseUrl();
+  const env: "demo" | "live" = isBybitLive() ? "live" : "demo";
+  const timestamp = Date.now().toString();
+  // GET signing payload is the URL-encoded query string. /v5/user/query-api
+  // takes no query parameters, so the payload is the empty string.
+  const headers = bybitAuthHeaders(apiKey, secret, timestamp, "", USER_AGENT);
+
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), REQUEST_TIMEOUT_MS);
+
+  let res: Response;
+  try {
+    res = await fetchImpl(`${baseUrl}${QUERY_API_PATH}`, {
+      method: "GET",
+      headers,
+      signal: ac.signal,
+    });
+  } catch (err) {
+    if ((err as { name?: string }).name === "AbortError") {
+      return { ok: false, code: "TIMEOUT", detail: "Bybit request timed out" };
+    }
+    return {
+      ok: false,
+      code: "NETWORK",
+      detail: `Bybit unreachable: ${(err as Error).message ?? "network error"}`,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (!res.ok) {
+    return {
+      ok: false,
+      code: "HTTP",
+      httpStatus: res.status,
+      detail: `Bybit returned HTTP ${res.status} ${res.statusText}`,
+    };
+  }
+
+  let body: BybitEnvelope;
+  try {
+    body = (await res.json()) as BybitEnvelope;
+  } catch {
+    return {
+      ok: false,
+      code: "MALFORMED",
+      detail: "Bybit response was not valid JSON",
+    };
+  }
+
+  if (typeof body.retCode !== "number") {
+    return {
+      ok: false,
+      code: "MALFORMED",
+      detail: "Bybit response missing retCode",
+    };
+  }
+
+  if (body.retCode !== 0) {
+    return {
+      ok: false,
+      code: "BYBIT",
+      retCode: body.retCode,
+      detail: `Bybit error ${body.retCode}: ${body.retMsg || "(no message)"}`,
+    };
+  }
+
+  const result = body.result;
+  if (!result) {
+    return {
+      ok: false,
+      code: "MALFORMED",
+      detail: "Bybit retCode=0 but no result payload",
+    };
+  }
+
+  return {
+    ok: true,
+    env,
+    permissions: flattenPermissions(result.permissions),
+    expiresAt: normaliseExpiry(result.expiredAt),
+    readOnly: result.readOnly === 1,
+  };
+}
+
+/**
+ * Bybit returns permissions as `{ Group: [Scope, Scope] }`. Flatten to
+ * `Group:Scope` strings sorted alphabetically — gives a stable, easily
+ * rendered list in the UI.
+ */
+function flattenPermissions(
+  raw: Record<string, string[]> | undefined,
+): string[] {
+  if (!raw) return [];
+  const flat: string[] = [];
+  for (const [group, scopes] of Object.entries(raw)) {
+    if (!Array.isArray(scopes)) continue;
+    for (const scope of scopes) {
+      if (typeof scope === "string" && scope.length > 0) {
+        flat.push(`${group}:${scope}`);
+      }
+    }
+  }
+  flat.sort();
+  return flat;
+}
+
+/**
+ * Bybit reports `expiredAt` either as an ISO timestamp ("2023-04-19T03:25:05Z"),
+ * the literal string "0" (no expiry), an empty string (no expiry), or the
+ * field is absent. Normalise to `string | null`.
+ */
+function normaliseExpiry(raw: string | undefined): string | null {
+  if (!raw) return null;
+  if (raw === "0") return null;
+  return raw;
+}

--- a/apps/api/src/routes/exchanges.ts
+++ b/apps/api/src/routes/exchanges.ts
@@ -3,6 +3,7 @@ import { prisma } from "../lib/prisma.js";
 import { problem } from "../lib/problem.js";
 import { resolveWorkspace } from "../lib/workspace.js";
 import { getEncryptionKey, encrypt, decryptWithFallback } from "../lib/crypto.js";
+import { bybitVerifyApiKey } from "../lib/exchange/bybitVerify.js";
 
 // ---------------------------------------------------------------------------
 // Safe projection — never return encryptedSecret or apiKey in responses
@@ -309,7 +310,11 @@ export async function exchangeRoutes(app: FastifyInstance) {
     return reply.status(204).send();
   });
 
-  // POST /exchanges/:id/test — demo-first connectivity check
+  // POST /exchanges/:id/test — real read-only call to Bybit /v5/user/query-api.
+  //
+  // Returns enriched metadata (env, permissions, expiry, readOnly) so the
+  // operator gets an instant, accurate answer about a freshly wired key
+  // before committing to a 30-min smoke run.
   app.post<{ Params: { id: string } }>("/exchanges/:id/test", { onRequest: [app.authenticate] }, async (request, reply) => {
     const workspace = await resolveWorkspace(request, reply);
     if (!workspace) return;
@@ -329,28 +334,63 @@ export async function exchangeRoutes(app: FastifyInstance) {
       return problem(reply, 500, "Internal Server Error", "Failed to decrypt exchange credentials");
     }
 
-    // Demo-first: validate that credentials are non-empty and perform a lightweight
-    // reachability check. A real exchange call (e.g. GET /v5/account/info on Bybit)
-    // would be wired in Stage 9b.
-    let status: "CONNECTED" | "FAILED" = "FAILED";
-    let detail = "Connection test failed";
+    if (!conn.apiKey || !decryptedSecret) {
+      await prisma.exchangeConnection.update({
+        where: { id: conn.id },
+        data: { status: "FAILED" },
+      });
+      return reply.send({
+        id: conn.id,
+        status: "FAILED" as const,
+        detail: "Stored credentials are empty",
+      });
+    }
 
-    if (conn.apiKey && decryptedSecret) {
-      // Demo placeholder: credentials present → optimistically mark CONNECTED.
-      // Stage 9b will replace this with a real exchange API call.
-      status = "CONNECTED";
-      detail = "Credentials verified (demo-first — real exchange call deferred to Stage 9b)";
+    if (conn.exchange !== "BYBIT") {
+      // Other exchanges are not yet wired into the verify helper. Surface a
+      // FAILED result rather than mis-reporting CONNECTED.
+      await prisma.exchangeConnection.update({
+        where: { id: conn.id },
+        data: { status: "FAILED" },
+      });
+      return reply.send({
+        id: conn.id,
+        status: "FAILED" as const,
+        detail: `Test endpoint not implemented for exchange ${conn.exchange}`,
+      });
+    }
+
+    const verify = await bybitVerifyApiKey(conn.apiKey, decryptedSecret);
+
+    if (!verify.ok) {
+      await prisma.exchangeConnection.update({
+        where: { id: conn.id },
+        data: { status: "FAILED" },
+      });
+      return reply.send({
+        id: conn.id,
+        status: "FAILED" as const,
+        detail: verify.detail,
+      });
     }
 
     await prisma.exchangeConnection.update({
       where: { id: conn.id },
-      data: { status },
+      data: { status: "CONNECTED" },
     });
 
+    const permLabel = verify.readOnly
+      ? "read-only"
+      : `${verify.permissions.length} permissions`;
+    const expiryLabel = verify.expiresAt ? ` · expires ${verify.expiresAt}` : "";
     return reply.send({
       id: conn.id,
-      status,
-      detail,
+      status: "CONNECTED" as const,
+      detail: `Bybit ${verify.env} key verified (${permLabel})${expiryLabel}`,
+      env: verify.env,
+      permissions: verify.permissions,
+      expiresAt: verify.expiresAt,
+      readOnly: verify.readOnly,
     });
   });
 }

--- a/apps/api/tests/lib/exchange/bybitVerify.test.ts
+++ b/apps/api/tests/lib/exchange/bybitVerify.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Unit tests for `bybitVerifyApiKey` — covers every branch in the result
+ * matrix: success (with and without expiry), Bybit error retCode, HTTP
+ * non-2xx, malformed body, network error, timeout, env detection.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import { bybitVerifyApiKey } from "../../../src/lib/exchange/bybitVerify.js";
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  // Force demo env for predictable URL/permission checks.
+  delete process.env.BYBIT_BASE_URL;
+  delete process.env.BYBIT_ENV;
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("bybitVerifyApiKey — success paths", () => {
+  it("returns ok=true with flattened permissions, env=demo, parsed expiry", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        retCode: 0,
+        retMsg: "",
+        result: {
+          apiKey: "key-1",
+          readOnly: 0,
+          expiredAt: "2026-12-31T00:00:00Z",
+          permissions: {
+            ContractTrade: ["Order", "Position"],
+            Spot: ["SpotTrade"],
+            BlockTrade: [],
+          },
+        },
+      }),
+    );
+
+    const out = await bybitVerifyApiKey("key-1", "secret-1", fetchMock);
+
+    expect(out.ok).toBe(true);
+    if (!out.ok) throw new Error("expected ok");
+    expect(out.env).toBe("demo");
+    expect(out.readOnly).toBe(false);
+    expect(out.expiresAt).toBe("2026-12-31T00:00:00Z");
+    expect(out.permissions).toEqual([
+      "ContractTrade:Order",
+      "ContractTrade:Position",
+      "Spot:SpotTrade",
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api-demo.bybit.com/v5/user/query-api");
+  });
+
+  it("returns env=live when BYBIT_ENV=live", async () => {
+    process.env.BYBIT_ENV = "live";
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        retCode: 0,
+        result: { permissions: {}, readOnly: 1 },
+      }),
+    );
+
+    const out = await bybitVerifyApiKey("k", "s", fetchMock);
+    if (!out.ok) throw new Error("expected ok");
+    expect(out.env).toBe("live");
+    expect(out.readOnly).toBe(true);
+  });
+
+  it("normalises expiredAt='0' to null", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        retCode: 0,
+        result: { permissions: {}, expiredAt: "0", readOnly: 0 },
+      }),
+    );
+    const out = await bybitVerifyApiKey("k", "s", fetchMock);
+    if (!out.ok) throw new Error("expected ok");
+    expect(out.expiresAt).toBeNull();
+  });
+
+  it("normalises absent expiredAt to null", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        retCode: 0,
+        result: { permissions: {}, readOnly: 0 },
+      }),
+    );
+    const out = await bybitVerifyApiKey("k", "s", fetchMock);
+    if (!out.ok) throw new Error("expected ok");
+    expect(out.expiresAt).toBeNull();
+  });
+});
+
+describe("bybitVerifyApiKey — failure paths", () => {
+  it("Bybit retCode!=0 → ok=false code=BYBIT", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        retCode: 33004,
+        retMsg: "Your api key has expired.",
+      }),
+    );
+    const out = await bybitVerifyApiKey("k", "s", fetchMock);
+    expect(out.ok).toBe(false);
+    if (out.ok) throw new Error("expected failure");
+    expect(out.code).toBe("BYBIT");
+    expect(out.retCode).toBe(33004);
+    expect(out.detail).toContain("33004");
+    expect(out.detail).toContain("expired");
+  });
+
+  it("HTTP 401 → ok=false code=HTTP", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response("forbidden", { status: 401, statusText: "Unauthorized" }),
+    );
+    const out = await bybitVerifyApiKey("k", "s", fetchMock);
+    expect(out.ok).toBe(false);
+    if (out.ok) throw new Error("expected failure");
+    expect(out.code).toBe("HTTP");
+    expect(out.httpStatus).toBe(401);
+  });
+
+  it("non-JSON body → ok=false code=MALFORMED", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response("<html>oops</html>", { status: 200, headers: { "Content-Type": "text/html" } }),
+    );
+    const out = await bybitVerifyApiKey("k", "s", fetchMock);
+    expect(out.ok).toBe(false);
+    if (out.ok) throw new Error("expected failure");
+    expect(out.code).toBe("MALFORMED");
+  });
+
+  it("retCode=0 but no result → ok=false code=MALFORMED", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({ retCode: 0, retMsg: "" }),
+    );
+    const out = await bybitVerifyApiKey("k", "s", fetchMock);
+    expect(out.ok).toBe(false);
+    if (out.ok) throw new Error("expected failure");
+    expect(out.code).toBe("MALFORMED");
+  });
+
+  it("retCode missing → ok=false code=MALFORMED", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ result: {} }));
+    const out = await bybitVerifyApiKey("k", "s", fetchMock);
+    expect(out.ok).toBe(false);
+    if (out.ok) throw new Error("expected failure");
+    expect(out.code).toBe("MALFORMED");
+  });
+
+  it("network error → ok=false code=NETWORK", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+    const out = await bybitVerifyApiKey("k", "s", fetchMock);
+    expect(out.ok).toBe(false);
+    if (out.ok) throw new Error("expected failure");
+    expect(out.code).toBe("NETWORK");
+    expect(out.detail).toContain("ECONNREFUSED");
+  });
+
+  it("AbortError → ok=false code=TIMEOUT", async () => {
+    const fetchMock = vi.fn().mockImplementation(() => {
+      const err = new Error("aborted");
+      (err as { name?: string }).name = "AbortError";
+      return Promise.reject(err);
+    });
+    const out = await bybitVerifyApiKey("k", "s", fetchMock);
+    expect(out.ok).toBe(false);
+    if (out.ok) throw new Error("expected failure");
+    expect(out.code).toBe("TIMEOUT");
+  });
+});
+
+describe("bybitVerifyApiKey — request shape", () => {
+  it("sends signed GET with X-BAPI-* headers, no body", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({ retCode: 0, result: { permissions: {}, readOnly: 0 } }),
+    );
+
+    await bybitVerifyApiKey("api-key-xyz", "secret-xyz", fetchMock);
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.method).toBe("GET");
+    expect(init.body).toBeUndefined();
+    const headers = init.headers as Record<string, string>;
+    expect(headers["X-BAPI-API-KEY"]).toBe("api-key-xyz");
+    expect(headers["X-BAPI-SIGN"]).toMatch(/^[a-f0-9]{64}$/);
+    expect(headers["X-BAPI-TIMESTAMP"]).toMatch(/^\d+$/);
+    expect(headers["X-BAPI-RECV-WINDOW"]).toBe("5000");
+    expect(headers["User-Agent"]).toBe("botmarketplace-verify/1");
+  });
+});

--- a/apps/web/src/app/exchanges/page.tsx
+++ b/apps/web/src/app/exchanges/page.tsx
@@ -25,6 +25,14 @@ interface TestResult {
   id: string;
   status: string;
   detail: string;
+  /** Populated only on CONNECTED — Bybit env inferred from configured base URL. */
+  env?: "demo" | "live";
+  /** Populated only on CONNECTED — flat list of `Group:Scope` granted permissions. */
+  permissions?: string[];
+  /** Populated only on CONNECTED — ISO expiry timestamp, or null when no expiry. */
+  expiresAt?: string | null;
+  /** Populated only on CONNECTED — true when Bybit reports the key is read-only. */
+  readOnly?: boolean;
 }
 
 const EMPTY_FORM = {
@@ -212,9 +220,20 @@ export default function ExchangesPage() {
                 </span>
               )}
               {tr && (
-                <span style={{ fontSize: 12, color: tr.status === "CONNECTED" ? "#3fb950" : "#f85149" }}>
-                  {tr.detail}
-                </span>
+                <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+                  <span style={{ fontSize: 12, color: tr.status === "CONNECTED" ? "#3fb950" : "#f85149" }}>
+                    {tr.detail}
+                  </span>
+                  {tr.status === "CONNECTED" && tr.permissions && tr.permissions.length > 0 && (
+                    <span
+                      style={{ fontSize: 11, color: "var(--text-secondary)" }}
+                      title={tr.permissions.join("\n")}
+                    >
+                      {tr.permissions.slice(0, 4).join(", ")}
+                      {tr.permissions.length > 4 ? `, +${tr.permissions.length - 4} more` : ""}
+                    </span>
+                  )}
+                </div>
               )}
             </div>
             <div style={{ display: "flex", gap: 8, flexShrink: 0 }}>


### PR DESCRIPTION
## Summary

`/exchanges/:id/test` was a demo placeholder — it checked only that `apiKey` + decrypted secret were non-empty strings, then optimistically marked the connection CONNECTED. That misled operators: the UI showed green but credentials were never actually validated against Bybit, so a wrong-env / expired / typo'd key looked identical to a working one until a bot tried to trade with it.

This PR replaces the placeholder with a signed, read-only call to `GET /v5/user/query-api`. The endpoint now returns enriched metadata (env, permissions, expiresAt, readOnly) so the operator gets an instant, accurate answer before committing to a 30-min smoke run.

### What changed

- **`apps/api/src/lib/exchange/bybitVerify.ts`** (new) — signed query helper. Every failure mode (network / timeout / HTTP non-2xx / Bybit retCode / malformed body) funnels into a single `VerifyResult` discriminated union; never throws.
- **`apps/api/src/routes/exchanges.ts`** — `/test` now calls the helper, sets connection status from the real result, and surfaces metadata in the response. Non-Bybit exchanges return FAILED with explicit "not implemented" detail. Empty-credentials short-circuit preserved.
- **`apps/web/src/app/exchanges/page.tsx`** — `TestResult` interface extended; UI renders first four granted permissions inline with a tooltip showing the full list.
- **`apps/api/tests/lib/exchange/bybitVerify.test.ts`** (new) — 12 unit tests covering every branch.

### Backwards compat

The existing response shape `{ id, status, detail }` is preserved. New fields (`env`, `permissions`, `expiresAt`, `readOnly`) are optional additions, populated only on CONNECTED.

### Why now

Discovered while wiring up first Bybit demo connection — the operator's saved key was marked CONNECTED but had not actually been verified. demoSmoke is the next step and depends on real validation; running smoke against an unvalidated key wastes a 30-min cycle when a 1-second `/test` call could catch the same issue.

## Test plan
- [x] `pnpm test:api` — 134 files / 2260 tests passed (was 2248, +12 new)
- [x] `pnpm --filter @botmarketplace/api exec tsc --noEmit` — clean
- [x] `pnpm build:web` — clean, all 22 pages prerender, /exchanges bundle unchanged
- [ ] After deploy: click **Test** on existing demo connection → expect CONNECTED with permissions + env=demo + (optional) expiry
- [ ] After deploy: forge a bad key (deleted on Bybit side or wrong env) → expect FAILED with Bybit `retCode/retMsg` surfaced

https://claude.ai/code/session_01A1kKhq5N9185WfdAwDAU2s

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1kKhq5N9185WfdAwDAU2s)_