### PR TITLE
docs(14): note privilege model for deploy.sh + future CI-user sudoers fragment

### DIFF
--- a/docs/14-deployment.md
+++ b/docs/14-deployment.md
@@ -51,3 +51,45 @@ MVP MUST:
 - `WEBHOOK_SECRET`
 - `DB_URL`
 
+## 6) Privilege model для `deploy.sh`
+
+Текущее состояние (verified 2026-05-13, follow-up #3):
+
+- `deploy/deploy.sh` не содержит ни одного внутреннего вызова `sudo`. Скрипт целиком ожидает root-окружения: `cp /etc/systemd/system/`, `systemctl daemon-reload`, `systemctl restart botmarket-{api,web,worker}`, `journalctl -u …`.
+- На VPS он запускается одной внешней `sudo bash deploy/deploy.sh` либо напрямую под `root`.
+- `ubuntu` имеет `NOPASSWD:ALL` из `/etc/sudoers.d/90-cloud-init-users` (cloud-init default). `botmarket` (uid 997) — service-юзер для рантайма, не в sudoers.
+- Никаких password-prompt'ов в существующих deploy-логах нет.
+
+Если позже появится отдельный CI-юзер (например `claude-ci`) и захочется убрать его из `sudo ALL=(ALL)`, минимальный sudoers-fragment с принципом least-privilege:
+
+```sudo
+# /etc/sudoers.d/botmarket-deploy   (mode 0440, root:root)
+Cmnd_Alias BOTMARKET_DEPLOY = \
+    /usr/bin/bash /opt/-botmarketplace-site/deploy/deploy.sh, \
+    /usr/bin/bash /opt/-botmarketplace-site/deploy/deploy.sh --ref *, \
+    /usr/bin/bash /opt/-botmarketplace-site/deploy/deploy.sh --branch *
+Cmnd_Alias BOTMARKET_UNITS = \
+    /usr/bin/systemctl restart botmarket-api, \
+    /usr/bin/systemctl restart botmarket-web, \
+    /usr/bin/systemctl restart botmarket-worker, \
+    /usr/bin/systemctl is-active botmarket-api, \
+    /usr/bin/systemctl is-active botmarket-web, \
+    /usr/bin/systemctl is-active botmarket-worker, \
+    /usr/bin/systemctl show -p ActiveState --value botmarket-worker
+Cmnd_Alias BOTMARKET_LOGS = \
+    /usr/bin/journalctl -u botmarket-api *, \
+    /usr/bin/journalctl -u botmarket-web *, \
+    /usr/bin/journalctl -u botmarket-worker *
+
+claude-ci ALL=(root) NOPASSWD: BOTMARKET_DEPLOY, BOTMARKET_UNITS, BOTMARKET_LOGS
+```
+
+Принципы:
+- Точные пути бинарей (`/usr/bin/systemctl`, `/usr/bin/journalctl`), без wildcards в путях.
+- Wildcards только в аргументах `journalctl` (`-n`, `--since`, `-f`).
+- Без `ALL` и без `NOPASSWD:ALL`.
+
+Polkit-альтернатива покрывает только `systemctl`, но не `cp` в `/etc/systemd/system/` — для end-to-end deploy нужен sudoers-путь.
+
+Сейчас этот fragment **НЕ применён**. Появится потребность — применять без расширения области.
+


### PR DESCRIPTION
## Summary

- Documents the actual privilege model of `deploy/deploy.sh` after on-VPS research (follow-up #3): the script contains no internal `sudo` invocations and runs entirely under root in the current setup; no password prompts in deploy logs.
- Adds a ready-to-apply least-privilege sudoers fragment for the day a separate CI user (e.g. `claude-ci`) is introduced, so future operators don't re-discover this from scratch.
- Fragment is intentionally **not** applied to `/etc/sudoers.d/` — current sudoers state on the VPS stays as-is.

## Why

Follow-up #3 ("polkit/sudoers narrowing") was filed on the assumption that `deploy.sh` triggered password prompts via `sudo -u botmarket` switches inside the script. On-VPS verification (`/etc/sudoers.d/`, `sudo -l -U botmarket`, full grep of `deploy/*.sh` for `\bsudo\b`) showed:
- No internal `sudo` calls — script expects to run as root.
- `botmarket` (uid 997) is not in sudoers; it's the service user owned by systemd units.
- `ubuntu` has `NOPASSWD:ALL` via cloud-init default.
- Deploy logs contain no `password|pam|sudo` traces.

So there's nothing to narrow today. But the analysis still has shelf value if/when a CI user enters the picture — capturing it as docs avoids reinventing the wheel.

## Test plan

- [x] Docs-only change to `docs/14-deployment.md` (one new §6, 42 lines added).
- [ ] No runtime / build impact — CI should pass on docs lint only.

https://claude.ai/code/session_01JTqLNdnCoDhomy9Q6Rbo9M

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTqLNdnCoDhomy9Q6Rbo9M)_