### PR TITLE
fix(demoSmoke): support --admin-token for PRIVATE preset access (404 on instantiate)

### DIFF
--- a/apps/api/scripts/demoSmoke.ts
+++ b/apps/api/scripts/demoSmoke.ts
@@ -22,10 +22,16 @@
  *     --workspace ws_xyz \
  *     --connection conn_xyz \
  *     --token "$DEMO_JWT" \
+ *     --admin-token "$ADMIN_API_TOKEN" \
  *     --base-url http://localhost:3001/api/v1 \
  *     --duration-min 30 \
  *     --symbol BTCUSDT \
  *     --quote-amount 50
+ *
+ * `--admin-token` обязателен пока target preset PRIVATE (все 5 флагманов
+ * до publishPreset.ts флипа). Без него `/presets/:slug/instantiate`
+ * вернёт 404 ("Preset not found" — намеренно скрывает существование).
+ * Опускайте флаг только когда preset уже флипнут в BETA / PUBLIC.
  *
  * `--connection` обязателен. Без exchangeConnectionId на боте
  * `intentExecutor` (apps/api/src/lib/worker/intentExecutor.ts:93)
@@ -60,6 +66,14 @@ export interface ParsedSmokeArgs {
    *  thin tokenizer. */
   connection?: string;
   token?: string;
+  /**
+   * X-Admin-Token shared secret. Required when the target preset has
+   * visibility PRIVATE (true for every flagship until publishPreset.ts
+   * flips it post-acceptance) — without it `/presets/:slug/instantiate`
+   * returns 404 "Preset not found" by design (404 not 403 to avoid leaking
+   * existence). Optional: omit when the preset is already BETA / PUBLIC.
+   */
+  adminToken?: string;
   baseUrl?: string;
   durationMin?: number;
   pollIntervalSec?: number;
@@ -77,6 +91,7 @@ export function parseArgs(argv: readonly string[]): ParsedSmokeArgs {
     else if (arg === "--workspace") out.workspace = argv[++i];
     else if (arg === "--connection") out.connection = argv[++i];
     else if (arg === "--token") out.token = argv[++i];
+    else if (arg === "--admin-token") out.adminToken = argv[++i];
     else if (arg === "--base-url") out.baseUrl = argv[++i];
     else if (arg === "--duration-min") out.durationMin = Number(argv[++i]);
     else if (arg === "--poll-interval-sec") out.pollIntervalSec = Number(argv[++i]);
@@ -528,15 +543,28 @@ interface BuildApiInput {
    * is invisible until a real run hits the route.
    */
   workspaceId: string;
+  /**
+   * Optional X-Admin-Token shared secret. When omitted the harness can
+   * only target BETA / PUBLIC presets — `/presets/:slug/instantiate`
+   * returns 404 for PRIVATE presets without admin (intentional 404-not-403
+   * info-leak protection in `presets.ts:canViewPreset`). Every flagship
+   * starts PRIVATE pre-acceptance, so demoSmoke runs against them require
+   * this token. Routes that don't gate on admin (bots/runs) ignore the
+   * header — including it in default headers when set is harmless.
+   */
+  adminToken?: string;
   prisma: PrismaClient;
 }
 
 export function buildDefaultApi(input: BuildApiInput): SmokeApi {
-  const headers = {
+  const headers: Record<string, string> = {
     "content-type": "application/json",
     authorization: `Bearer ${input.token}`,
     "x-workspace-id": input.workspaceId,
   };
+  if (input.adminToken) {
+    headers["x-admin-token"] = input.adminToken;
+  }
 
   async function postJson<T>(path: string, body: unknown): Promise<T> {
     const res = await fetch(`${input.baseUrl}${path}`, {
@@ -546,7 +574,23 @@ export function buildDefaultApi(input: BuildApiInput): SmokeApi {
     });
     if (!res.ok) {
       const text = await res.text().catch(() => "");
-      throw new Error(`POST ${path} -> ${res.status} ${res.statusText}: ${text.slice(0, 200)}`);
+      // Operator-friendly hint: 404 on /presets/*/instantiate without admin
+      // token is almost always a PRIVATE-visibility issue, not a missing
+      // preset. Surface that interpretation so the operator does not chase
+      // a phantom seed problem.
+      let hint = "";
+      if (
+        res.status === 404 &&
+        path.startsWith("/presets/") &&
+        path.endsWith("/instantiate") &&
+        !input.adminToken
+      ) {
+        hint =
+          " | hint: target preset may be PRIVATE — every flagship is PRIVATE pre-acceptance. " +
+          "Re-run with --admin-token \"$ADMIN_API_TOKEN\" (or set DEMO_SMOKE_ADMIN_TOKEN env var). " +
+          "See docs/53-baseline-results.md §2 pre-flight checklist.";
+      }
+      throw new Error(`POST ${path} -> ${res.status} ${res.statusText}: ${text.slice(0, 200)}${hint}`);
     }
     return (await res.json()) as T;
   }
@@ -687,6 +731,8 @@ export interface ValidatedSmokeConfig {
   workspace: string;
   connection: string;
   token: string;
+  /** Optional X-Admin-Token; required when preset visibility is PRIVATE. */
+  adminToken?: string;
   baseUrl: string;
   durationMin: number;
   pollIntervalSec: number;
@@ -707,6 +753,7 @@ export function validateCliArgs(parsed: ParsedSmokeArgs, env: Record<string, str
   const workspace = parsed.workspace ?? env.DEMO_SMOKE_WORKSPACE;
   const connection = parsed.connection ?? env.DEMO_SMOKE_CONNECTION;
   const token = parsed.token ?? env.DEMO_SMOKE_TOKEN;
+  const adminToken = parsed.adminToken ?? env.DEMO_SMOKE_ADMIN_TOKEN;
   const baseUrl = parsed.baseUrl ?? env.DEMO_SMOKE_BASE_URL ?? "http://localhost:3001/api/v1";
 
   if (!preset) return { kind: "error", reason: "--preset <slug> is required (or DEMO_SMOKE_PRESET)" };
@@ -742,6 +789,7 @@ export function validateCliArgs(parsed: ParsedSmokeArgs, env: Record<string, str
       workspace,
       connection,
       token,
+      adminToken,
       baseUrl,
       durationMin,
       pollIntervalSec,
@@ -765,7 +813,11 @@ async function main(): Promise<number> {
 
   if (cfg.dryRun) {
     console.log("[demoSmoke] dry-run — config validated, no run executed:");
-    console.log(JSON.stringify({ ...cfg, token: "<redacted>" }, null, 2));
+    console.log(JSON.stringify({
+      ...cfg,
+      token: "<redacted>",
+      adminToken: cfg.adminToken ? "<redacted>" : undefined,
+    }, null, 2));
     return 0;
   }
 
@@ -774,6 +826,7 @@ async function main(): Promise<number> {
     baseUrl: cfg.baseUrl,
     token: cfg.token,
     workspaceId: cfg.workspace,
+    adminToken: cfg.adminToken,
     prisma,
   });
 

--- a/apps/api/tests/scripts/demoSmoke.test.ts
+++ b/apps/api/tests/scripts/demoSmoke.test.ts
@@ -42,6 +42,7 @@ describe("demoSmoke.parseArgs", () => {
       "--workspace", "ws-1",
       "--connection", "conn-7",
       "--token", "jwt",
+      "--admin-token", "admin-secret",
       "--base-url", "http://api.test/v1",
       "--duration-min", "45",
       "--poll-interval-sec", "30",
@@ -55,6 +56,7 @@ describe("demoSmoke.parseArgs", () => {
       workspace: "ws-1",
       connection: "conn-7",
       token: "jwt",
+      adminToken: "admin-secret",
       baseUrl: "http://api.test/v1",
       durationMin: 45,
       pollIntervalSec: 30,
@@ -145,6 +147,33 @@ describe("demoSmoke.validateCliArgs", () => {
       expect(r.config.baseUrl).toBe("http://localhost:3001/api/v1");
       expect(r.config.connection).toBe("c");
     }
+  });
+
+  it("admin-token is optional; absent → adminToken=undefined", () => {
+    const r = validateCliArgs(baseValid, baseEnv);
+    expect(r.kind).toBe("ok");
+    if (r.kind === "ok") expect(r.config.adminToken).toBeUndefined();
+  });
+
+  it("admin-token via flag is forwarded", () => {
+    const r = validateCliArgs({ ...baseValid, adminToken: "secret-flag" }, baseEnv);
+    expect(r.kind).toBe("ok");
+    if (r.kind === "ok") expect(r.config.adminToken).toBe("secret-flag");
+  });
+
+  it("admin-token via DEMO_SMOKE_ADMIN_TOKEN env is forwarded when flag absent", () => {
+    const r = validateCliArgs(baseValid, { DEMO_SMOKE_ADMIN_TOKEN: "secret-env" });
+    expect(r.kind).toBe("ok");
+    if (r.kind === "ok") expect(r.config.adminToken).toBe("secret-env");
+  });
+
+  it("flag --admin-token wins over env DEMO_SMOKE_ADMIN_TOKEN", () => {
+    const r = validateCliArgs(
+      { ...baseValid, adminToken: "from-flag" },
+      { DEMO_SMOKE_ADMIN_TOKEN: "from-env" },
+    );
+    expect(r.kind).toBe("ok");
+    if (r.kind === "ok") expect(r.config.adminToken).toBe("from-flag");
   });
 });
 
@@ -789,5 +818,118 @@ describe("demoSmoke.buildDefaultApi — wire headers", () => {
       expect(headers["x-workspace-id"]).toBe("ws-xyz");
       expect(headers["authorization"]).toBe("Bearer jwt-abc");
     }
+  });
+
+  it("X-Admin-Token header is sent when adminToken is provided", async () => {
+    const recorded: Array<{ url: string; init: RequestInit }> = [];
+    globalThis.fetch = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      recorded.push({ url: String(url), init: init ?? {} });
+      return new Response(
+        JSON.stringify({ botId: "bot-1", strategyId: "s-1", strategyVersionId: "sv-1", exchangeConnectionId: "conn-1" }),
+        { status: 201, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const api = buildDefaultApi({
+      baseUrl: "http://api.test/api/v1",
+      token: "jwt-abc",
+      workspaceId: "ws-xyz",
+      adminToken: "admin-secret",
+      prisma: fakePrisma,
+    });
+
+    await api.instantiatePreset({
+      slug: "adaptive-regime",
+      workspaceId: "ws-xyz",
+      exchangeConnectionId: "conn-1",
+      overrides: {},
+    });
+
+    const headers = recorded[0].init.headers as Record<string, string>;
+    expect(headers["x-admin-token"]).toBe("admin-secret");
+  });
+
+  it("X-Admin-Token header is omitted when adminToken not provided", async () => {
+    const recorded: Array<{ url: string; init: RequestInit }> = [];
+    globalThis.fetch = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      recorded.push({ url: String(url), init: init ?? {} });
+      return new Response(
+        JSON.stringify({ botId: "bot-1", strategyId: "s-1", strategyVersionId: "sv-1", exchangeConnectionId: "conn-1" }),
+        { status: 201, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const api = buildDefaultApi({
+      baseUrl: "http://api.test/api/v1",
+      token: "jwt-abc",
+      workspaceId: "ws-xyz",
+      prisma: fakePrisma,
+    });
+
+    await api.instantiatePreset({
+      slug: "adaptive-regime",
+      workspaceId: "ws-xyz",
+      exchangeConnectionId: "conn-1",
+      overrides: {},
+    });
+
+    const headers = recorded[0].init.headers as Record<string, string>;
+    expect(headers["x-admin-token"]).toBeUndefined();
+  });
+
+  it("404 on /presets/*/instantiate without admin token surfaces operator hint", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({ title: "Not Found", detail: "Preset not found" }),
+        { status: 404, statusText: "Not Found", headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const api = buildDefaultApi({
+      baseUrl: "http://api.test/api/v1",
+      token: "jwt-abc",
+      workspaceId: "ws-xyz",
+      prisma: fakePrisma,
+    });
+
+    await expect(
+      api.instantiatePreset({
+        slug: "adaptive-regime",
+        workspaceId: "ws-xyz",
+        exchangeConnectionId: "conn-1",
+        overrides: {},
+      }),
+    ).rejects.toThrow(/PRIVATE.*--admin-token|admin-token.*PRIVATE/);
+  });
+
+  it("404 on /presets/*/instantiate WITH admin token surfaces no false hint", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({ title: "Not Found", detail: "Preset not found" }),
+        { status: 404, statusText: "Not Found", headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const api = buildDefaultApi({
+      baseUrl: "http://api.test/api/v1",
+      token: "jwt-abc",
+      workspaceId: "ws-xyz",
+      adminToken: "admin-secret",
+      prisma: fakePrisma,
+    });
+
+    let caught: Error | null = null;
+    try {
+      await api.instantiatePreset({
+        slug: "missing-slug",
+        workspaceId: "ws-xyz",
+        exchangeConnectionId: "conn-1",
+        overrides: {},
+      });
+    } catch (err) {
+      caught = err as Error;
+    }
+    expect(caught).not.toBeNull();
+    expect(caught!.message).not.toMatch(/--admin-token/);
   });
 });

--- a/docs/53-baseline-results.md
+++ b/docs/53-baseline-results.md
@@ -45,7 +45,17 @@ Before running, verify:
    - `TRADING_ENABLED` not set to `false` / `0` / `off` / `no` — fail-open
      default is fine; explicit `true` also fine.
 3. **JWT token** for an authed user with workspace membership — copy from
-   browser localStorage after `/login` (`accessToken` key).
+   browser localStorage after `/login` (`accessToken` key), or
+   `curl POST /api/v1/auth/login` directly. JWT TTL is 1h — start the run
+   within ~5 min of obtaining the token (a 30-min run leaves ~25 min slack).
+4. **Admin token (`ADMIN_API_TOKEN`)** for PRIVATE presets. Every flagship
+   ships PRIVATE pre-acceptance, and `/presets/:slug/instantiate` returns
+   `404 Preset not found` (intentional info-leak protection — same code
+   as "really not found") for non-admin requests against PRIVATE presets.
+   The harness `--admin-token` flag (or `DEMO_SMOKE_ADMIN_TOKEN` env var)
+   sends the token as `X-Admin-Token` header. On prod the value lives in
+   the api process's `ADMIN_API_TOKEN` env var. Skip the flag only after
+   `publishPreset.ts` flips the preset to BETA / PUBLIC.
 
 ### Harness command
 
@@ -55,6 +65,7 @@ pnpm --filter @botmarketplace/api exec tsx scripts/demoSmoke.ts \
   --workspace <ws-id> \
   --connection <conn-id> \
   --token "$DEMO_JWT" \
+  --admin-token "$ADMIN_API_TOKEN" \
   --base-url http://localhost:3001/api/v1 \
   --duration-min 30 \
   --symbol BTCUSDT \


### PR DESCRIPTION
## Summary

First real demoSmoke run after #392 (X-Workspace-Id fix) hit `404 Preset not found` on `POST /presets/adaptive-regime/instantiate`. Root cause: every flagship preset ships `PRIVATE` pre-acceptance, and `presets.ts:canViewPreset` returns false for `PRIVATE` without admin — the route then sends `404 Preset not found` (intentional 404-not-403 info-leak protection — same code as "really not found", to avoid revealing PRIVATE preset existence).

The acceptance gate workflow is by design:
1. Preset is `PRIVATE`
2. Run demoSmoke → record `Acceptance: PASS` in companion-doc
3. `publishPreset.ts` flips visibility to `BETA` / `PUBLIC`

Without admin support the harness can only target `BETA` / `PUBLIC` presets — meaning it could only run **after** a successful gate, which is the chicken-and-egg this PR closes.

## Fix

- New `--admin-token` flag (or `DEMO_SMOKE_ADMIN_TOKEN` env var fallback). Required when the target preset is `PRIVATE`.
- `BuildApiInput.adminToken?: string`; `main()` plumbs `cfg.adminToken` through.
- `buildDefaultApi` includes `x-admin-token` in default headers when the field is set. Routes that don't gate on admin (bots/runs) ignore it; the one route that does (`/presets/:slug/instantiate`) now succeeds against `PRIVATE`.
- `404` on `/presets/*/instantiate` without an admin token surfaces an operator-friendly hint pointing at the docs/53 pre-flight checklist, instead of leaving them chasing a phantom seed-data problem.
- `--dry-run` config dump redacts `adminToken` alongside `token`.

## Tests

8 new unit tests:
- `parseArgs` recognises `--admin-token` flag
- `validateCliArgs`: optional default (`undefined`), flag forwarded, env fallback (`DEMO_SMOKE_ADMIN_TOKEN`), flag wins over env
- Wire-level (`buildDefaultApi`): `x-admin-token` header present when `adminToken` set, absent when omitted
- 404 path: hint surfaces when `instantiate` 404s without admin token; hint does NOT surface when admin token IS present (avoids false positive)

api tests: 2290 → **2298**. tsc clean. Web build clean. Audit 0 critical.

## Docs

`docs/53-baseline-results.md` §2 pre-flight gains an item 4 explaining the admin-token requirement, where the value lives on prod (`ADMIN_API_TOKEN` env var on the api host), and that the flag is only safe to omit after `publishPreset.ts` flip.

## Test plan

- [x] `pnpm --filter @botmarketplace/api exec tsc --noEmit` — clean
- [x] `pnpm test:api` — 134 files / **2298** tests passed (was 2290, +8 new)
- [x] `pnpm build:web` — clean, all 22 pages prerender
- [x] `pnpm audit --prod --audit-level=critical` — 0 critical
- [x] `pnpm check:stray` — clean
- [ ] After deploy: rerun 5-min demoSmoke against `botmarketplace-demo-2` connection with `--admin-token "$ADMIN_API_TOKEN"` → expect successful instantiate + run

## Out of scope (separate tickets)

- `deploy.sh` umask hardening — production EACCES incident today was caused by `umask 077` leaking from the credential-capture flow into the deploy script's child processes. Fix: explicit `umask 022` at the top of `deploy.sh` plus `chown -R botmarket:botmarket` after build.
- Auto-fetch admin token from VPS env in the harness when `DEMO_SMOKE_ADMIN_TOKEN` is unset (would skip one operator step, but adds env coupling — keep manual for now).

https://claude.ai/code/session_01A1kKhq5N9185WfdAwDAU2s

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1kKhq5N9185WfdAwDAU2s)_