### PR TITLE
feat(presets): materialize datasetBundleHintJson onto Bot.datasetBundleJson at instantiate

### DIFF
--- a/apps/api/prisma/seed/presets/adaptive-regime.json
+++ b/apps/api/prisma/seed/presets/adaptive-regime.json
@@ -86,7 +86,7 @@
     "maxOpenPositions": 1
   },
   "datasetBundleHintJson": {
-    "5m": true,
-    "1h": true
+    "M5": true,
+    "H1": true
   }
 }

--- a/apps/api/prisma/seed/presets/mtf-scalper.json
+++ b/apps/api/prisma/seed/presets/mtf-scalper.json
@@ -69,8 +69,8 @@
     "maxOpenPositions": 1
   },
   "datasetBundleHintJson": {
-    "1m": true,
-    "5m": true,
-    "15m": true
+    "M1": true,
+    "M5": true,
+    "M15": true
   }
 }

--- a/apps/api/prisma/seed/presets/smc-liquidity-sweep.json
+++ b/apps/api/prisma/seed/presets/smc-liquidity-sweep.json
@@ -64,8 +64,8 @@
     "maxOpenPositions": 1
   },
   "datasetBundleHintJson": {
-    "15m": true,
-    "1h": true,
-    "4h": true
+    "M15": true,
+    "H1": true,
+    "H4": true
   }
 }

--- a/apps/api/src/routes/presets.ts
+++ b/apps/api/src/routes/presets.ts
@@ -23,6 +23,11 @@ import { problem } from "../lib/problem.js";
 import { validateDsl } from "../lib/dslValidator.js";
 import { isAdminRequest } from "../lib/adminGuard.js";
 import { resolveWorkspace } from "../lib/workspace.js";
+import {
+  parseDatasetBundle,
+  bundleIntervals,
+  type CandleInterval,
+} from "../types/datasetBundle.js";
 
 // ---------------------------------------------------------------------------
 // Visibility helpers
@@ -439,6 +444,45 @@ export async function presetRoutes(app: FastifyInstance) {
         }
       }
 
+      // docs/52-T1 — materialize the preset's multi-TF bundle hint onto the
+      // Bot row so botWorker.evaluateStrategies picks up the multi-interval
+      // path instead of the legacy single-TF one (mtfContext=null). Validated
+      // up-front so a broken preset surfaces as 422 before any rows are
+      // written, and so the bot's primary timeframe is guaranteed to be
+      // present in the bundle (mirrors the runtime check in
+      // botWorker.ts:evaluateStrategies, just earlier).
+      let materializedBundle: Record<CandleInterval, string | true> | null = null;
+      if (preset.datasetBundleHintJson !== null && preset.datasetBundleHintJson !== undefined) {
+        const parsed = parseDatasetBundle(preset.datasetBundleHintJson, { mode: "runtime" });
+        if (!parsed.bundle) {
+          return problem(
+            reply,
+            422,
+            "Validation Error",
+            "Preset has invalid datasetBundleHintJson",
+            { errors: parsed.errors },
+          );
+        }
+        const intervals = bundleIntervals(parsed.bundle);
+        if (!intervals.includes(config.timeframe as CandleInterval)) {
+          return problem(
+            reply,
+            422,
+            "Validation Error",
+            "Bot timeframe is not present in preset.datasetBundleHintJson",
+            {
+              errors: [
+                {
+                  field: "datasetBundleHintJson",
+                  message: `bot timeframe ${config.timeframe} not in bundle intervals [${intervals.join(", ")}]`,
+                },
+              ],
+            },
+          );
+        }
+        materializedBundle = parsed.bundle as Record<CandleInterval, string | true>;
+      }
+
       // Generate a unique-per-workspace suffix for both Strategy and Bot names
       // so repeated instantiate calls do not collide on the (workspaceId, name)
       // unique index. Six hex chars = 24 bits of entropy — plenty for human
@@ -485,6 +529,9 @@ export async function presetRoutes(app: FastifyInstance) {
               mode: config.mode,
               ...(requestedConnectionId
                 ? { exchangeConnectionId: requestedConnectionId }
+                : {}),
+              ...(materializedBundle
+                ? { datasetBundleJson: materializedBundle as Prisma.InputJsonValue }
                 : {}),
             },
           });

