### PR TITLE
feat(demoSmoke): bind exchange connection + close 5 acceptance gaps

### DIFF
--- a/apps/api/scripts/demoSmoke.ts
+++ b/apps/api/scripts/demoSmoke.ts
@@ -20,14 +20,28 @@
  *   pnpm --filter @botmarketplace/api exec tsx scripts/demoSmoke.ts \
  *     --preset adaptive-regime \
  *     --workspace ws_xyz \
+ *     --connection conn_xyz \
  *     --token "$DEMO_JWT" \
  *     --base-url http://localhost:3001/api/v1 \
  *     --duration-min 30 \
  *     --symbol BTCUSDT \
  *     --quote-amount 50
  *
+ * `--connection` обязателен. Без exchangeConnectionId на боте
+ * `intentExecutor` (apps/api/src/lib/worker/intentExecutor.ts:93)
+ * автосимулирует все intents без вызова Bybit — gate проходит «зелёным»,
+ * но реально ничего не торгуется. Harness отказывается стартовать без
+ * connection чтобы исключить эту иллюзию.
+ *
+ * Pre-flight (fail-fast перед instantiate):
+ *  - connection.status === "CONNECTED" (свежий /test пройден)
+ *  - BYBIT_ENV !== "live" (anti-live guard, демо-only)
+ *  - TRADING_ENABLED не выключен (kill switch off → все intents в FAILED)
+ *  - после instantiate bot.exchangeConnectionId === requested (catches DB rollback)
+ *
  * Результат: JSON-отчёт в `apps/api/scripts/.smoke-output/<timestamp>-<slug>.json`
- * + summary в stdout. Exit code 0 = PASS, 1 = FAIL, 2 = INPUT_ERROR.
+ * + summary в stdout. Exit codes: 0 = PASS, 1 = FAIL, 2 = INPUT_ERROR
+ * (CLI/env валидация), 3 = PREFLIGHT_FAIL (connection/env/post-bind).
  */
 
 import { mkdir, writeFile } from "node:fs/promises";
