### PR TITLE
fix(demoSmoke): send X-Workspace-Id header so /presets/instantiate stops returning 400

### DIFF
--- a/apps/api/scripts/demoSmoke.ts
+++ b/apps/api/scripts/demoSmoke.ts
@@ -518,6 +518,16 @@ export async function runDemoSmoke(args: RunDemoSmokeArgs): Promise<SmokeReport>
 interface BuildApiInput {
   baseUrl: string;
   token: string;
+  /**
+   * Workspace id for the `X-Workspace-Id` header. Every authed write route
+   * resolves the active workspace from this header (`resolveWorkspace` in
+   * `apps/api/src/lib/workspace.ts`); the body's `workspaceId` is ignored.
+   * Without this header, `/presets/:slug/instantiate` returns 400 long
+   * before pre-flight or auth checks have a chance to surface a clearer
+   * message — the unit-test mocks bypass `resolveWorkspace`, so the gap
+   * is invisible until a real run hits the route.
+   */
+  workspaceId: string;
   prisma: PrismaClient;
 }
 
@@ -525,6 +535,7 @@ export function buildDefaultApi(input: BuildApiInput): SmokeApi {
   const headers = {
     "content-type": "application/json",
     authorization: `Bearer ${input.token}`,
+    "x-workspace-id": input.workspaceId,
   };
 
   async function postJson<T>(path: string, body: unknown): Promise<T> {
@@ -759,7 +770,12 @@ async function main(): Promise<number> {
   }
 
   const prisma = new PrismaClient();
-  const api = buildDefaultApi({ baseUrl: cfg.baseUrl, token: cfg.token, prisma });
+  const api = buildDefaultApi({
+    baseUrl: cfg.baseUrl,
+    token: cfg.token,
+    workspaceId: cfg.workspace,
+    prisma,
+  });
 
   try {
     const report = await runDemoSmoke({

--- a/apps/api/tests/scripts/demoSmoke.test.ts
+++ b/apps/api/tests/scripts/demoSmoke.test.ts
@@ -13,7 +13,8 @@
  * Без сети, без БД, без real time — sleep / now инжектируются.
  */
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { PrismaClient } from "@prisma/client";
 import {
   parseArgs,
   validateCliArgs,
@@ -23,6 +24,7 @@ import {
   resolveBybitEnv,
   isTradingEnabled,
   runDemoSmoke,
+  buildDefaultApi,
   PreflightError,
   type SmokeApi,
   type SmokeMetrics,
@@ -703,5 +705,89 @@ describe("demoSmoke.runDemoSmoke", () => {
 
     expect(report.acceptance.pass).toBe(false);
     expect(report.acceptance.failures.join(",")).toMatch(/simulatedEventCount=4/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildDefaultApi — auth + workspace header regression
+// ---------------------------------------------------------------------------
+//
+// First real run of the harness against prod hit a 400 on
+// /presets/:slug/instantiate because the route reads workspaceId from
+// X-Workspace-Id header (not from body), and buildDefaultApi was not
+// sending the header. Tests for runDemoSmoke use a mocked SmokeApi that
+// bypasses buildDefaultApi entirely, so the gap was invisible. These
+// tests fake the global `fetch` and assert the wire-level shape.
+
+describe("demoSmoke.buildDefaultApi — wire headers", () => {
+  const fakePrisma = {} as unknown as PrismaClient;
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("sends Authorization Bearer + X-Workspace-Id on every postJson call", async () => {
+    const recorded: Array<{ url: string; init: RequestInit }> = [];
+    globalThis.fetch = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      recorded.push({ url: String(url), init: init ?? {} });
+      return new Response(
+        JSON.stringify({
+          botId: "bot-1",
+          strategyId: "s-1",
+          strategyVersionId: "sv-1",
+          exchangeConnectionId: "conn-1",
+        }),
+        { status: 201, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const api = buildDefaultApi({
+      baseUrl: "http://api.test/api/v1",
+      token: "jwt-abc",
+      workspaceId: "ws-xyz",
+      prisma: fakePrisma,
+    });
+
+    await api.instantiatePreset({
+      slug: "adaptive-regime",
+      workspaceId: "ws-xyz",
+      exchangeConnectionId: "conn-1",
+      overrides: {},
+    });
+
+    expect(recorded).toHaveLength(1);
+    const headers = recorded[0].init.headers as Record<string, string>;
+    expect(headers["authorization"]).toBe("Bearer jwt-abc");
+    expect(headers["x-workspace-id"]).toBe("ws-xyz");
+    expect(headers["content-type"]).toBe("application/json");
+  });
+
+  it("startRun and stopRun also include X-Workspace-Id", async () => {
+    const recorded: Array<{ url: string; init: RequestInit }> = [];
+    globalThis.fetch = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      recorded.push({ url: String(url), init: init ?? {} });
+      return new Response(JSON.stringify({ id: "run-1", state: "RUNNING" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const api = buildDefaultApi({
+      baseUrl: "http://api.test/api/v1",
+      token: "jwt-abc",
+      workspaceId: "ws-xyz",
+      prisma: fakePrisma,
+    });
+
+    await api.startRun({ botId: "bot-1", durationMinutes: 5 });
+    await api.stopRun({ botId: "bot-1", runId: "run-1" });
+
+    expect(recorded).toHaveLength(2);
+    for (const call of recorded) {
+      const headers = call.init.headers as Record<string, string>;
+      expect(headers["x-workspace-id"]).toBe("ws-xyz");
+      expect(headers["authorization"]).toBe("Bearer jwt-abc");
+    }
   });
 });


### PR DESCRIPTION
## Summary

First real run of the demoSmoke harness against prod (post-#391 deploy) hit a `400` on `POST /presets/adaptive-regime/instantiate` immediately after pre-flight passed. Root cause: `buildDefaultApi` constructs a `headers` object with only `Authorization` and `Content-Type` — no `X-Workspace-Id`. The route resolves the active workspace from that header (`resolveWorkspace` in `apps/api/src/lib/workspace.ts`); the body's `workspaceId` is ignored by design (intentional, see comment at `apps/api/src/routes/presets.ts:386`). Without the header, `resolveWorkspace` returns 400 before pre-flight or auth checks reach the route logic.

The bug was invisible until a real run hit the route because:
- existing `runDemoSmoke` tests use a fully-mocked `SmokeApi` that bypasses `buildDefaultApi` entirely
- route-level tests mock `resolveWorkspace` to return a fixed workspace, never reading the header

Neither layer touched the actual wire shape.

## Fix

- Add `workspaceId: string` to `BuildApiInput`; plumb `cfg.workspace` through `main()` to `buildDefaultApi`.
- Default `headers` include `x-workspace-id: ${input.workspaceId}` so every `postJson` call (`instantiatePreset`, `startRun`, `stopRun`) carries it.
- Two regression tests fake `globalThis.fetch` and assert the request headers include `Authorization: Bearer …` + `X-Workspace-Id: …` on instantiate, startRun and stopRun.

## Test plan
- [x] `pnpm --filter @botmarketplace/api exec tsc --noEmit` — clean
- [x] `pnpm test:api` — 134 files / **2290 tests** passed (was 2288, +2 new wire-level tests)
- [x] `pnpm build:web` — clean, all 22 pages prerender
- [x] `pnpm audit --prod --audit-level=critical` — 0 critical
- [x] `pnpm check:stray` — clean
- [ ] After deploy: rerun 5-min demoSmoke against `botmarketplace-demo-2` connection → expect successful instantiate + run

https://claude.ai/code/session_01A1kKhq5N9185WfdAwDAU2s

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1kKhq5N9185WfdAwDAU2s)_