--- a/apps/api/tests/integration/presetInstantiateFlow.test.ts
+++ b/apps/api/tests/integration/presetInstantiateFlow.test.ts
@@ -325,6 +325,12 @@ describe("preset instantiate flow (e2e, mocked Prisma)", () => {
     expect(version).toBeDefined();
     expect(version.strategyId).toBe(strategyId);
     expect(version.dslJson).toEqual(fixture.dslJson);
+
+    // docs/52-T1 — adaptive-regime's preset.datasetBundleHintJson is
+    // materialized onto Bot.datasetBundleJson so botWorker takes the
+    // multi-TF path instead of the legacy single-TF one.
+    expect(bot.datasetBundleJson).toEqual(fixture.datasetBundleHintJson);
+    expect(bot.datasetBundleJson).toEqual({ M5: true, H1: true });
   });
 
   it("PRIVATE preset cannot be instantiated without admin token (404)", async () => {

--- a/apps/api/tests/routes/presets.test.ts
+++ b/apps/api/tests/routes/presets.test.ts
@@ -250,6 +250,7 @@ async function seedPreset(
   visibility: "PRIVATE" | "BETA" | "PUBLIC",
   category = "trend",
   configOverrides: Record<string, unknown> = {},
+  datasetBundleHintJson: Record<string, unknown> | null = null,
 ) {
   mockPresets[slug] = {
     slug,
@@ -264,7 +265,7 @@ async function seedPreset(
       maxOpenPositions: 1,
       ...configOverrides,
     },
-    datasetBundleHintJson: null,
+    datasetBundleHintJson,
     visibility,
     createdAt: new Date(),
     updatedAt: new Date(),
@@ -739,6 +740,84 @@ describe("POST /api/v1/presets/:slug/instantiate", () => {
     expect(res.statusCode).toBe(400);
     const body = res.json() as { errors: Array<{ field: string; message: string }> };
     expect(body.errors.some((e) => e.field === "mode" && /must be one of/.test(e.message))).toBe(true);
+  });
+
+  // ── datasetBundleHintJson materialization (docs/52-T1) ────────────────────
+
+  it("materializes preset.datasetBundleHintJson onto Bot.datasetBundleJson", async () => {
+    await seedPreset(
+      "mtf-preset",
+      "PUBLIC",
+      "trend",
+      { timeframe: "M5" },
+      { M5: true, H1: true },
+    );
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/presets/mtf-preset/instantiate",
+      headers: userHeaders(),
+      payload: {},
+    });
+    expect(res.statusCode).toBe(201);
+    const bot = Object.values(mockBots)[0] as { datasetBundleJson?: unknown };
+    expect(bot.datasetBundleJson).toEqual({ M5: true, H1: true });
+  });
+
+  it("leaves Bot.datasetBundleJson absent when preset.datasetBundleHintJson is null", async () => {
+    await seedPreset("single-tf", "PUBLIC");
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/presets/single-tf/instantiate",
+      headers: userHeaders(),
+      payload: {},
+    });
+    expect(res.statusCode).toBe(201);
+    const bot = Object.values(mockBots)[0] as { datasetBundleJson?: unknown };
+    expect(bot.datasetBundleJson).toBeUndefined();
+  });
+
+  it("rejects preset with invalid datasetBundleHintJson shape (422)", async () => {
+    await seedPreset(
+      "bad-hint",
+      "PUBLIC",
+      "trend",
+      { timeframe: "M5" },
+      { "5m": true, "1h": true }, // lowercase TV keys — invalid for the bundle contract
+    );
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/presets/bad-hint/instantiate",
+      headers: userHeaders(),
+      payload: {},
+    });
+    expect(res.statusCode).toBe(422);
+    const body = res.json() as { detail: string; errors: Array<{ field: string; message: string }> };
+    expect(body.detail).toMatch(/datasetBundleHintJson/);
+    expect(body.errors.some((e) => /unknown interval/.test(e.message))).toBe(true);
+    // No rows committed on validation failure.
+    expect(Object.keys(mockBots)).toHaveLength(0);
+    expect(Object.keys(mockStrategies)).toHaveLength(0);
+  });
+
+  it("rejects when bot timeframe is not present in datasetBundleHintJson keys (422)", async () => {
+    await seedPreset(
+      "tf-mismatch",
+      "PUBLIC",
+      "trend",
+      { timeframe: "M5" },
+      { M15: true, H1: true }, // valid shape but missing M5 → mismatch
+    );
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/presets/tf-mismatch/instantiate",
+      headers: userHeaders(),
+      payload: {},
+    });
+    expect(res.statusCode).toBe(422);
+    const body = res.json() as { detail: string; errors: Array<{ field: string; message: string }> };
+    expect(body.detail).toMatch(/timeframe/i);
+    expect(body.errors[0].message).toMatch(/M5.*M15.*H1|M15.*H1/);
+    expect(Object.keys(mockBots)).toHaveLength(0);
   });
 });
 

