### PR TITLE
feat(botWorker): emit dataset_insufficient BotEvent on runtime starvation

### DIFF
--- a/apps/api/src/lib/botWorker.ts
+++ b/apps/api/src/lib/botWorker.ts
@@ -437,6 +437,7 @@ async function stopRun(runId: string) {
     });
     trailingStopStates.delete(runId);
     lastTradeCloseTimes.delete(runId);
+    clearDatasetInsufficientForRun(runId);
     await syncBotStatus(run.botId);
   } catch (err) {
     workerLog.error({ err, runId }, "stopRun error");
@@ -469,6 +470,7 @@ async function timeoutExpiredRuns() {
       });
       trailingStopStates.delete(run.id);
       lastTradeCloseTimes.delete(run.id);
+      clearDatasetInsufficientForRun(run.id);
       workerLog.warn({ runId: run.id, state: run.state }, "stuck ephemeral run → FAILED");
       await syncBotStatus(run.botId);
       notifyRunEvent(run.workspaceId, {
@@ -510,6 +512,7 @@ async function timeoutExpiredRuns() {
       });
       trailingStopStates.delete(run.id);
       lastTradeCloseTimes.delete(run.id);
+      clearDatasetInsufficientForRun(run.id);
       workerLog.info({ runId: run.id, elapsed, maxDurationMs }, "run timed out");
       await syncBotStatus(run.botId);
       notifyRunEvent(run.workspaceId, {
@@ -1207,6 +1210,71 @@ const trailingStopStates = new Map<string, TrailingStopState>();
 const lastTradeCloseTimes = new Map<string, number>();
 
 /**
+ * Tracks (runId, symbol, interval) tuples currently in a "dataset
+ * insufficient" state — i.e. the last tick saw fewer than the required
+ * candles to evaluate the strategy. Used to rate-limit the
+ * `dataset_insufficient` BotEvent to one emit per
+ * sufficient → insufficient transition, so an operator sees a single
+ * signal per starvation episode instead of one per poll tick.
+ *
+ * Pre-flight check (#395) catches insufficient data at run start; this
+ * surface covers the runtime mid-run case where the dataset is depleted
+ * (or the gate was bypassed in single-TF flows) so the silent
+ * `continue` in `evaluateStrategies` no longer hides the condition.
+ */
+const datasetInsufficientFlags = new Set<string>();
+
+function datasetInsufficientKey(runId: string, symbol: string, interval: string): string {
+  return `${runId}|${symbol}|${interval}`;
+}
+
+async function emitDatasetInsufficient(
+  runId: string,
+  symbol: string,
+  interval: string,
+  candleCount: number,
+  requiredCount: number,
+): Promise<void> {
+  const key = datasetInsufficientKey(runId, symbol, interval);
+  if (datasetInsufficientFlags.has(key)) return;
+  datasetInsufficientFlags.add(key);
+  try {
+    await prisma.botEvent.create({
+      data: {
+        botRunId: runId,
+        type: "dataset_insufficient",
+        payloadJson: {
+          symbol,
+          interval,
+          candleCount,
+          requiredCount,
+        } as Prisma.InputJsonValue,
+      },
+    });
+    workerLog.warn(
+      { runId, symbol, interval, candleCount, requiredCount },
+      "dataset insufficient at runtime; strategy evaluation skipped",
+    );
+  } catch (err) {
+    // Don't lose the transition signal on a DB hiccup: clear the flag so the
+    // next tick will retry the emit. Tick itself continues regardless.
+    datasetInsufficientFlags.delete(key);
+    workerLog.error({ err, runId, symbol, interval }, "failed to emit dataset_insufficient BotEvent");
+  }
+}
+
+function clearDatasetInsufficient(runId: string, symbol: string, interval: string): void {
+  datasetInsufficientFlags.delete(datasetInsufficientKey(runId, symbol, interval));
+}
+
+function clearDatasetInsufficientForRun(runId: string): void {
+  const prefix = `${runId}|`;
+  for (const key of datasetInsufficientFlags) {
+    if (key.startsWith(prefix)) datasetInsufficientFlags.delete(key);
+  }
+}
+
+/**
  * Build a {@link RuntimeMtfContext} from a `loadCandleBundle` result.
  *
  * Returns `null` when the primary timeframe has no entry in
@@ -1374,7 +1442,11 @@ async function evaluateStrategies(): Promise<void> {
           recentCandles = rows as typeof recentCandles;
         }
 
-        if (recentCandles.length < 2) continue; // not enough data
+        if (recentCandles.length < 2) {
+          await emitDatasetInsufficient(run.id, symbol, timeframe, recentCandles.length, 2);
+          continue;
+        }
+        clearDatasetInsufficient(run.id, symbol, timeframe);
 
         // Convert to Candle format
         const candles = recentCandles.map((mc) => ({
@@ -1793,6 +1865,12 @@ export { stopRun as _stopRun };
 export { processIntents as _processIntents };
 export { executeIntent as _executeIntent };
 export { reconcilePlacedIntents as _reconcilePlacedIntents };
+export {
+  emitDatasetInsufficient as _emitDatasetInsufficient,
+  clearDatasetInsufficient as _clearDatasetInsufficient,
+  clearDatasetInsufficientForRun as _clearDatasetInsufficientForRun,
+  datasetInsufficientFlags as _datasetInsufficientFlags,
+};
 
 export function startBotWorker(): () => Promise<void> {
   workerLog.info({ workerId: WORKER_ID, interval: POLL_INTERVAL_MS }, "botWorker started");

--- a/apps/api/tests/lib/botWorker.test.ts
+++ b/apps/api/tests/lib/botWorker.test.ts
@@ -189,6 +189,10 @@ import {
   _processIntents as processIntents,
   _executeIntent as executeIntent,
   _reconcilePlacedIntents as reconcilePlacedIntents,
+  _emitDatasetInsufficient as emitDatasetInsufficient,
+  _clearDatasetInsufficient as clearDatasetInsufficient,
+  _clearDatasetInsufficientForRun as clearDatasetInsufficientForRun,
+  _datasetInsufficientFlags as datasetInsufficientFlags,
 } from "../../src/lib/botWorker.js";
 
 import { bybitPlaceOrder, bybitGetOrderStatus, mapBybitStatus } from "../../src/lib/bybitOrder.js";
@@ -1061,5 +1065,92 @@ describe("reconcilePlacedIntents (real function)", () => {
 
     // Should not throw, should not update intent
     expect(mockBotIntentUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe("dataset_insufficient BotEvent emission (#397)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBotEventCreate.mockResolvedValue(undefined);
+    datasetInsufficientFlags.clear();
+  });
+
+  it("emits exactly one BotEvent across 10 consecutive insufficient ticks (transition-only)", async () => {
+    const runId = "run-ds-1";
+    for (let i = 0; i < 10; i++) {
+      await emitDatasetInsufficient(runId, "BTCUSDT", "M5", 0, 2);
+    }
+    const calls = mockBotEventCreate.mock.calls.filter(
+      (c) => (c[0] as { data: { type: string } }).data.type === "dataset_insufficient",
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0][0]).toMatchObject({
+      data: {
+        botRunId: runId,
+        type: "dataset_insufficient",
+        payloadJson: { symbol: "BTCUSDT", interval: "M5", candleCount: 0, requiredCount: 2 },
+      },
+    });
+  });
+
+  it("re-emits after a sufficient→insufficient transition cycle", async () => {
+    const runId = "run-ds-2";
+    await emitDatasetInsufficient(runId, "BTCUSDT", "M5", 1, 2);
+    // Sufficient tick → clear the flag.
+    clearDatasetInsufficient(runId, "BTCUSDT", "M5");
+    // Dataset drops again → second emit.
+    await emitDatasetInsufficient(runId, "BTCUSDT", "M5", 0, 2);
+    const calls = mockBotEventCreate.mock.calls.filter(
+      (c) => (c[0] as { data: { type: string } }).data.type === "dataset_insufficient",
+    );
+    expect(calls).toHaveLength(2);
+  });
+
+  it("keys are scoped per (runId, symbol, interval)", async () => {
+    await emitDatasetInsufficient("run-A", "BTCUSDT", "M5", 0, 2);
+    await emitDatasetInsufficient("run-B", "BTCUSDT", "M5", 0, 2);
+    await emitDatasetInsufficient("run-A", "ETHUSDT", "M5", 0, 2);
+    await emitDatasetInsufficient("run-A", "BTCUSDT", "H1", 0, 2);
+    const calls = mockBotEventCreate.mock.calls.filter(
+      (c) => (c[0] as { data: { type: string } }).data.type === "dataset_insufficient",
+    );
+    expect(calls).toHaveLength(4);
+  });
+
+  it("clears flag on DB error so the next tick retries the emit", async () => {
+    const runId = "run-ds-err";
+    mockBotEventCreate.mockRejectedValueOnce(new Error("connection lost"));
+    await emitDatasetInsufficient(runId, "BTCUSDT", "M5", 0, 2);
+    expect(datasetInsufficientFlags.has(`${runId}|BTCUSDT|M5`)).toBe(false);
+    // Next tick succeeds → second attempt creates the event.
+    mockBotEventCreate.mockResolvedValueOnce(undefined);
+    await emitDatasetInsufficient(runId, "BTCUSDT", "M5", 0, 2);
+    expect(mockBotEventCreate).toHaveBeenCalledTimes(2);
+    expect(datasetInsufficientFlags.has(`${runId}|BTCUSDT|M5`)).toBe(true);
+  });
+
+  it("clearDatasetInsufficientForRun removes all entries for a runId", async () => {
+    await emitDatasetInsufficient("run-X", "BTCUSDT", "M5", 0, 2);
+    await emitDatasetInsufficient("run-X", "ETHUSDT", "H1", 0, 2);
+    await emitDatasetInsufficient("run-Y", "BTCUSDT", "M5", 0, 2);
+    expect(datasetInsufficientFlags.size).toBe(3);
+    clearDatasetInsufficientForRun("run-X");
+    expect(datasetInsufficientFlags.size).toBe(1);
+    expect(datasetInsufficientFlags.has("run-Y|BTCUSDT|M5")).toBe(true);
+  });
+
+  it("stopRun clears dataset_insufficient flags for the run", async () => {
+    const runId = "run-stop-ds";
+    await emitDatasetInsufficient(runId, "BTCUSDT", "M5", 0, 2);
+    await emitDatasetInsufficient(runId, "BTCUSDT", "H1", 0, 2);
+    expect(datasetInsufficientFlags.size).toBe(2);
+
+    mockBotRunFindUnique.mockResolvedValueOnce({ id: runId, state: "STOPPING", botId: "bot-stop" });
+    mockBotRunCount.mockResolvedValueOnce(0);
+    mockTransition.mockResolvedValueOnce(undefined);
+
+    await stopRun(runId);
+
+    expect(datasetInsufficientFlags.size).toBe(0);
   });
 });

--- a/docs/53-baseline-results.md
+++ b/docs/53-baseline-results.md
@@ -119,6 +119,15 @@ Pre-flight FAIL (exit code 3 — no bot is created):
 - `MarketCandle[symbol, interval] < --min-candle-count` (data starvation)
 - post-instantiate `bot.exchangeConnectionId` mismatch
 
+Runtime mid-run starvation (data depleted after a run is already
+RUNNING, or single-TF flows that bypass the pre-flight gate) now
+surfaces as `BotEvent.type=dataset_insufficient` emitted by `botWorker`
+on each sufficient → insufficient transition (one event per starvation
+episode, not per poll tick). Payload: `{ symbol, interval, candleCount,
+requiredCount }`. Operator query:
+`SELECT * FROM "BotEvent" WHERE "botRunId" = $1 AND type =
+'dataset_insufficient' ORDER BY "createdAt" DESC`.
+
 > **Historical note.** Earlier revisions HARD-FAILed on
 > `marketEventCount === 0` looking for `market_*` / `candle_*` /
 > `tick_*` / `regime_*` event prefixes. The engine never emits those —


### PR DESCRIPTION
## Summary

- Replace silent `continue` in `evaluateStrategies` (botWorker.ts) when `recentCandles.length < 2` with a `BotEvent.type=dataset_insufficient` emit. Payload: `{ symbol, interval, candleCount, requiredCount }`.
- Rate-limited via an in-memory `Set<string>` keyed by `(runId, symbol, interval)` — exactly one emit per `sufficient → insufficient` transition. Flag cleared on the next sufficient tick and on every terminal run state (`stopRun`, ephemeral timeout, max-duration timeout).
- Complements pre-flight candle gate from #395 (entry-time check) by covering mid-run depletion and single-TF flows that bypass the gate.

## Why

Before this change, a RUNNING bot that lost access to enough candles would loop silently on every poll tick — operator had no signal. The pre-flight gate in #395 closed the entry case; this PR closes the runtime case while keeping noise minimal (one event per starvation episode, not per tick).

## Implementation notes

- New module-level state `datasetInsufficientFlags` lives next to `trailingStopStates` / `lastTradeCloseTimes`; cleanup added to the same three terminal paths (`stopRun`, ephemeral FAILED, TIMED_OUT).
- DB-error path inside `emitDatasetInsufficient` deletes the flag on failure so the next tick retries the emit; tick continues regardless.
- Helpers exported with `_` prefix for direct unit testing, matching existing `_activateRun` / `_stopRun` convention.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test` — 134 files / 2314 tests PASS (+6 to baseline 2308)
- [x] `pnpm --filter @botmarketplace/api build` clean
- [x] New unit tests cover: 10 consecutive insufficient ticks → exactly 1 emit; transition cycle insufficient→sufficient→insufficient → 2 emits; per-`(runId,symbol,interval)` key scoping; DB error retries on next tick; `clearDatasetInsufficientForRun` selectivity; `stopRun` flushes flags
- [ ] Post-merge: verify on prod after next deploy that flag cleanup paths fire (no leaked Set entries across run lifecycles)

## Docs

`docs/53-baseline-results.md` Pre-flight FAIL section now documents the runtime-side surface with payload shape and the operator SQL query.

https://claude.ai/code/session_01JTqLNdnCoDhomy9Q6Rbo9M

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTqLNdnCoDhomy9Q6Rbo9M)_