@@ -42,6 +56,9 @@ import { PrismaClient } from "@prisma/client";
 export interface ParsedSmokeArgs {
   preset?: string;
   workspace?: string;
+  /** Required at validation step; carried separately so parseArgs stays a
+   *  thin tokenizer. */
+  connection?: string;
   token?: string;
   baseUrl?: string;
   durationMin?: number;
@@ -58,6 +75,7 @@ export function parseArgs(argv: readonly string[]): ParsedSmokeArgs {
     const arg = argv[i];
     if (arg === "--preset") out.preset = argv[++i];
     else if (arg === "--workspace") out.workspace = argv[++i];
+    else if (arg === "--connection") out.connection = argv[++i];
     else if (arg === "--token") out.token = argv[++i];
     else if (arg === "--base-url") out.baseUrl = argv[++i];
     else if (arg === "--duration-min") out.durationMin = Number(argv[++i]);
@@ -85,6 +103,20 @@ export interface SmokeMetrics {
   failedIntentCount: number;
   /** Число BotEvent, у которых type содержит "error" / "fail" (case-insensitive). */
   errorEventCount: number;
+  /**
+   * Число BotEvent с type="intent_simulated" — индикатор что бот скатился
+   * в demo simulation mode (intentExecutor:93). Для acceptance gate это
+   * HARD FAIL: simulation означает что Bybit не получил ни одного ордера,
+   * gate бессмысленный.
+   */
+  simulatedEventCount: number;
+  /**
+   * Число BotEvent рыночных категорий (`market_*`, `candle_*`, `tick_*`,
+   * `signal_*`, `regime_*`). Если 0 — engine не получает данные / poll-loop
+   * мёртвый, отсутствие intents объясняется не flat market'ом, а сломанной
+   * data-pipeline.
+   */
+  marketEventCount: number;
   /** Сколько HTTP запросов harness'а получили статус >= 400 (auth issues / rate limits). */
   harnessHttpFailures: number;
   /** Реальная длительность run'а в минутах. */
@@ -93,21 +125,26 @@ export interface SmokeMetrics {
 
 export interface SmokeAcceptance {
   pass: boolean;
-  /** Warning (не fail) если intentCount === 0 — может быть legit flat market. */
+  /** Warning (не fail). Например intentCount=0 при наличии market events
+   *  и duration ≥ 15 мин — легитимный flat market. */
   warnings: string[];
   /** Конкретные причины fail (пусто если pass). */
   failures: string[];
 }
 
 /**
- * Acceptance критерии из docs/53-T3:
- *   1. finalRunState !== "FAILED" / "TIMED_OUT"  → fail если нарушено.
- *   2. errorEventCount === 0                      → fail если > 0.
- *   3. harnessHttpFailures === 0                  → fail если > 0
- *      (sustained 401/403/429 от Bybit или /api).
- *   4. failedIntentCount === 0                    → fail если > 0.
- *   5. intentCount > 0                            → warning если 0
- *      (рынок может быть flat — operator решает rerun или принять).
+ * Acceptance критерии (docs/53-T3, расширено в #PR-после-effa475):
+ *   1. finalRunState !== "FAILED" / "TIMED_OUT"  → fail.
+ *   2. errorEventCount === 0                      → fail.
+ *   3. harnessHttpFailures === 0                  → fail.
+ *   4. failedIntentCount === 0                    → fail.
+ *   5. simulatedEventCount === 0                  → fail (бот в sim-режиме).
+ *   6. marketEventCount > 0                       → fail (engine не получает данные).
+ *   7. intentCount > 0                            → graded warning:
+ *        - duration < 15 min          → warning (короткий run, ок что 0)
+ *        - market events ≥ 1 + ≥15min → warning (legit flat market)
+ *
+ * Pure function — все границы тестируются без сети.
  */
 export function evaluateAcceptance(metrics: SmokeMetrics): SmokeAcceptance {
   const failures: string[] = [];
@@ -124,6 +161,17 @@ export function evaluateAcceptance(metrics: SmokeMetrics): SmokeAcceptance {
   }
   if (metrics.failedIntentCount > 0) {
     failures.push(`failedIntentCount=${metrics.failedIntentCount} (expected 0)`);
+  }
+  if (metrics.simulatedEventCount > 0) {
+    failures.push(
+      `simulatedEventCount=${metrics.simulatedEventCount} (expected 0 — bot fell back to ` +
+      `demo simulation mode, exchangeConnectionId likely null)`,
+    );
+  }
+  if (metrics.marketEventCount === 0) {
+    failures.push(
+      "marketEventCount=0 — strategy never received market data (engine / poll-loop broken)",
+    );
   }
   if (metrics.intentCount === 0) {
     warnings.push(
@@ -142,6 +190,9 @@ export interface InstantiateResponse {
   botId: string;
   strategyId: string;
   strategyVersionId: string;
+  /** Echo of the connection bound to the new bot, or null when none was
+   *  passed. Harness uses this for fail-fast bind verification. */
+  exchangeConnectionId: string | null;
 }
 
 export interface RunResponse {
@@ -149,13 +200,36 @@ export interface RunResponse {
   state: string;
 }
 
+export interface ConnectionInfo {
+  id: string;
+  status: string;
+  exchange: string;
+}
+
+export interface BotInfo {
+  id: string;
+  exchangeConnectionId: string | null;
+}
+
 export interface SmokeApi {
-  /** POST /presets/:slug/instantiate. */
+  /** GET /exchanges/:id (or Prisma-direct) — pre-flight pre-instantiate. */
+  getConnection(id: string): Promise<ConnectionInfo | null>;
+
+  /**
+   * POST /presets/:slug/instantiate. `exchangeConnectionId` is forwarded
+   * to the route, which validates cross-workspace + binds it to the new
+   * bot.
+   */
   instantiatePreset(input: {
     slug: string;
     workspaceId: string;
+    exchangeConnectionId: string;
     overrides?: { symbol?: string; quoteAmount?: number; name?: string };
   }): Promise<InstantiateResponse>;
+
+  /** Re-fetch bot after instantiate to verify the connection actually bound
+   *  (catches DB rollback / silent route bypass). */
+  getBot(botId: string): Promise<BotInfo | null>;
 
   /** POST /bots/:botId/runs. */
   startRun(input: { botId: string; durationMinutes: number }): Promise<RunResponse>;
@@ -171,6 +245,18 @@ export interface SmokeApi {
 
   /** Aggregate error-flavoured BotEvent for a run (через Prisma). */
   countErrorEvents(runId: string): Promise<number>;
+
+  /** Count BotEvent with type='intent_simulated' — proof bot fell into
+   *  demo simulation mode (intentExecutor:93). Should be 0 for a real run. */
+  countSimulatedEvents(runId: string): Promise<number>;
+
+  /** Count BotEvent of market data category — non-zero proves the engine
+   *  is alive, even when intentCount=0 (legit flat market). */
+  countMarketEvents(runId: string): Promise<number>;
+
+  /** First N orderId values from BotIntent (FILLED or PLACED). Lets the
+   *  operator cross-check on bybit.com/demo/orders. */
+  samplePlacedOrders(runId: string, limit: number): Promise<string[]>;
 }
 
 // ---------------------------------------------------------------------------
@@ -180,6 +266,7 @@ export interface SmokeApi {
 export interface RunDemoSmokeArgs {
   presetSlug: string;
   workspaceId: string;
+  exchangeConnectionId: string;
   durationMin: number;
   pollIntervalSec: number;
   overrides: { symbol?: string; quoteAmount?: number };
@@ -188,19 +275,106 @@ export interface RunDemoSmokeArgs {
   sleep: (ms: number) => Promise<void>;
   /** Inject clock so tests can fix `actualDurationMin`. */
   now: () => number;
+  /**
+   * Snapshot of `process.env` at script invocation, captured by the
+   * caller. Injected so unit tests can supply controlled values for the
+   * BYBIT_ENV / TRADING_ENABLED pre-flight without mutating real env.
+   */
+  env: Record<string, string | undefined>;
   /** Optional sink for progress lines. */
   log?: (line: string) => void;
+}
+
+/** A pre-flight check failed — harness aborts before instantiate so the
+ *  operator does not waste a 30-min run on a misconfigured environment. */
+export class PreflightError extends Error {
+  constructor(public readonly checks: string[]) {
+    super(`demoSmoke pre-flight failed: ${checks.join("; ")}`);
+    this.name = "PreflightError";
+  }
 }
 
 export interface SmokeReport {
   presetSlug: string;
   workspaceId: string;
+  exchangeConnectionId: string;
+  /** "demo" / "live" / "unknown" — derived from BYBIT_ENV / BYBIT_BASE_URL
+   *  at run start. Pre-flight rejects "live" outright, so successful
+   *  reports are always "demo". Recorded for audit. */
+  bybitEnv: "demo" | "live" | "unknown";
   startedAt: string;
   finishedAt: string;
   botId: string;
   runId: string;
+  /** Up to 5 orderIds from this run — the operator pastes them into
+   *  bybit.com/demo/orders to verify real exchange-side activity. */
+  placedOrderSamples: string[];
   metrics: SmokeMetrics;
   acceptance: SmokeAcceptance;
+}
+
+/**
+ * Resolve which Bybit environment is currently configured. Mirrors the
+ * priority used by `apps/api/src/lib/bybitOrder.ts:getBybitBaseUrl` so
+ * the report matches what the running api process actually talks to.
+ */
+export function resolveBybitEnv(env: Record<string, string | undefined>): "demo" | "live" | "unknown" {
+  const baseUrl = env.BYBIT_BASE_URL;
+  if (baseUrl) {
+    if (baseUrl.includes("api.bybit.com")) return "live";
+    if (baseUrl.includes("api-demo.bybit.com") || baseUrl.includes("api-testnet")) return "demo";
+    return "unknown";
+  }
+  if (env.BYBIT_ENV === "live") return "live";
+  return "demo"; // matches getBybitBaseUrl default
+}
+
+/**
+ * Read the kill switch the same way `apps/api/src/lib/tradingKillSwitch.ts`
+ * does — fail-open default, falsy aliases off.
+ */
+export function isTradingEnabled(env: Record<string, string | undefined>): boolean {
+  const raw = env.TRADING_ENABLED;
+  if (raw === undefined) return true; // fail-open
+  const norm = raw.toLowerCase().trim();
+  return !(norm === "false" || norm === "0" || norm === "off" || norm === "no");
+}
+
+/**
+ * Pre-flight bundle. Pure: takes already-fetched connection plus env, returns
+ * the list of failed checks (empty = OK).
+ */
+export function preflightChecks(input: {
+  connection: ConnectionInfo | null;
+  env: Record<string, string | undefined>;
+}): string[] {
+  const failures: string[] = [];
+
+  if (!input.connection) {
+    failures.push("connection not found in workspace (verify --connection id)");
+  } else {
+    if (input.connection.exchange !== "BYBIT") {
+      failures.push(`connection.exchange=${input.connection.exchange} (expected BYBIT)`);
+    }
+    if (input.connection.status !== "CONNECTED") {
+      failures.push(
+        `connection.status=${input.connection.status} (expected CONNECTED — run /test endpoint first)`,
+      );
+    }
+  }
+
+  const bybitEnv = resolveBybitEnv(input.env);
+  if (bybitEnv === "live") {
+    failures.push("BYBIT_ENV=live (refuse — demoSmoke is demo-only by design)");
+  }
+
+  if (!isTradingEnabled(input.env)) {
+    failures.push(
+      "TRADING_ENABLED is off (every intent would land in FAILED state — fix env first)",
+    );
+  }
+
+  return failures;
 }
 
 export async function runDemoSmoke(args: RunDemoSmokeArgs): Promise<SmokeReport> {
@@ -221,14 +395,43 @@ export async function runDemoSmoke(args: RunDemoSmokeArgs): Promise<SmokeReport>
     }
   };
 
-  log(`[demoSmoke] preset=${args.presetSlug} workspace=${args.workspaceId} duration=${args.durationMin}min`);
+  log(
+    `[demoSmoke] preset=${args.presetSlug} workspace=${args.workspaceId} ` +
+    `connection=${args.exchangeConnectionId} duration=${args.durationMin}min`,
+  );
+
+  // ── Pre-flight: bail out before instantiate when env / connection are
+  //    obviously misconfigured. Failures here throw `PreflightError` so
+  //    `main()` can map to a distinct exit code (3) and the operator does
+  //    not get a 30-minute "FAIL" report for a 1-second config issue.
+  const connection = await args.api.getConnection(args.exchangeConnectionId);
+  const preflightFailures = preflightChecks({ connection, env: args.env });
+  if (preflightFailures.length > 0) {
+    throw new PreflightError(preflightFailures);
+  }
+  const bybitEnv = resolveBybitEnv(args.env);
+  log(`[demoSmoke] pre-flight OK · bybitEnv=${bybitEnv} · connection.status=CONNECTED`);
 
   const created = await args.api.instantiatePreset({
     slug: args.presetSlug,
     workspaceId: args.workspaceId,
+    exchangeConnectionId: args.exchangeConnectionId,
     overrides: args.overrides,
   });
   log(`[demoSmoke] instantiated bot=${created.botId} strategy=${created.strategyId}`);
+
+  // Post-instantiate verification: the route echoes back the bound
+  // connection but a stale code path or DB rollback could have produced a
+  // bot with `exchangeConnectionId: null` and we would silently slip into
+  // simulation mode. Re-read the bot row to confirm.
+  const bot = await args.api.getBot(created.botId);
+  if (!bot || bot.exchangeConnectionId !== args.exchangeConnectionId) {
+    throw new PreflightError([
+      `bot.exchangeConnectionId=${bot?.exchangeConnectionId ?? "null"} ` +
+      `(expected ${args.exchangeConnectionId} — instantiate likely ignored the field)`,
+    ]);
+  }
+  log(`[demoSmoke] bot bind verified · exchangeConnectionId=${bot.exchangeConnectionId}`);
 
   const run = await args.api.startRun({ botId: created.botId, durationMinutes: args.durationMin });
   log(`[demoSmoke] started run=${run.id} state=${run.state}`);
@@ -270,9 +473,14 @@ export async function runDemoSmoke(args: RunDemoSmokeArgs): Promise<SmokeReport>
     if (final) lastState = final.state;
   }
 
-  // Final read-out — capture state after stop completed.
+  // Final read-out — capture state after stop completed. The simulation /
+  // market-event / placedOrders read happen exactly once at the end so the
+  // harness's per-poll overhead is unchanged (existing CI baselines).
   lastIntents = await safeCall(() => args.api.countIntents(run.id), lastIntents);
   lastErrorEvents = await safeCall(() => args.api.countErrorEvents(run.id), lastErrorEvents);
+  const simulatedEventCount = await safeCall(() => args.api.countSimulatedEvents(run.id), 0);
+  const marketEventCount = await safeCall(() => args.api.countMarketEvents(run.id), 0);
+  const placedOrderSamples = await safeCall(() => args.api.samplePlacedOrders(run.id, 5), []);
 
   const finishedAt = args.now();
   const metrics: SmokeMetrics = {
@@ -281,6 +489,8 @@ export async function runDemoSmoke(args: RunDemoSmokeArgs): Promise<SmokeReport>
     intentCount: lastIntents.total,
     failedIntentCount: lastIntents.failed,
     errorEventCount: lastErrorEvents,
+    simulatedEventCount,
+    marketEventCount,
     harnessHttpFailures,
     actualDurationMin: (finishedAt - startedAt) / 60_000,
   };
@@ -289,10 +499,13 @@ export async function runDemoSmoke(args: RunDemoSmokeArgs): Promise<SmokeReport>
   return {
     presetSlug: args.presetSlug,
     workspaceId: args.workspaceId,
+    exchangeConnectionId: args.exchangeConnectionId,
+    bybitEnv,
     startedAt: new Date(startedAt).toISOString(),
     finishedAt: new Date(finishedAt).toISOString(),
     botId: created.botId,
     runId: run.id,
+    placedOrderSamples,
     metrics,
     acceptance,
   };
@@ -328,11 +541,27 @@ export function buildDefaultApi(input: BuildApiInput): SmokeApi {
   }
 
   return {
-    async instantiatePreset({ slug, workspaceId, overrides }) {
+    async getConnection(id) {
+      const row = await input.prisma.exchangeConnection.findUnique({
+        where: { id },
+        select: { id: true, status: true, exchange: true },
+      });
+      return row;
+    },
+
+    async instantiatePreset({ slug, workspaceId, exchangeConnectionId, overrides }) {
       return postJson<InstantiateResponse>(
         `/presets/${encodeURIComponent(slug)}/instantiate`,
-        { workspaceId, overrides },
+        { workspaceId, exchangeConnectionId, overrides },
       );
+    },
+
+    async getBot(botId) {
+      const row = await input.prisma.bot.findUnique({
+        where: { id: botId },
+        select: { id: true, exchangeConnectionId: true },
+      });
+      return row;
     },
 
     async startRun({ botId, durationMinutes }) {
@@ -372,6 +601,43 @@ export function buildDefaultApi(input: BuildApiInput): SmokeApi {
       });
       return events.filter((e) => isErrorEvent(e.type, e.payloadJson)).length;
     },
+
+    async countSimulatedEvents(runId) {
+      return input.prisma.botEvent.count({
+        where: { botRunId: runId, type: "intent_simulated" },
+      });
+    },
+
+    async countMarketEvents(runId) {
+      // Match the categories listed in SmokeMetrics.marketEventCount JSDoc.
+      // Bybit-side evaluator emits e.g. "regime_check", "signal_entry",
+      // "candle_close" — proof the engine is alive even on flat market.
+      return input.prisma.botEvent.count({
+        where: {
+          botRunId: runId,
+          OR: [
+            { type: { startsWith: "market_" } },
+            { type: { startsWith: "candle_" } },
+            { type: { startsWith: "tick_" } },
+            { type: { startsWith: "signal_" } },
+            { type: { startsWith: "regime_" } },
+          ],
+        },
+      });
+    },
+
+    async samplePlacedOrders(runId, limit) {
+      const rows = await input.prisma.botIntent.findMany({
+        where: {
+          botRunId: runId,
+          orderId: { not: null },
+        },
+        select: { orderId: true },
+        orderBy: { createdAt: "asc" },
+        take: limit,
+      });
+      return rows.map((r) => r.orderId).filter((id): id is string => !!id);
+    },
   };
 }
 
@@ -408,6 +674,7 @@ const isDirectInvocation = (() => {
 export interface ValidatedSmokeConfig {
   preset: string;
   workspace: string;
+  connection: string;
   token: string;
   baseUrl: string;
   durationMin: number;
@@ -427,11 +694,22 @@ export type ValidationResult =
 export function validateCliArgs(parsed: ParsedSmokeArgs, env: Record<string, string | undefined>): ValidationResult {
   const preset = parsed.preset ?? env.DEMO_SMOKE_PRESET;
   const workspace = parsed.workspace ?? env.DEMO_SMOKE_WORKSPACE;
+  const connection = parsed.connection ?? env.DEMO_SMOKE_CONNECTION;
   const token = parsed.token ?? env.DEMO_SMOKE_TOKEN;
   const baseUrl = parsed.baseUrl ?? env.DEMO_SMOKE_BASE_URL ?? "http://localhost:3001/api/v1";
 
   if (!preset) return { kind: "error", reason: "--preset <slug> is required (or DEMO_SMOKE_PRESET)" };
   if (!workspace) return { kind: "error", reason: "--workspace <id> is required (or DEMO_SMOKE_WORKSPACE)" };
+  if (!connection) {
+    return {
+      kind: "error",
+      reason:
+        "--connection <id> is required (or DEMO_SMOKE_CONNECTION). Without it the bot stays in " +
+        "demo simulation mode (intentExecutor:93) and the run does not exercise Bybit at all. " +
+        "Get the id from /exchanges UI or `pnpm --filter @botmarketplace/api exec prisma studio` " +
+        "→ ExchangeConnection table.",
+    };
+  }
   if (!token) return { kind: "error", reason: "--token <jwt> is required (or DEMO_SMOKE_TOKEN)" };
 
   const durationMin = parsed.durationMin ?? 30;
@@ -451,6 +729,7 @@ export function validateCliArgs(parsed: ParsedSmokeArgs, env: Record<string, str
     config: {
       preset,
       workspace,
+      connection,
       token,
       baseUrl,
       durationMin,
@@ -486,12 +765,14 @@ async function main(): Promise<number> {
     const report = await runDemoSmoke({
       presetSlug: cfg.preset,
       workspaceId: cfg.workspace,
+      exchangeConnectionId: cfg.connection,
       durationMin: cfg.durationMin,
       pollIntervalSec: cfg.pollIntervalSec,
       overrides: { symbol: cfg.symbol, quoteAmount: cfg.quoteAmount },
       api,
       sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
       now: () => Date.now(),
+      env: process.env,
     });
 
     await mkdir(cfg.outputDir, { recursive: true });
@@ -502,11 +783,16 @@ async function main(): Promise<number> {
     console.log("\n=== demoSmoke summary ===");
     console.log(`preset:        ${report.presetSlug}`);
     console.log(`run:           ${report.runId}`);
+    console.log(`bybitEnv:      ${report.bybitEnv}`);
+    console.log(`connection:    ${report.exchangeConnectionId}`);
     console.log(`finalState:    ${report.metrics.finalRunState}`);
     console.log(`intents:       ${report.metrics.intentCount} (failed=${report.metrics.failedIntentCount})`);
+    console.log(`marketEvents:  ${report.metrics.marketEventCount}`);
+    console.log(`simulated:     ${report.metrics.simulatedEventCount}`);
     console.log(`errorEvents:   ${report.metrics.errorEventCount}`);
     console.log(`httpFailures:  ${report.metrics.harnessHttpFailures}`);
     console.log(`durationMin:   ${report.metrics.actualDurationMin.toFixed(2)}`);
+    console.log(`orderSamples:  ${report.placedOrderSamples.length ? report.placedOrderSamples.join(", ") : "(none)"}`);
     console.log(`acceptance:    ${report.acceptance.pass ? "PASS" : "FAIL"}`);
     if (report.acceptance.warnings.length) {
       console.log(`warnings:      ${report.acceptance.warnings.join("; ")}`);
@@ -517,6 +803,17 @@ async function main(): Promise<number> {
     console.log(`report:        ${outPath}`);
 
     return report.acceptance.pass ? 0 : 1;
+  } catch (err) {
+    if (err instanceof PreflightError) {
+      console.error("\n[demoSmoke] pre-flight FAILED — aborting before instantiate:");
+      for (const c of err.checks) console.error(`  ✗ ${c}`);
+      console.error(
+        "\nFix the underlying environment / connection state and rerun. " +
+        "No bot was created; no run was started.",
+      );
+      return 3;
+    }
+    throw err;
   } finally {
     await prisma.$disconnect();
   }

--- a/apps/api/src/routes/presets.ts
+++ b/apps/api/src/routes/presets.ts
@@ -104,6 +104,18 @@ interface InstantiateBody {
     maxOpenPositions: number;
     name: string;
   }>;
+  /**
+   * Optional exchange connection to bind to the new bot. When omitted, the
+   * bot is created with `exchangeConnectionId: null` and stays in
+   * simulation mode (intentExecutor:93) — fine for engine smoke / CI runs,
+   * not acceptable for the docs/53-T3 acceptance gate which depends on
+   * real Bybit traffic. demoSmoke makes this required at the CLI layer.
+   *
+   * Cross-workspace bypass is rejected with 404 — same code as
+   * "preset not found", to avoid leaking existence of other workspaces'
+   * connections.
+   */
+  exchangeConnectionId?: string;
 }
 
 interface ResolvedConfig {
@@ -409,6 +421,24 @@ export async function presetRoutes(app: FastifyInstance) {
         return problem(reply, 400, "Validation Error", "Invalid instantiate payload", { errors });
       }
 
+      // Optional exchange connection binding. When provided, validate that
+      // the connection exists and belongs to the same workspace; cross-
+      // workspace IDs are rejected with 404 (same as "preset not found")
+      // so existence of other workspaces' connections is not leaked.
+      const requestedConnectionId = request.body?.exchangeConnectionId;
+      if (requestedConnectionId !== undefined) {
+        if (typeof requestedConnectionId !== "string" || requestedConnectionId.length === 0) {
+          return problem(reply, 400, "Validation Error", "exchangeConnectionId must be a non-empty string");
+        }
+        const conn = await prisma.exchangeConnection.findUnique({
+          where: { id: requestedConnectionId },
+          select: { id: true, workspaceId: true },
+        });
+        if (!conn || conn.workspaceId !== workspace.id) {
+          return problem(reply, 404, "Not Found", "Exchange connection not found");
+        }
+      }
+
       // Generate a unique-per-workspace suffix for both Strategy and Bot names
       // so repeated instantiate calls do not collide on the (workspaceId, name)
       // unique index. Six hex chars = 24 bits of entropy — plenty for human
@@ -453,6 +483,9 @@ export async function presetRoutes(app: FastifyInstance) {
               status: "DRAFT",
               templateSlug: preset.slug,
               mode: config.mode,
+              ...(requestedConnectionId
+                ? { exchangeConnectionId: requestedConnectionId }
+                : {}),
             },
           });
 
@@ -463,6 +496,7 @@ export async function presetRoutes(app: FastifyInstance) {
           botId: result.bot.id,
           strategyId: result.strategy.id,
           strategyVersionId: result.version.id,
+          exchangeConnectionId: requestedConnectionId ?? null,
         });
       } catch (err) {
         if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {

--- a/apps/api/tests/routes/presets.test.ts
+++ b/apps/api/tests/routes/presets.test.ts
@@ -17,6 +17,7 @@ const mockStrategies: Record<string, Record<string, unknown>> = {};
 const mockStrategyVersions: Record<string, Record<string, unknown>> = {};
 const mockBots: Record<string, Record<string, unknown>> = {};
 const mockWorkspaceMemberships: Array<Record<string, unknown>> = [];
+const mockExchangeConnections: Record<string, { id: string; workspaceId: string; status: string; exchange: string }> = {};
 
 let strategyIdCounter = 0;
 let strategyVersionIdCounter = 0;
@@ -136,6 +137,11 @@ vi.mock("../../src/lib/prisma.js", () => {
         return Promise.resolve(mockPresets[where.slug] ?? null);
       }),
     },
+    exchangeConnection: {
+      findUnique: vi.fn().mockImplementation(({ where }: { where: { id: string } }) => {
+        return Promise.resolve(mockExchangeConnections[where.id] ?? null);
+      }),
+    },
     workspaceMember: {
       findUnique: vi.fn().mockImplementation(({ where }: { where: { workspaceId_userId: { workspaceId: string; userId: string } } }) => {
         const m = mockWorkspaceMemberships.find(
@@ -207,6 +213,7 @@ beforeEach(() => {
   Object.keys(mockStrategies).forEach((k) => delete mockStrategies[k]);
   Object.keys(mockStrategyVersions).forEach((k) => delete mockStrategyVersions[k]);
   Object.keys(mockBots).forEach((k) => delete mockBots[k]);
+  Object.keys(mockExchangeConnections).forEach((k) => delete mockExchangeConnections[k]);
   mockWorkspaceMemberships.length = 0;
   strategyIdCounter = 0;
   strategyVersionIdCounter = 0;
@@ -732,5 +739,99 @@ describe("POST /api/v1/presets/:slug/instantiate", () => {
     expect(res.statusCode).toBe(400);
     const body = res.json() as { errors: Array<{ field: string; message: string }> };
     expect(body.errors.some((e) => e.field === "mode" && /must be one of/.test(e.message))).toBe(true);
+  });
+});
+
+// ── exchangeConnectionId binding ────────────────────────────────────────────
+
+describe("POST /api/v1/presets/:slug/instantiate — exchangeConnectionId", () => {
+  const OTHER_WS_ID = "ws-other";
+
+  it("binds bot.exchangeConnectionId when a same-workspace connection is supplied", async () => {
+    await seedPreset("public-a", "PUBLIC");
+    mockExchangeConnections["conn-1"] = {
+      id: "conn-1",
+      workspaceId: WS_ID,
+      status: "CONNECTED",
+      exchange: "BYBIT",
+    };
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/presets/public-a/instantiate",
+      headers: userHeaders(),
+      payload: { exchangeConnectionId: "conn-1" },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.exchangeConnectionId).toBe("conn-1");
+
+    const bot = Object.values(mockBots)[0];
+    expect(bot.exchangeConnectionId).toBe("conn-1");
+  });
+
+  it("omitting exchangeConnectionId leaves bot.exchangeConnectionId unset (back-compat)", async () => {
+    await seedPreset("public-a", "PUBLIC");
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/presets/public-a/instantiate",
+      headers: userHeaders(),
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.exchangeConnectionId).toBeNull();
+
+    const bot = Object.values(mockBots)[0];
+    expect(bot.exchangeConnectionId).toBeUndefined();
+  });
+
+  it("rejects empty-string exchangeConnectionId with 400", async () => {
+    await seedPreset("public-a", "PUBLIC");
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/presets/public-a/instantiate",
+      headers: userHeaders(),
+      payload: { exchangeConnectionId: "" },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 404 when connection belongs to a different workspace (no info leak)", async () => {
+    await seedPreset("public-a", "PUBLIC");
+    mockExchangeConnections["conn-other"] = {
+      id: "conn-other",
+      workspaceId: OTHER_WS_ID,
+      status: "CONNECTED",
+      exchange: "BYBIT",
+    };
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/presets/public-a/instantiate",
+      headers: userHeaders(),
+      payload: { exchangeConnectionId: "conn-other" },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(Object.keys(mockBots)).toHaveLength(0);
+  });
+
+  it("returns 404 when connection id is unknown", async () => {
+    await seedPreset("public-a", "PUBLIC");
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/presets/public-a/instantiate",
+      headers: userHeaders(),
+      payload: { exchangeConnectionId: "conn-does-not-exist" },
+    });
+
+    expect(res.statusCode).toBe(404);
   });
 });

--- a/apps/api/tests/scripts/demoSmoke.test.ts
+++ b/apps/api/tests/scripts/demoSmoke.test.ts
@@ -19,9 +19,14 @@ import {
   validateCliArgs,
   evaluateAcceptance,
   isErrorEvent,
+  preflightChecks,
+  resolveBybitEnv,
+  isTradingEnabled,
   runDemoSmoke,
+  PreflightError,
   type SmokeApi,
   type SmokeMetrics,
+  type ConnectionInfo,
 } from "../../scripts/demoSmoke.js";
 
 // ---------------------------------------------------------------------------
@@ -33,6 +38,7 @@ describe("demoSmoke.parseArgs", () => {
     const out = parseArgs([
       "--preset", "adaptive-regime",
       "--workspace", "ws-1",
+      "--connection", "conn-7",
       "--token", "jwt",
       "--base-url", "http://api.test/v1",
       "--duration-min", "45",
@@ -45,6 +51,7 @@ describe("demoSmoke.parseArgs", () => {
     expect(out).toEqual({
       preset: "adaptive-regime",
       workspace: "ws-1",
+      connection: "conn-7",
       token: "jwt",
       baseUrl: "http://api.test/v1",
       durationMin: 45,
@@ -67,31 +74,42 @@ describe("demoSmoke.parseArgs", () => {
 
 describe("demoSmoke.validateCliArgs", () => {
   const baseEnv = {} as Record<string, string | undefined>;
+  const baseValid = { preset: "p", workspace: "w", connection: "c", token: "t", dryRun: false };
 
   it("requires preset", () => {
-    const r = validateCliArgs({ workspace: "w", token: "t", dryRun: false }, baseEnv);
+    const r = validateCliArgs({ workspace: "w", connection: "c", token: "t", dryRun: false }, baseEnv);
     expect(r.kind).toBe("error");
     if (r.kind === "error") expect(r.reason).toMatch(/preset/);
   });
 
   it("requires workspace", () => {
-    const r = validateCliArgs({ preset: "p", token: "t", dryRun: false }, baseEnv);
+    const r = validateCliArgs({ preset: "p", connection: "c", token: "t", dryRun: false }, baseEnv);
     expect(r.kind).toBe("error");
     if (r.kind === "error") expect(r.reason).toMatch(/workspace/);
   });
 
+  it("requires connection — explicit error mentions simulation mode", () => {
+    const r = validateCliArgs({ preset: "p", workspace: "w", token: "t", dryRun: false }, baseEnv);
+    expect(r.kind).toBe("error");
+    if (r.kind === "error") {
+      expect(r.reason).toMatch(/--connection/);
+      expect(r.reason).toMatch(/simulation/);
+    }
+  });
+
   it("requires token", () => {
-    const r = validateCliArgs({ preset: "p", workspace: "w", dryRun: false }, baseEnv);
+    const r = validateCliArgs({ preset: "p", workspace: "w", connection: "c", dryRun: false }, baseEnv);
     expect(r.kind).toBe("error");
     if (r.kind === "error") expect(r.reason).toMatch(/token/);
   });
 
-  it("falls back to env vars", () => {
+  it("falls back to env vars (incl DEMO_SMOKE_CONNECTION)", () => {
     const r = validateCliArgs(
       { dryRun: false },
       {
         DEMO_SMOKE_PRESET: "p",
         DEMO_SMOKE_WORKSPACE: "w",
+        DEMO_SMOKE_CONNECTION: "c-env",
         DEMO_SMOKE_TOKEN: "t",
         DEMO_SMOKE_BASE_URL: "http://example/v1",
       },
@@ -100,37 +118,30 @@ describe("demoSmoke.validateCliArgs", () => {
     if (r.kind === "ok") {
       expect(r.config.preset).toBe("p");
       expect(r.config.workspace).toBe("w");
+      expect(r.config.connection).toBe("c-env");
       expect(r.config.token).toBe("t");
       expect(r.config.baseUrl).toBe("http://example/v1");
     }
   });
 
   it("rejects out-of-range durationMin", () => {
-    const r = validateCliArgs(
-      { preset: "p", workspace: "w", token: "t", durationMin: 9999, dryRun: false },
-      baseEnv,
-    );
+    const r = validateCliArgs({ ...baseValid, durationMin: 9999 }, baseEnv);
     expect(r.kind).toBe("error");
   });
 
   it("rejects out-of-range pollIntervalSec", () => {
-    const r = validateCliArgs(
-      { preset: "p", workspace: "w", token: "t", pollIntervalSec: 0, dryRun: false },
-      baseEnv,
-    );
+    const r = validateCliArgs({ ...baseValid, pollIntervalSec: 0 }, baseEnv);
     expect(r.kind).toBe("error");
   });
 
   it("applies sensible defaults", () => {
-    const r = validateCliArgs(
-      { preset: "p", workspace: "w", token: "t", dryRun: false },
-      baseEnv,
-    );
+    const r = validateCliArgs(baseValid, baseEnv);
     expect(r.kind).toBe("ok");
     if (r.kind === "ok") {
       expect(r.config.durationMin).toBe(30);
       expect(r.config.pollIntervalSec).toBe(60);
       expect(r.config.baseUrl).toBe("http://localhost:3001/api/v1");
+      expect(r.config.connection).toBe("c");
     }
   });
 });
@@ -145,6 +156,8 @@ const baseMetrics = (): SmokeMetrics => ({
   intentCount: 5,
   failedIntentCount: 0,
   errorEventCount: 0,
+  simulatedEventCount: 0,
+  marketEventCount: 12,
   harnessHttpFailures: 0,
   actualDurationMin: 30,
 });
@@ -157,7 +170,7 @@ describe("demoSmoke.evaluateAcceptance", () => {
     expect(r.warnings).toEqual([]);
   });
 
-  it("warns (not fails) when intentCount=0", () => {
+  it("warns (not fails) when intentCount=0 with market events present", () => {
     const r = evaluateAcceptance({ ...baseMetrics(), intentCount: 0 });
     expect(r.pass).toBe(true);
     expect(r.warnings.length).toBeGreaterThan(0);
@@ -193,15 +206,119 @@ describe("demoSmoke.evaluateAcceptance", () => {
     expect(r.failures.join(",")).toMatch(/failedIntentCount=1/);
   });
 
+  it("HARD FAIL on simulatedEventCount > 0 (bot fell into sim mode)", () => {
+    const r = evaluateAcceptance({ ...baseMetrics(), simulatedEventCount: 1 });
+    expect(r.pass).toBe(false);
+    expect(r.failures.join(",")).toMatch(/simulatedEventCount=1/);
+    expect(r.failures.join(",")).toMatch(/exchangeConnectionId likely null/);
+  });
+
+  it("HARD FAIL on marketEventCount=0 (engine dead)", () => {
+    const r = evaluateAcceptance({ ...baseMetrics(), marketEventCount: 0, intentCount: 0 });
+    expect(r.pass).toBe(false);
+    expect(r.failures.join(",")).toMatch(/marketEventCount=0/);
+  });
+
   it("aggregates multiple failures", () => {
     const r = evaluateAcceptance({
       ...baseMetrics(),
       finalRunState: "FAILED",
       errorEventCount: 2,
       failedIntentCount: 1,
+      simulatedEventCount: 4,
     });
     expect(r.pass).toBe(false);
-    expect(r.failures).toHaveLength(3);
+    expect(r.failures).toHaveLength(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pre-flight pure helpers
+// ---------------------------------------------------------------------------
+
+describe("demoSmoke.resolveBybitEnv", () => {
+  it("BYBIT_BASE_URL with api.bybit.com → live", () => {
+    expect(resolveBybitEnv({ BYBIT_BASE_URL: "https://api.bybit.com" })).toBe("live");
+  });
+  it("BYBIT_BASE_URL with api-demo → demo", () => {
+    expect(resolveBybitEnv({ BYBIT_BASE_URL: "https://api-demo.bybit.com" })).toBe("demo");
+  });
+  it("BYBIT_BASE_URL custom (proxy/fixture) → unknown", () => {
+    expect(resolveBybitEnv({ BYBIT_BASE_URL: "http://localhost:9000" })).toBe("unknown");
+  });
+  it("BYBIT_ENV=live → live", () => {
+    expect(resolveBybitEnv({ BYBIT_ENV: "live" })).toBe("live");
+  });
+  it("default (nothing set) → demo", () => {
+    expect(resolveBybitEnv({})).toBe("demo");
+  });
+  it("BYBIT_BASE_URL takes precedence over BYBIT_ENV", () => {
+    expect(resolveBybitEnv({ BYBIT_BASE_URL: "https://api.bybit.com", BYBIT_ENV: "demo" })).toBe("live");
+  });
+});
+
+describe("demoSmoke.isTradingEnabled", () => {
+  it("undefined → fail-open (true)", () => {
+    expect(isTradingEnabled({})).toBe(true);
+  });
+  it("'true' / 'TRUE' / '1' / 'on' / 'yes' → true", () => {
+    for (const v of ["true", "TRUE", "1", "on", "yes"]) {
+      expect(isTradingEnabled({ TRADING_ENABLED: v })).toBe(true);
+    }
+  });
+  it("'false' / 'FALSE' / '0' / 'off' / 'no' → false", () => {
+    for (const v of ["false", "FALSE", "0", "off", "no"]) {
+      expect(isTradingEnabled({ TRADING_ENABLED: v })).toBe(false);
+    }
+  });
+});
+
+describe("demoSmoke.preflightChecks", () => {
+  const goodConn: ConnectionInfo = { id: "c1", status: "CONNECTED", exchange: "BYBIT" };
+  const goodEnv: Record<string, string | undefined> = { BYBIT_ENV: "demo", TRADING_ENABLED: "true" };
+
+  it("passes on healthy demo + connected bybit + trading enabled", () => {
+    expect(preflightChecks({ connection: goodConn, env: goodEnv })).toEqual([]);
+  });
+
+  it("fails when connection is null", () => {
+    const out = preflightChecks({ connection: null, env: goodEnv });
+    expect(out.length).toBe(1);
+    expect(out[0]).toMatch(/connection not found/);
+  });
+
+  it("fails when connection.status is FAILED", () => {
+    const out = preflightChecks({
+      connection: { ...goodConn, status: "FAILED" },
+      env: goodEnv,
+    });
+    expect(out.some((m) => m.includes("connection.status=FAILED"))).toBe(true);
+  });
+
+  it("fails when exchange is not BYBIT", () => {
+    const out = preflightChecks({
+      connection: { ...goodConn, exchange: "OKX" },
+      env: goodEnv,
+    });
+    expect(out.some((m) => m.includes("exchange=OKX"))).toBe(true);
+  });
+
+  it("fails when BYBIT_ENV=live (anti-live guard)", () => {
+    const out = preflightChecks({ connection: goodConn, env: { ...goodEnv, BYBIT_ENV: "live" } });
+    expect(out.some((m) => m.includes("BYBIT_ENV=live"))).toBe(true);
+  });
+
+  it("fails when TRADING_ENABLED=off", () => {
+    const out = preflightChecks({ connection: goodConn, env: { ...goodEnv, TRADING_ENABLED: "off" } });
+    expect(out.some((m) => m.includes("TRADING_ENABLED is off"))).toBe(true);
+  });
+
+  it("aggregates multiple failures", () => {
+    const out = preflightChecks({
+      connection: { ...goodConn, status: "UNKNOWN" },
+      env: { BYBIT_ENV: "live", TRADING_ENABLED: "0" },
+    });
+    expect(out.length).toBe(3);
   });
 });
 
@@ -250,24 +367,52 @@ function buildFakeApi(opts: {
   runStates: string[];
   intentsByPoll?: { total: number; failed: number }[];
   errorEventsByPoll?: number[];
+  /** Final-readout values (single-shot at end of runDemoSmoke). */
+  simulatedEventCount?: number;
+  marketEventCount?: number;
+  placedOrderSamples?: string[];
+  /** Connection metadata returned by getConnection (defaults to healthy CONNECTED Bybit). */
+  connection?: ConnectionInfo | null;
+  /** Bot row returned by getBot (defaults to bot bound to "conn-1"). */
+  botBindConnectionId?: string | null;
   /** If set, instantiatePreset throws once before succeeding. */
   failFirstInstantiate?: boolean;
   /** If true, getRun throws on every call. */
   throwOnGetRun?: boolean;
-}): { api: SmokeApi; calls: { instantiate: number; start: number; stop: number; getRun: number; countIntents: number; countErrors: number } } {
+}): { api: SmokeApi; calls: { instantiate: number; start: number; stop: number; getRun: number; countIntents: number; countErrors: number; getConnection: number; getBot: number; lastInstantiateInput?: { exchangeConnectionId: string } } } {
   let pollIdx = 0;
   let instantiateCount = 0;
   let stopped = false;
-  const calls = { instantiate: 0, start: 0, stop: 0, getRun: 0, countIntents: 0, countErrors: 0 };
+  const calls: ReturnType<typeof buildFakeApi>["calls"] = {
+    instantiate: 0, start: 0, stop: 0, getRun: 0, countIntents: 0, countErrors: 0,
+    getConnection: 0, getBot: 0,
+  };
 
   const api: SmokeApi = {
-    async instantiatePreset() {
+    async getConnection(): Promise<ConnectionInfo | null> {
+      calls.getConnection++;
+      return opts.connection !== undefined
+        ? opts.connection
+        : { id: "conn-1", status: "CONNECTED", exchange: "BYBIT" };
+    },
+    async instantiatePreset(input) {
       calls.instantiate++;
       instantiateCount++;
+      calls.lastInstantiateInput = { exchangeConnectionId: input.exchangeConnectionId };
       if (opts.failFirstInstantiate && instantiateCount === 1) {
         throw new Error("simulated instantiate failure");
       }
-      return { botId: "bot-1", strategyId: "s-1", strategyVersionId: "sv-1" };
+      return {
+        botId: "bot-1",
+        strategyId: "s-1",
+        strategyVersionId: "sv-1",
+        exchangeConnectionId: input.exchangeConnectionId,
+      };
+    },
+    async getBot() {
+      calls.getBot++;
+      const bind = opts.botBindConnectionId !== undefined ? opts.botBindConnectionId : "conn-1";
+      return { id: "bot-1", exchangeConnectionId: bind };
     },
     async startRun() {
       calls.start++;
@@ -298,12 +443,28 @@ function buildFakeApi(opts: {
       const i = Math.min(calls.countErrors - 1, (opts.errorEventsByPoll?.length ?? 1) - 1);
       return opts.errorEventsByPoll?.[i] ?? 0;
     },
+    async countSimulatedEvents() {
+      return opts.simulatedEventCount ?? 0;
+    },
+    async countMarketEvents() {
+      // Default to 12 — non-zero so existing tests pass without explicit
+      // setup; tests asserting marketEventCount=0 supply 0 explicitly.
+      return opts.marketEventCount ?? 12;
+    },
+    async samplePlacedOrders() {
+      return opts.placedOrderSamples ?? [];
+    },
   };
   return { api, calls };
 }
 
+const DEFAULT_ENV: Record<string, string | undefined> = {
+  BYBIT_ENV: "demo",
+  TRADING_ENABLED: "true",
+};
+
 describe("demoSmoke.runDemoSmoke", () => {
-  it("happy path: instantiates → starts → polls → stops → PASS", async () => {
+  it("happy path: pre-flight → instantiate → bind verify → polls → stops → PASS", async () => {
     const { api, calls } = buildFakeApi({
       runStates: ["RUNNING", "RUNNING", "RUNNING"],
       intentsByPoll: [
@@ -313,6 +474,8 @@ describe("demoSmoke.runDemoSmoke", () => {
         { total: 3, failed: 0 }, // post-stop final read
       ],
       errorEventsByPoll: [0, 0, 0, 0],
+      placedOrderSamples: ["bybit-ord-1", "bybit-ord-2"],
+      marketEventCount: 30,
     });
 
     let now = 1_000_000;
@@ -321,25 +484,105 @@ describe("demoSmoke.runDemoSmoke", () => {
     const report = await runDemoSmoke({
       presetSlug: "adaptive-regime",
       workspaceId: "ws-1",
+      exchangeConnectionId: "conn-1",
       durationMin: 2,        // 2 минуты × 60s polls = 2 итерации
       pollIntervalSec: 60,
       overrides: { symbol: "BTCUSDT", quoteAmount: 50 },
       api,
       sleep,
       now: () => now,
+      env: DEFAULT_ENV,
       log: () => {},
     });
 
+    expect(calls.getConnection).toBe(1);
     expect(calls.instantiate).toBe(1);
+    expect(calls.lastInstantiateInput?.exchangeConnectionId).toBe("conn-1");
+    expect(calls.getBot).toBe(1);
     expect(calls.start).toBe(1);
     expect(calls.stop).toBe(1);
     expect(report.metrics.finalRunState).toBe("STOPPED");
     expect(report.metrics.intentCount).toBe(3);
     expect(report.metrics.failedIntentCount).toBe(0);
     expect(report.metrics.harnessHttpFailures).toBe(0);
+    expect(report.metrics.simulatedEventCount).toBe(0);
+    expect(report.metrics.marketEventCount).toBe(30);
     expect(report.acceptance.pass).toBe(true);
     expect(report.botId).toBe("bot-1");
     expect(report.runId).toBe("run-1");
+    expect(report.exchangeConnectionId).toBe("conn-1");
+    expect(report.bybitEnv).toBe("demo");
+    expect(report.placedOrderSamples).toEqual(["bybit-ord-1", "bybit-ord-2"]);
+  });
+
+  it("PreflightError when connection is FAILED — no instantiate happens", async () => {
+    const { api, calls } = buildFakeApi({
+      runStates: ["RUNNING"],
+      connection: { id: "conn-1", status: "FAILED", exchange: "BYBIT" },
+    });
+    let now = 0;
+    await expect(
+      runDemoSmoke({
+        presetSlug: "p",
+        workspaceId: "ws-1",
+        exchangeConnectionId: "conn-1",
+        durationMin: 1,
+        pollIntervalSec: 60,
+        overrides: {},
+        api,
+        sleep: async () => { /* never */ },
+        now: () => now,
+        env: DEFAULT_ENV,
+        log: () => {},
+      }),
+    ).rejects.toBeInstanceOf(PreflightError);
+    expect(calls.instantiate).toBe(0);
+    expect(calls.start).toBe(0);
+  });
+
+  it("PreflightError when BYBIT_ENV=live (anti-live)", async () => {
+    const { api, calls } = buildFakeApi({ runStates: ["RUNNING"] });
+    await expect(
+      runDemoSmoke({
+        presetSlug: "p",
+        workspaceId: "ws-1",
+        exchangeConnectionId: "conn-1",
+        durationMin: 1,
+        pollIntervalSec: 60,
+        overrides: {},
+        api,
+        sleep: async () => {},
+        now: () => 0,
+        env: { BYBIT_ENV: "live", TRADING_ENABLED: "true" },
+        log: () => {},
+      }),
+    ).rejects.toBeInstanceOf(PreflightError);
+    expect(calls.instantiate).toBe(0);
+  });
+
+  it("PreflightError when bot bind verification fails (route ignored connectionId)", async () => {
+    const { api, calls } = buildFakeApi({
+      runStates: ["RUNNING"],
+      botBindConnectionId: null, // route returned 201 but bot is unbound
+    });
+    await expect(
+      runDemoSmoke({
+        presetSlug: "p",
+        workspaceId: "ws-1",
+        exchangeConnectionId: "conn-1",
+        durationMin: 1,
+        pollIntervalSec: 60,
+        overrides: {},
+        api,
+        sleep: async () => {},
+        now: () => 0,
+        env: DEFAULT_ENV,
+        log: () => {},
+      }),
+    ).rejects.toThrow(/bot.exchangeConnectionId/);
+    // instantiate happened (we need to know post-bind), but startRun did not
+    expect(calls.instantiate).toBe(1);
+    expect(calls.start).toBe(0);
   });
 
   it("early-exits on terminal FAILED state and skips stop call", async () => {
@@ -355,12 +598,14 @@ describe("demoSmoke.runDemoSmoke", () => {
     const report = await runDemoSmoke({
       presetSlug: "adaptive-regime",
       workspaceId: "ws-1",
+      exchangeConnectionId: "conn-1",
       durationMin: 10,
       pollIntervalSec: 60,
       overrides: {},
       api,
       sleep,
       now: () => now,
+      env: DEFAULT_ENV,
       log: () => {},
     });
 
@@ -383,12 +628,14 @@ describe("demoSmoke.runDemoSmoke", () => {
     const report = await runDemoSmoke({
       presetSlug: "adaptive-regime",
       workspaceId: "ws-1",
+      exchangeConnectionId: "conn-1",
       durationMin: 1,
       pollIntervalSec: 60,
       overrides: {},
       api,
       sleep,
       now: () => now,
+      env: DEFAULT_ENV,
       log: () => {},
     });
 
@@ -398,11 +645,12 @@ describe("demoSmoke.runDemoSmoke", () => {
     expect(report.acceptance.failures.some((f) => f.includes("harnessHttpFailures"))).toBe(true);
   });
 
-  it("warns when intentCount remains 0", async () => {
+  it("warns when intentCount remains 0 with market events present", async () => {
     const { api } = buildFakeApi({
       runStates: ["RUNNING"],
       intentsByPoll: [{ total: 0, failed: 0 }, { total: 0, failed: 0 }],
       errorEventsByPoll: [0, 0],
+      marketEventCount: 8,
     });
 
     let now = 0;
@@ -411,17 +659,49 @@ describe("demoSmoke.runDemoSmoke", () => {
     const report = await runDemoSmoke({
       presetSlug: "adaptive-regime",
       workspaceId: "ws-1",
+      exchangeConnectionId: "conn-1",
       durationMin: 1,
       pollIntervalSec: 60,
       overrides: {},
       api,
       sleep,
       now: () => now,
+      env: DEFAULT_ENV,
       log: () => {},
     });
 
     expect(report.acceptance.pass).toBe(true);
     expect(report.acceptance.warnings.length).toBe(1);
     expect(report.acceptance.warnings[0]).toMatch(/intentCount=0/);
+  });
+
+  it("HARD FAIL when bot fell back to simulation (simulatedEventCount > 0)", async () => {
+    const { api } = buildFakeApi({
+      runStates: ["RUNNING"],
+      intentsByPoll: [{ total: 4, failed: 0 }],
+      errorEventsByPoll: [0],
+      simulatedEventCount: 4,
+      marketEventCount: 10,
+    });
+
+    let now = 0;
+    const sleep = async (ms: number) => { now += ms; };
+
+    const report = await runDemoSmoke({
+      presetSlug: "adaptive-regime",
+      workspaceId: "ws-1",
+      exchangeConnectionId: "conn-1",
+      durationMin: 1,
+      pollIntervalSec: 60,
+      overrides: {},
+      api,
+      sleep,
+      now: () => now,
+      env: DEFAULT_ENV,
+      log: () => {},
+    });
+
+    expect(report.acceptance.pass).toBe(false);
+    expect(report.acceptance.failures.join(",")).toMatch(/simulatedEventCount=4/);
   });
 });

--- a/docs/53-baseline-results.md
+++ b/docs/53-baseline-results.md
@@ -31,12 +31,29 @@ Notes: _populate after run_
 
 Status: PENDING
 
-Harness:
+### Pre-flight checklist (operator)
+
+Before running, verify:
+1. **Bybit demo connection wired** — go to `/exchanges`, add a Bybit demo
+   key, click **Test**. The status badge must show CONNECTED with non-empty
+   `permissions` containing at least `ContractTrade:Order`. Note the
+   connection id (visible after expanding the row, or via
+   `pnpm --filter @botmarketplace/api exec prisma studio` → `ExchangeConnection`).
+2. **Environment** on the host running the api process:
+   - `BYBIT_ENV=demo` (or `BYBIT_BASE_URL` pointing at `api-demo.bybit.com`)
+     — the harness refuses to start with `BYBIT_ENV=live`.
+   - `TRADING_ENABLED` not set to `false` / `0` / `off` / `no` — fail-open
+     default is fine; explicit `true` also fine.
+3. **JWT token** for an authed user with workspace membership — copy from
+   browser localStorage after `/login` (`accessToken` key).
+
+### Harness command
 
 ```
 pnpm --filter @botmarketplace/api exec tsx scripts/demoSmoke.ts \
   --preset adaptive-regime \
   --workspace <ws-id> \
+  --connection <conn-id> \
   --token "$DEMO_JWT" \
   --base-url http://localhost:3001/api/v1 \
   --duration-min 30 \
@@ -44,25 +61,53 @@ pnpm --filter @botmarketplace/api exec tsx scripts/demoSmoke.ts \
   --quote-amount 50
 ```
 
-Acceptance (from `apps/api/scripts/demoSmoke.ts:evaluateAcceptance`):
-- `finalRunState ∉ {FAILED, TIMED_OUT}`
-- `errorEventCount === 0`
-- `failedIntentCount === 0`
-- `harnessHttpFailures === 0`
-- `intentCount > 0` (warning if 0; operator decides rerun)
+`--connection` is **required**. Without it the bot is created with
+`exchangeConnectionId: null` and intents auto-simulate
+(`apps/api/src/lib/worker/intentExecutor.ts:93`) — the harness would
+return PASS without any real Bybit traffic. The CLI rejects the missing
+flag with exit code 2.
+
+### Acceptance (from `apps/api/scripts/demoSmoke.ts:evaluateAcceptance`)
+
+HARD FAIL if any of:
+- `finalRunState ∈ {FAILED, TIMED_OUT}`
+- `errorEventCount > 0`
+- `failedIntentCount > 0`
+- `harnessHttpFailures > 0`
+- `simulatedEventCount > 0` (proof bot fell into demo simulation mode)
+- `marketEventCount === 0` (engine never received any market data)
+
+WARNING (does not fail):
+- `intentCount === 0` while `marketEventCount > 0` — legit flat market;
+  operator decides rerun.
+
+Pre-flight FAIL (exit code 3 — no bot is created):
+- connection not found, FAILED, or non-Bybit
+- `BYBIT_ENV=live`
+- `TRADING_ENABLED` off
+- post-instantiate `bot.exchangeConnectionId` mismatch
+
+### Result
 
 | Field | Value |
 | ----- | ----- |
 | Run timestamp |  |
 | Duration (min) |  |
+| Bybit env | demo \| live \| unknown |
+| Connection id |  |
 | Final run state |  |
 | Intent count |  |
 | Failed intents |  |
 | Error events |  |
+| Simulated events | 0 (must be 0) |
+| Market events |  |
+| Order samples (orderId list) |  |
 | Acceptance | PASS \| FAIL |
 | Report file | `apps/api/scripts/.smoke-output/<ts>-adaptive-regime.json` |
 
-Notes: _operator pastes summary excerpt + sign-off here_
+Notes: _operator pastes summary excerpt + sign-off here. Cross-check
+`Order samples` on bybit.com → Demo Trading → Order History — they must
+appear as real demo orders._
 
 ---
 

--- a/docs/54-baseline-results.md
+++ b/docs/54-baseline-results.md
@@ -13,8 +13,9 @@ preset.
 
 The smoke harness itself is preset-agnostic
 (`apps/api/scripts/demoSmoke.ts` — see `docs/53-baseline-results.md §2`
-for invocation shape). All three sections below reuse the same
-acceptance criteria as `docs/53-T3`.
+for invocation shape, including the **required** `--connection <id>`
+flag and the pre-flight checklist). All three sections below reuse the
+same acceptance criteria as `docs/53-T3`.
 
 ---
 
@@ -36,10 +37,15 @@ Invocation: `--preset dca-momentum --duration-min 30`.
 | ----- | ----- |
 | Run timestamp |  |
 | Duration (min) |  |
+| Bybit env | demo \| live \| unknown |
+| Connection id |  |
 | Final run state |  |
 | Intent count |  |
 | Failed intents |  |
 | Error events |  |
+| Simulated events | 0 (must be 0) |
+| Market events |  |
+| Order samples (orderId list) |  |
 | Acceptance | PASS \| FAIL |
 | Report file | `apps/api/scripts/.smoke-output/<ts>-dca-momentum.json` |
 
@@ -69,10 +75,15 @@ Invocation: `--preset mtf-scalper --duration-min 30`.
 | ----- | ----- |
 | Run timestamp |  |
 | Duration (min) |  |
+| Bybit env | demo \| live \| unknown |
+| Connection id |  |
 | Final run state |  |
 | Intent count |  |
 | Failed intents |  |
 | Error events |  |
+| Simulated events | 0 (must be 0) |
+| Market events |  |
+| Order samples (orderId list) |  |
 | Acceptance | PASS \| FAIL |
 | Report file | `apps/api/scripts/.smoke-output/<ts>-mtf-scalper.json` |
 
@@ -102,10 +113,15 @@ Invocation: `--preset smc-liquidity-sweep --duration-min 30`.
 | ----- | ----- |
 | Run timestamp |  |
 | Duration (min) |  |
+| Bybit env | demo \| live \| unknown |
+| Connection id |  |
 | Final run state |  |
 | Intent count |  |
 | Failed intents |  |
 | Error events |  |
+| Simulated events | 0 (must be 0) |
+| Market events |  |
+| Order samples (orderId list) |  |
 | Acceptance | PASS \| FAIL |
 | Report file | `apps/api/scripts/.smoke-output/<ts>-smc-liquidity-sweep.json` |
 


### PR DESCRIPTION
## Summary

While verifying the freshly wired Bybit demo connection on prod (`/test` button now works thanks to #390), discovered that the demoSmoke acceptance gate is **silently bypassable**: `POST /presets/:slug/instantiate` never accepted an `exchangeConnectionId` field, so bots created by the harness had `exchangeConnectionId: null`. `intentExecutor.ts:93` then routes every intent through demo simulation mode — fills are written immediately without any Bybit call. A 30-min run would return PASS while exercising nothing.

This is an end-to-end fix: backend accepts the field with cross-workspace guard, harness requires it, and the acceptance check is hardened so simulation-mode runs HARD FAIL even if a future regression slips a null connection past the new validations.

## Five gaps closed

| # | Gap | Fix |
|---|---|---|
| 1 | instantiate route had no `exchangeConnectionId` field | `InstantiateBody.exchangeConnectionId?: string` + same-workspace validation (404 leak-safe) + pass to `bot.create` + echoed in response |
| 2 | harness silently bound nothing — caller could not opt into real trades | `--connection <id>` required (exit 2 with simulation-mode warning) |
| 3 | `intent_simulated` events were invisible to acceptance — sim-mode runs PASS-ed | `simulatedEventCount` metric, HARD FAIL when > 0 |
| 4 | `intentCount=0` was always a soft warning even when engine was dead | `marketEventCount` metric, HARD FAIL when 0; warning only when market events > 0 |
| 5 | post-instantiate bind was unverified — DB rollback / route bypass invisible | re-fetch bot, throw `PreflightError` if `exchangeConnectionId !== requested` |

Plus pre-flight: connection.status, exchange == BYBIT, `BYBIT_ENV !== live` (anti-live guard), `TRADING_ENABLED` not off. All evaluated before instantiate so misconfig fails in 1 second instead of 30 minutes.

`SmokeReport` extended with `bybitEnv`, `exchangeConnectionId`, `placedOrderSamples` (first 5 orderIds) — operator pastes order IDs into bybit.com/demo/orders to confirm real activity.

Exit codes: 0 PASS · 1 FAIL · 2 INPUT_ERROR · 3 PREFLIGHT_FAIL.

## What changed

- **`apps/api/src/routes/presets.ts`** — `InstantiateBody` accepts `exchangeConnectionId?: string`; cross-workspace check; pass to `bot.create`; echo in response.
- **`apps/api/scripts/demoSmoke.ts`** — `--connection` required; new `preflightChecks` / `resolveBybitEnv` / `isTradingEnabled` exported helpers; `SmokeApi` extended with `getConnection`, `getBot`, `countSimulatedEvents`, `countMarketEvents`, `samplePlacedOrders`; `SmokeMetrics` + `evaluateAcceptance` extended; `SmokeReport` extended.
- **`apps/api/tests/scripts/demoSmoke.test.ts`** — 23 new tests across parseArgs / validateCliArgs / resolveBybitEnv / isTradingEnabled / preflightChecks / evaluateAcceptance / runDemoSmoke (PreflightError paths + simulation-mode HARD FAIL + bind-verify failure).
- **`apps/api/tests/routes/presets.test.ts`** — `exchangeConnection` mock + 5 new tests (happy bind, omitted = back-compat null, empty-string = 400, cross-workspace = 404, unknown id = 404).
- **`docs/53-baseline-results.md`** §2 — pre-flight checklist, new harness command, extended acceptance list (HARD FAIL + WARNING + PREFLIGHT FAIL), new result table fields.
- **`docs/54-baseline-results.md`** — same table fields propagated to DCA / MTF / SMC sections.

## Test plan

- [x] `pnpm --filter @botmarketplace/api exec tsc --noEmit` — clean
- [x] `pnpm test:api` — 134 files / **2288 tests** passed (was 2260, +28 new)
- [x] `pnpm build:web` — clean, all 22 pages prerender
- [x] `pnpm audit --prod --audit-level=critical` — 0 critical
- [x] `pnpm check:stray` — clean
- [ ] After deploy: instantiate via `/lab/library` (no connection field in UI yet — out of scope for this PR) still works → bot still created without connection (back-compat preserved)
- [ ] After deploy: run demoSmoke against new Bybit demo connection — expect real fills on bybit.com/demo/orders matching `placedOrderSamples`

## Out of scope (separate tickets)

- UI connection picker in `/lab/library` `InstantiateDialog` (backend ready)
- `--cleanup` flag to delete the test bot after run
- FUNDING_ARB special handling (`docs/55-T6` sub-gate, different code path)
- Spot key separate `/test` verification

https://claude.ai/code/session_01A1kKhq5N9185WfdAwDAU2s

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1kKhq5N9185WfdAwDAU2s)_