--- a/docs/52-multi-interval-dataset-bundle.md
+++ b/docs/52-multi-interval-dataset-bundle.md
@@ -283,7 +283,7 @@ type DatasetBundle = Partial<Record<CandleInterval, string | true>>;
 5. UX-требования:
    - Если у пользователя нет datasets для нужного `(symbol, interval)` — селектор интервалов помечает их disabled с подсказкой "No dataset available for this TF. Sync M5/H1/etc data first."
    - Все `availableDatasets` грузятся через существующий API, без новых endpoints.
-6. Никаких изменений в Library page (51-T5) — там `datasetBundleHintJson` пресета используется чисто как информационная подсказка для пользователя, фактический bundle для бота настраивается на странице бота.
+6. Никаких изменений в Library page (51-T5) — там `datasetBundleHintJson` пресета остаётся информационной подсказкой в UI. При `POST /presets/:slug/instantiate` хинт автоматически материализуется в `Bot.datasetBundleJson` (`routes/presets.ts`): хинт прогоняется через `parseDatasetBundle({mode:"runtime"})`; невалидный shape или несоответствие `bot.timeframe ∉ keys(hint)` отдаёт 422 до записи в БД. Если у preset'а `datasetBundleHintJson = null` — Bot создаётся без bundle (legacy single-TF путь).
 
 **Тест-план:**
 - Ручной smoke: запустить backtest на single TF — поведение прежнее.


### PR DESCRIPTION
## Summary

- `POST /presets/:slug/instantiate` (`routes/presets.ts`) теперь материализует `preset.datasetBundleHintJson` в `Bot.datasetBundleJson` при создании бота. Хинт прогоняется через `parseDatasetBundle({mode:"runtime"})` до открытия транзакции; невалидный shape → 422 с `errors[]`. Если `bot.timeframe ∉ keys(hint)` → 422 с понятным сообщением (зеркалит runtime-guard в `botWorker.ts:evaluateStrategies`, но fail-fast).
- Нормализованы 3 seed-фикстуры (`adaptive-regime`, `mtf-scalper`, `smc-liquidity-sweep`) — ключи `datasetBundleHintJson` приведены к UPPER Prisma Timeframe (`M5`/`H1` etc.) вместо lowercase TV (`5m`/`1h`), который не пропускает `parseDatasetBundle`.
- docs/52 §52-T5/6 обновлён: `datasetBundleHintJson` теперь материализуется автоматически при instantiate (раньше доку утверждала что bundle настраивается «на странице бота», что не соответствует реальности).

## Why

Главное последствие follow-up #2: флагман-стратегии (adaptive-regime, mtf-scalper, smc-liquidity-sweep) при `POST /presets/:slug/instantiate` создавали Bot с `datasetBundleJson = null`, что заставляло `botWorker.evaluateStrategies` идти в legacy single-TF путь с `mtfContext = null`. Multi-TF блоки DSL (`sourceTimeframe: "1h"` и т.п.) бросали `MtfBundleRequiredError`. Хинт был «информационной подсказкой» по docs/52, но единственный материализатор в коде (`/lab/backtest`) ему не помогал — runtime ботам нужен живой Bot.datasetBundleJson.

Это PR закрывает gap: instantiate → bundle на Bot → botWorker видит multi-TF путь → MTF-индикаторы работают как задумано.

## Implementation notes

- Validation up-front, до `prisma.$transaction` — 422 без открытия транзакции и без частичных записей.
- При hint = null путь идентичен предыдущему (Bot без `datasetBundleJson`), legacy single-TF tests остаются зелёными.
- Re-seed на проде через `prisma db seed` (включён в deploy.sh c #394) — upsert по slug, идемпотентно. Существующие бот-записи с lowercase ключами в БД не мигрируются (это backfill-операция вне scope этого PR; новый код их не создаёт).

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test` — 134 files / 2318 tests PASS (+4 to baseline 2314 after #397)
- [x] `pnpm --filter @botmarketplace/api build` clean
- [x] Tests:
  - `tests/routes/presets.test.ts`: hint материализуется → `Bot.datasetBundleJson === hint`; null hint → bot без bundle; invalid shape (lowercase keys) → 422; timeframe ∉ keys(hint) → 422.
  - `tests/integration/presetInstantiateFlow.test.ts`: adaptive-regime instantiate теперь assert'ит `Bot.datasetBundleJson === {M5: true, H1: true}`.
- [ ] Post-deploy: запустить acceptance-smoke с adaptive-regime на проде — `mtfContext` теперь будет non-null; intentCount по-прежнему может быть 0 (flat market — легит), но `strategyActivityCount` начнёт реагировать на multi-TF сигналы. Это уже отдельное upgrade поведения, не блокер для merge.

https://claude.ai/code/session_01JTqLNdnCoDhomy9Q6Rbo9M

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTqLNdnCoDhomy9Q6Rbo9M)_